### PR TITLE
Update/add missing properties to allocation object

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Domain/AllocationTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Domain/AllocationTests.cs
@@ -62,5 +62,23 @@ namespace SocialCareCaseViewerApi.Tests.V1.Domain
         {
             Assert.IsNull(_allocation.CaseStatus);
         }
+
+        [Test]
+        public void AllocationHasPersonName()
+        {
+            Assert.IsNull(_allocation.PersonName);
+        }
+
+        [Test]
+        public void AllocationHasPersonAddress()
+        {
+            Assert.IsNull(_allocation.PersonAddress);
+        }
+
+        [Test]
+        public void AllocationHasPersonDateOfBirth()
+        {
+            Assert.IsNull(_allocation.PersonDateOfBirth);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Infrastructure/AddressTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Infrastructure/AddressTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Infrastructure
+{
+
+    [TestFixture]
+    public class AddressTests
+    {
+        private Address _address;
+
+        [SetUp]
+        public void Setup()
+        {
+            _address = new Address();
+        }
+
+        [Test]    
+        public void AddressHasPersonAddressId()
+        {
+            Assert.AreEqual(0, _address.PersonAddressId);
+        }
+
+        [Test]
+        public void AddressHasAddressId()
+        {
+            Assert.AreEqual(0, _address.AddressId);
+        }
+
+        [Test]
+        public void AddressHasPerson()
+        {
+            Assert.IsNull(_address.Person);
+        }
+
+        [Test]
+        public void AddressHasPersonId()
+        {
+            Assert.IsNull(_address.PersonId);
+        }
+
+        [Test]
+        public void AddressHasEndDate()
+        {
+            Assert.IsNull(_address.EndDate);
+        }
+
+        [Test]
+        public void AddressHasAddressLines()
+        {
+            Assert.IsNull(_address.AddressLines);
+        }
+
+        [Test]
+        public void AddressHasPostCode()
+        {
+            Assert.IsNull(_address.PostCode);
+        }
+
+        [Test]
+        public void AddressHasUprn()
+        {
+            Assert.IsNull(_address.Uprn);
+        }
+
+        [Test]
+        public void AddressHasDataIsFromDmPersonsBackup()
+        {
+            Assert.IsNull(_address.DataIsFromDmPersonsBackup);
+        }
+
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Infrastructure/AddressTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Infrastructure/AddressTests.cs
@@ -15,7 +15,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Infrastructure
             _address = new Address();
         }
 
-        [Test]    
+        [Test]
         public void AddressHasPersonAddressId()
         {
             Assert.AreEqual(0, _address.PersonAddressId);

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/Allocation.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/Allocation.cs
@@ -6,6 +6,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
     {
         public int Id { get; set; }
         public long PersonId { get; set; }
+        public string PersonName { get; set; }
+        public string PersonAddress { get; set; }
+        public DateTime? PersonDateOfBirth { get; set; }
         public string AllocatedWorker { get; set; }
         public string WorkerType { get; set; }
         public string AllocatedWorkerTeam { get; set; }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -47,7 +47,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     join person in _databaseContext.Persons on allocation.MosaicId equals person.Id into Person
                     from p in Person.DefaultIfEmpty()
 
-                    join address in _databaseContext.Addresses.Where(x => x.IsDisplayAddress == "Y") on p.Id equals address.PersonId into Address
+                    join address in _databaseContext.Addresses.Where(x => !string.IsNullOrEmpty(x.IsDisplayAddress) && x.IsDisplayAddress.ToUpper() == "Y") on p.Id equals address.PersonId into Address
                     from a in Address.DefaultIfEmpty()
 
                     where allocation.MosaicId == mosaicId
@@ -83,7 +83,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     join person in _databaseContext.Persons on allocation.MosaicId equals person.Id into Person
                     from p in Person.DefaultIfEmpty()
 
-                    join address in _databaseContext.Addresses.Where(x => x.IsDisplayAddress == "Y") on p.Id equals address.PersonId into Address
+                    join address in _databaseContext.Addresses.Where(x => !string.IsNullOrEmpty(x.IsDisplayAddress) && x.IsDisplayAddress.ToUpper() == "Y") on p.Id equals address.PersonId into Address
                     from a in Address.DefaultIfEmpty()
 
                     where w.Id == workerId

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -56,7 +56,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     {
                         Id = allocation.Id,
                         PersonId = allocation.MosaicId,
-                        PersonDateOfBirth = p.DateOfBirth, 
+                        PersonDateOfBirth = p.DateOfBirth,
                         PersonName = ToFullPersonName(p.FirstName, p.LastName),
                         AllocatedWorker = w == null ? null : $"{w.FirstName} {w.LastName }",
                         AllocatedWorkerTeam = t.Name,

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -13,6 +13,7 @@ using Worker = SocialCareCaseViewerApi.V1.Infrastructure.Worker;
 using Team = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using Newtonsoft.Json;
+using System.Globalization;
 
 namespace SocialCareCaseViewerApi.V1.Gateways
 {
@@ -43,18 +44,27 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     join team in _databaseContext.Teams on w.TeamId equals team.Id into Teams
                     from t in Teams.DefaultIfEmpty()
 
+                    join person in _databaseContext.Persons on allocation.MosaicId equals person.Id into Person
+                    from p in Person.DefaultIfEmpty()
+
+                    join address in _databaseContext.Addresses.Where(x => x.IsDisplayAddress == "Y") on p.Id equals address.PersonId into Address
+                    from a in Address.DefaultIfEmpty()
+
                     where allocation.MosaicId == mosaicId
 
                     select new Allocation()
                     {
                         Id = allocation.Id,
                         PersonId = allocation.MosaicId,
+                        PersonDateOfBirth = p.DateOfBirth, 
+                        PersonName = ToFullPersonName(p.FirstName, p.LastName),
                         AllocatedWorker = w == null ? null : $"{w.FirstName} {w.LastName }",
                         AllocatedWorkerTeam = t.Name,
                         WorkerType = w.Role,
                         AllocationStartDate = allocation.AllocationStartDate,
                         AllocationEndDate = allocation.AllocationEndDate,
-                        CaseStatus = allocation.CaseStatus
+                        CaseStatus = allocation.CaseStatus,
+                        PersonAddress = a.AddressLines
                     }
 
                     ).ToList();
@@ -70,18 +80,27 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     join team in _databaseContext.Teams on w.TeamId equals team.Id into Teams
                     from t in Teams.DefaultIfEmpty()
 
+                    join person in _databaseContext.Persons on allocation.MosaicId equals person.Id into Person
+                    from p in Person.DefaultIfEmpty()
+
+                    join address in _databaseContext.Addresses.Where(x => x.IsDisplayAddress == "Y") on p.Id equals address.PersonId into Address
+                    from a in Address.DefaultIfEmpty()
+
                     where w.Id == workerId
 
                     select new Allocation()
                     {
                         Id = allocation.Id,
                         PersonId = allocation.MosaicId,
+                        PersonDateOfBirth = p.DateOfBirth,
+                        PersonName = ToFullPersonName(p.FirstName, p.LastName),
                         AllocatedWorker = w == null ? null : $"{w.FirstName} {w.LastName }",
                         AllocatedWorkerTeam = t.Name,
                         WorkerType = w.Role,
                         AllocationStartDate = allocation.AllocationStartDate,
                         AllocationEndDate = allocation.AllocationEndDate,
-                        CaseStatus = allocation.CaseStatus
+                        CaseStatus = allocation.CaseStatus,
+                        PersonAddress = a.AddressLines
                     }
 
                     ).ToList();
@@ -425,6 +444,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             allocationToRestore.CaseStatus = tmpAllocation.CaseStatus;
             allocationToRestore.WorkerId = tmpAllocation.WorkerId;
             allocationToRestore.CaseClosureDate = tmpAllocation.CaseClosureDate;
+        }
+
+        private static string ToFullPersonName(string firstName, string lastName)
+        {
+            string first = string.IsNullOrWhiteSpace(firstName) ? null : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(firstName.ToLower());
+            string last = string.IsNullOrWhiteSpace(lastName) ? null : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(lastName.ToLower());
+
+            return (first + " " + last).TrimStart().TrimEnd();
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/Address.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/Address.cs
@@ -43,5 +43,9 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [Column("from_dm_person")]
         [MaxLength(1)]
         public string DataIsFromDmPersonsBackup { get; set; }
+
+        [Column("is_display_address")]
+        [MaxLength(1)]
+        public string IsDisplayAddress { get; set; }
     }
 }


### PR DESCRIPTION
Add more person details to allocation object required by the front end. Address handling and columns need to be re-factored/updated later to support update operations so this is just a stop gap for now. 