### PR TITLE
Use allocated worker's name instead of their email as input paramater

### DIFF
--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -23,4 +23,14 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [FromQuery(Name = "worker_email")]
         public string WorkerEmail { get; set; }
     }
+
+    public class ListAscAllocationsRequest
+    {
+        [FromQuery(Name = "mosaic_id")]
+        public long? MosaicId { get; set; }
+
+        [FromQuery(Name = "allocated_worker")]
+
+        public string AllocatedWorker { get; set; }
+    }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -125,7 +125,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [ProducesResponseType(typeof(AscAllocationList), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("asc-allocations")]
-        public IActionResult GetAdultsAllocatedWorker([FromQuery] ListAllocationsRequest request)
+        public IActionResult GetAdultsAllocatedWorker([FromQuery] ListAscAllocationsRequest request)
         {
             return Ok(_adultsAllocationUseCase.Execute(request));
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -72,7 +72,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     PersonId = r.Id.ToString(),
                     LastName = r.LastName,
                     FirstName = r.FirstName,
-                    DateOfBirth = r.DateOfBirth != null ? r.DateOfBirth.ToString() : null,
+                    DateOfBirth = r.DateOfBirth != null ? Convert.ToDateTime(r.DateOfBirth).ToString("dd-MM-yyyy") : null,
                     Age = r.Age,
                     PrimarySupportReason = r.PrimarySupportReason,
                     AllocatedTeam = r.AllocatedTeam,

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -62,11 +62,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return allocations;
         }
 
-        public List<AscAllocation> SelectAscAllocations(long? mosaicId, string officerEmail)
+        public List<AscAllocation> SelectAscAllocations(long? mosaicId, string allocatedWorker)
         {
             var allocations = _databaseContext.AscAllocations
                 .Where(r => (mosaicId == null) || r.Id == mosaicId)
-                .Where(r => string.IsNullOrEmpty(officerEmail) || r.AllocatedWorker.Contains(officerEmail))
+                .Where(r => string.IsNullOrWhiteSpace(allocatedWorker) || r.AllocatedWorker.ToLower() == allocatedWorker.ToLower())
                 .Select(r => new AscAllocation
                 {
                     PersonId = r.Id.ToString(),

--- a/SocialCareCaseViewerApi/V1/UseCase/GetAdultsAllocationUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/GetAdultsAllocationUseCase.cs
@@ -14,9 +14,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
         }
 
-        public AscAllocationList Execute(ListAllocationsRequest request)
+        public AscAllocationList Execute(ListAscAllocationsRequest request)
         {
-            return new AscAllocationList { AscAllocations = _databaseGateway.SelectAscAllocations(request.MosaicId, request.WorkerEmail) };
+            return new AscAllocationList { AscAllocations = _databaseGateway.SelectAscAllocations(request.MosaicId, request.AllocatedWorker) };
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IGetAdultsAllocationsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IGetAdultsAllocationsUseCase.cs
@@ -5,6 +5,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface IGetAdultsAllocationsUseCase
     {
-        AscAllocationList Execute(ListAllocationsRequest request);
+        AscAllocationList Execute(ListAscAllocationsRequest request);
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

The initial asc allocations end point assumed that the supplied officer detail would be an email address. This is incorrect and the parameter should be the officer's full name.

### *What changes have we introduced*

Input parameter is now handled as a name rather than email address.

### *Follow up actions after merging PR*

Update swagger and other related docs
