### PR TITLE
Align historic case notes attributes to cases attributes 

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -243,7 +243,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         {
             var request = new GetCaseNotesRequest() { Id = "1" };
 
-            var note = _fixture.Create<CaseNote>();
+            var note = _fixture.Create<CaseNoteResponse>();
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -145,5 +145,44 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             Assert.AreEqual(expectedDocument.GetElement("timestamp"), result.First().GetElement("timestamp"));
             Assert.AreEqual(expectedDocument.GetElement("is_historical"), result.First().GetElement("is_historical"));
         }
+
+        [Test]
+        public void CanMapHistoricalCaseNoteToCaseNoteResponse()
+        {
+            var historicalCaseNote = new CaseNote()
+            {
+                MosaicId = "1",
+                CaseNoteId = "123",
+                CaseNoteTitle = "Case Note Title",
+                CaseNoteContent = "Some case note content.",
+                CreatedByName = "John Smith",
+                CreatedByEmail = "john.smith@email.com",
+                NoteType = "Case Summary (ASC)",
+                CreatedOn = new DateTime(2021, 3, 1, 15, 30, 0),
+            };
+
+            var expectedCaseNoteResponse = new CaseNoteResponse()
+            {
+                RecordId = historicalCaseNote.CaseNoteId,
+                PersonId = historicalCaseNote.MosaicId,
+                Title = historicalCaseNote.CaseNoteTitle,
+                Content = historicalCaseNote.CaseNoteContent,
+                DateOfEvent = "2021-03-01T15:30:00",
+                OfficerName = historicalCaseNote.CreatedByName,
+                OfficerEmail = historicalCaseNote.CreatedByEmail,
+                FormName = historicalCaseNote.NoteType
+            };
+
+            var result = ResponseFactory.ToResponse(historicalCaseNote);
+
+            Assert.AreEqual(expectedCaseNoteResponse.RecordId, result.RecordId);
+            Assert.AreEqual(expectedCaseNoteResponse.PersonId, result.PersonId);
+            Assert.AreEqual(expectedCaseNoteResponse.Title, result.Title);
+            Assert.AreEqual(expectedCaseNoteResponse.Content, result.Content);
+            Assert.AreEqual(expectedCaseNoteResponse.DateOfEvent, result.DateOfEvent);
+            Assert.AreEqual(expectedCaseNoteResponse.OfficerName, result.OfficerName);
+            Assert.AreEqual(expectedCaseNoteResponse.OfficerEmail, result.OfficerEmail);
+            Assert.AreEqual(expectedCaseNoteResponse.FormName, result.FormName);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseNotesUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseNotesUseCaseTests.cs
@@ -54,7 +54,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var response = _caseNotesUseCase.ExecuteGetById(request.Id);
 
-            Assert.IsInstanceOf<CaseNote>(response);
+            Assert.IsInstanceOf<CaseNoteResponse>(response);
 
             _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNoteById(It.IsAny<string>()));
         }
@@ -68,7 +68,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var response = _caseNotesUseCase.ExecuteGetById(request.Id);
 
-            Assert.IsInstanceOf<CaseNote>(response);
+            Assert.IsInstanceOf<CaseNoteResponse>(response);
 
             _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNoteById(request.Id));
         }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseNoteResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseNoteResponse.cs
@@ -1,0 +1,14 @@
+namespace SocialCareCaseViewerApi.V1.Boundary.Response
+{
+    public class CaseNoteResponse
+    {
+        public string RecordId { get; set; }
+        public string PersonId { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public string DateOfEvent { get; set; }
+        public string OfficerEmail { get; set; }
+        public string OfficerName { get; set; }
+        public string FormName { get; set; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -98,5 +98,20 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
             return historicalVisits;
         }
+
+        public static CaseNoteResponse ToResponse(CaseNote historicalCaseNote)
+        {
+            return new CaseNoteResponse()
+            {
+                RecordId = historicalCaseNote.CaseNoteId,
+                PersonId = historicalCaseNote.MosaicId,
+                Title = historicalCaseNote.CaseNoteTitle,
+                Content = historicalCaseNote.CaseNoteContent,
+                DateOfEvent = historicalCaseNote.CreatedOn.ToString("s"),
+                OfficerName = historicalCaseNote.CreatedByName,
+                OfficerEmail = historicalCaseNote.CreatedByEmail,
+                FormName = historicalCaseNote.NoteType
+            };
+        }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseNotesUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseNotesUseCase.cs
@@ -1,5 +1,5 @@
 using SocialCareCaseViewerApi.V1.Boundary.Response;
-using SocialCareCaseViewerApi.V1.Domain;
+using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
@@ -19,9 +19,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return _socialCarePlatformAPIGateway.GetCaseNotesByPersonId(id);
         }
 
-        public CaseNote ExecuteGetById(string id)
+        public CaseNoteResponse ExecuteGetById(string id)
         {
-            return _socialCarePlatformAPIGateway.GetCaseNoteById(id);
+            var caseNote = _socialCarePlatformAPIGateway.GetCaseNoteById(id);
+
+            return ResponseFactory.ToResponse(caseNote);
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseNotesUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseNotesUseCase.cs
@@ -7,6 +7,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     {
         ListCaseNotesResponse ExecuteGetByPersonId(string personId);
 
-        CaseNote ExecuteGetById(string id);
+        CaseNoteResponse ExecuteGetById(string id);
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Currently, the API endpoint: `api/v1/casenotes/{id}` returns a response like:

```
{
  "mosaicId": "string",
  "caseNoteId": "string",
  "caseNoteTitle": "string",
  "caseNoteContent": "string",
  "createdOn": "2021-03-24T10:31:53.008Z",
  "createdByEmail": "string",
  "createdByName": "string",
  "noteType": "string"
}
```

However this is not aligned with the `cases` attributes. 

### *What changes have we introduced*

This PR updates the `CaseNotesUseCase#ExecuteGetById` to map the `Domain.CaseNote` object to the `CaseNoteResponse` which has the correct naming of attributes e.g.

```
{
  "personId": "string", //mosaicId
  "recordId": "string", //caseNoteId
  "title": "string", //caseNoteTitle
  "content": "string", //caseNoteContent
  "dateOfEvent": "2021-03-24T10:31:53.008Z", //createdOn
  "officerEmail": "string", //createdByEmail
  "officerName": "string", //createdByName
  "formName": "string" //noteType
}
```

### *Follow up actions after merging PR*

- Double check sanity in staging
- Update Naomi and Luca the update has been made
- Return 404 if case note ID is not found

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-514