### PR TITLE
Set up feature flags for showing historic data

### DIFF
--- a/terraform/production/feature_flags.tf
+++ b/terraform/production/feature_flags.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "show_historic_data_feature_flag" {
+  name = "social_care_case_viewer_api_show_historic_data"
+}
+
+resource "aws_secretsmanager_secret_version" "show_historic_data_feature_flag" {
+  secret_id     = aws_secretsmanager_secret.show_historic_data_feature_flag.id
+  secret_string = "false"
+}

--- a/terraform/staging/feature_flags.tf
+++ b/terraform/staging/feature_flags.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "show_historic_data_feature_flag" {
+  name = "social_care_case_viewer_api_show_historic_data"
+}
+
+resource "aws_secretsmanager_secret_version" "show_historic_data_feature_flag" {
+  secret_id     = aws_secretsmanager_secret.show_historic_data_feature_flag.id
+  secret_string = "true"
+}


### PR DESCRIPTION
### *What is the problem we're trying to solve*

We want to be able to test showing the historic data in staging first before having the feature live in production but don't want to hinder any upcoming releases to production

### *What changes have we introduced*

Set up secrets in AWS that will act as feature flags per AWS environment so that we can enable/disable showing historic mosaic data.

We want it set to `true` for Staging (enable so that we can test it with users)
We want it set to `false` for Production (disable showing historic mosaic data until testing is done)

### *Follow up actions after merging PR*

* Check that values have been created correctly in staging and production.
* Add code that checks the value of the flag wherever we retrieve case notes & visits via the social care platform API