### PR TITLE
Show historic data based on feature flag value

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -270,23 +270,53 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void GetCaseNotesByNoteIdReturns200WhenSuccessful()
+        public void WhenShowHistoricDataFeatureFlagIsNullGetCaseNotesByNoteIdReturnsAStatusCodeOf500()
         {
-            var request = new GetCaseNotesRequest() { Id = "1" };
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
+            var request = new GetCaseNotesRequest { Id = "1" };
+
+            var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(500);
+        }
+
+
+        [Test]
+        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueGetCaseNotesByNoteIdReturnsAStatusCodeOf500()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
+            var request = new GetCaseNotesRequest { Id = "1" };
+
+            var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(500);
+        }
+
+        [Test]
+        public void WhenShowHistoricDataFeatureFlagIsTrueGetCaseNotesByNoteIdReturns200WhenSuccessful()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
+
+            var request = new GetCaseNotesRequest { Id = "1" };
 
             var note = _fixture.Create<CaseNoteResponse>();
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
 
-            var response = _classUnderTest.GetCaseNoteById(request);
+            var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
 
             response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
         }
 
         [Test]
         public void GetCaseNotesByNoteIdReturns404WhenNoMatchingCaseNoteId()
         {
-            var request = new GetCaseNotesRequest() { Id = "1" };
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
+
+            var request = new GetCaseNotesRequest { Id = "1" };
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
                 .Throws(new SocialCarePlatformApiException("404"));
@@ -300,7 +330,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void GetCaseNotesByNoteIdReturns500WhenSocialCarePlatformApiExceptionIs500()
         {
-            var request = new GetCaseNotesRequest() { Id = "1" };
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
+
+            var request = new GetCaseNotesRequest { Id = "1" };
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
                 .Throws(new SocialCarePlatformApiException("500"));

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -409,18 +409,47 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         #endregion
 
         #region Visits
+
         [Test]
-        public void GetVisitsByPersonIdReturns200WhenSuccessful()
+        public void WhenShowHistoricDataFeatureFlagIsTrueListVisitsByPersonIdReturns200WhenSuccessful()
         {
-            var request = new ListVisitsRequest() { Id = "1" };
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
 
-            var visistList = _fixture.Create<ListVisitsResponse>();
+            var request = new ListVisitsRequest { Id = "1" };
 
-            _mockVisitsUseCase.Setup(x => x.ExecuteGetByPersonId(It.IsAny<string>())).Returns(visistList);
+            var visitList = _fixture.Create<ListVisitsResponse>();
 
-            var response = _classUnderTest.ListVisits(request);
+            _mockVisitsUseCase.Setup(x => x.ExecuteGetByPersonId(It.IsAny<string>())).Returns(visitList);
+
+            var response = _classUnderTest.ListVisits(request) as ObjectResult;
 
             response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void WhenShowHistoricDataFeatureFlagIsNullListVisitsByPersonIdReturnsAStatusCodeOf500()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
+            var request = new ListVisitsRequest { Id = "1" };
+
+            var response = _classUnderTest.ListVisits(request) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(500);
+        }
+
+
+        [Test]
+        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListVisitsByPersonIdReturnsAStatusCodeOf500()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
+            var request = new ListVisitsRequest { Id = "1" };
+
+            var response = _classUnderTest.ListVisits(request) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(500);
         }
 
         #endregion

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -227,7 +227,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         #region Case notes
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListCaseNotesByPersonIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListCaseNotesByPersonIdReturnsAResponseWithNoCaseNoteData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
 
@@ -236,11 +236,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.ListCaseNotes(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNullListCaseNotesByPersonIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNullListCaseNotesByPersonIdReturnsAResponseWithNoCaseNoteData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
 
@@ -249,7 +250,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.ListCaseNotes(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
         [Test]
@@ -267,10 +269,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
+            response.Value.Should().NotBeNull();
         }
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNullGetCaseNotesByNoteIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNullGetCaseNotesByNoteIdReturnsAResponseWithNoCaseNoteData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
             var request = new GetCaseNotesRequest { Id = "1" };
@@ -278,12 +281,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueGetCaseNotesByNoteIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueGetCaseNotesByNoteIdReturnsAResponseWithNoCaseNoteData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
             var request = new GetCaseNotesRequest { Id = "1" };
@@ -291,7 +295,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
         [Test]
@@ -309,6 +314,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
+            response.Value.Should().NotBeNull();
         }
 
         [Test]
@@ -425,10 +431,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
+            response.Value.Should().NotBeNull();
         }
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNullListVisitsByPersonIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNullListVisitsByPersonIdReturnsAResponseWithNoVisitData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
             var request = new ListVisitsRequest { Id = "1" };
@@ -436,12 +443,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.ListVisits(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListVisitsByPersonIdReturnsAStatusCodeOf500()
+        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListVisitsByPersonIdReturnsAResponseWithNoVisitData()
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
             var request = new ListVisitsRequest { Id = "1" };
@@ -449,7 +457,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _classUnderTest.ListVisits(request) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(500);
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeNull();
         }
 
         #endregion

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/ProcessDataGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/ProcessDataGateway.Tests.cs
@@ -64,5 +64,68 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             //     responseList.First().OfficerEmail.Should().BeEquivalentTo(stubbedCaseData.WorkerEmail);
             //     responseList.First().FormName.Should().BeEquivalentTo(stubbedCaseData.FormName);
         }
+
+        #region ShowHistoricDataFeatureFlagTests
+
+        [Test]
+        public void WhenFeatureFlagIsTrueProcessDataCanCallSocialCarePlatformGatewayForListOfCaseNotes()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void WhenFeatureFlagIsNotTrueProcessDataShouldNotCallSocialCarePlatformGatewayForListOfCaseNotes()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void WhenFeatureFlagIsNullProcessDataShouldNotCallSocialCarePlatformGatewayForListOfCaseNotes()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void WhenFeatureFlagIsTrueProcessDataCanCallSocialCarePlatformGatewayForListOfVisits()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetVisitsByPersonId(It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void WhenFeatureFlagIsNotTrueProcessDataShouldNotCallSocialCarePlatformGatewayForListOfVisits()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetVisitsByPersonId(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void WhenFeatureFlagIsNullProcessDataShouldNotCallSocialCarePlatformGatewayForListOfVisits()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
+
+            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
+
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetVisitsByPersonId(It.IsAny<string>()), Times.Never());
+        }
+        #endregion
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -289,21 +289,26 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("casenotes/{id}")]
         public IActionResult GetCaseNoteById([FromQuery] GetCaseNotesRequest request)
         {
-            try
+            var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
+
+            if (showHistoricData != null && showHistoricData.Equals("true"))
             {
-                return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
-            }
-            catch (SocialCarePlatformApiException ex)
-            {
-                if (ex.Message == "404")
+                try
                 {
-                    return StatusCode(404);
+                    return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
                 }
-                else
+                catch (SocialCarePlatformApiException ex)
                 {
+                    if (ex.Message == "404")
+                    {
+                        return StatusCode(404);
+                    }
+
                     return StatusCode(500);
                 }
             }
+
+            return StatusCode(500, "Feature is not available");
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -273,7 +273,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
 
             return showHistoricData != null && showHistoricData.Equals("true")
                 ? Ok(_caseNotesUseCase.ExecuteGetByPersonId(request.Id))
-                : StatusCode(500, "Feature is not available");
+                : StatusCode(200, null);
         }
 
         /// <summary>
@@ -308,7 +308,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
                 }
             }
 
-            return StatusCode(500, "Feature is not available");
+            return StatusCode(200, null);
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
 
             return showHistoricData != null && showHistoricData.Equals("true")
                 ? Ok(_visitsUseCase.ExecuteGetByPersonId(request.Id))
-                : StatusCode(500, "Feature is not available");
+                : StatusCode(200, null);
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -324,7 +324,11 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("visits/person/{id}")]
         public IActionResult ListVisits([FromQuery] ListVisitsRequest request)
         {
-            return Ok(_visitsUseCase.ExecuteGetByPersonId(request.Id));
+            var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
+
+            return showHistoricData != null && showHistoricData.Equals("true")
+                ? Ok(_visitsUseCase.ExecuteGetByPersonId(request.Id))
+                : StatusCode(500, "Feature is not available");
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -269,7 +269,11 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("casenotes/person/{id}")]
         public IActionResult ListCaseNotes([FromQuery] ListCaseNotesRequest request)
         {
-            return Ok(_caseNotesUseCase.ExecuteGetByPersonId(request.Id));
+            var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
+
+            return showHistoricData != null && showHistoricData.Equals("true")
+                ? Ok(_caseNotesUseCase.ExecuteGetByPersonId(request.Id))
+                : StatusCode(500, "Feature is not available");
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -54,33 +54,36 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 }
 
                 //add historical case notes to the case history records when using mosaic id search
+                var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
 
-                //fail silently for now until platform API has been finalised
-                //TOOD: please do not use as production code
-                //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Remove when production ready")]
-                try
+                if (showHistoricData != null && showHistoricData.Equals("true"))
                 {
-                    var notesResponse = _socialCarePlatformAPIGateway.GetCaseNotesByPersonId(request.MosaicId);
-                    if (notesResponse.CaseNotes.Count > 0)
+                    //fail silently for now until platform API has been finalised
+                    //TOOD: please do not use as production code
+                    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Remove when production ready")]
+                    try
                     {
-                        result.AddRange(ResponseFactory.HistoricalCaseNotesToDomain(notesResponse.CaseNotes));
+                        var notesResponse = _socialCarePlatformAPIGateway.GetCaseNotesByPersonId(request.MosaicId);
+                        if (notesResponse.CaseNotes.Count > 0)
+                        {
+                            result.AddRange(ResponseFactory.HistoricalCaseNotesToDomain(notesResponse.CaseNotes));
+                        }
                     }
-                }
-                catch { }
+                    catch { }
 
-
-                //add historical visits to the case history records when using mosaic id search
-                //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Remove when production ready")]
-                try
-                {
-                    var visitsResponse = _socialCarePlatformAPIGateway.GetVisitsByPersonId(request.MosaicId);
-
-                    if (visitsResponse.Visits.Count > 0)
+                    //add historical visits to the case history records when using mosaic id search
+                    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Remove when production ready")]
+                    try
                     {
-                        result.AddRange(ResponseFactory.HistoricalVisitsToDomain(visitsResponse.Visits));
+                        var visitsResponse = _socialCarePlatformAPIGateway.GetVisitsByPersonId(request.MosaicId);
+
+                        if (visitsResponse.Visits.Count > 0)
+                        {
+                            result.AddRange(ResponseFactory.HistoricalVisitsToDomain(visitsResponse.Visits));
+                        }
                     }
+                    catch { }
                 }
-                catch { }
             }
             else
             {

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,7 @@ functions:
       MOSAIC_API_URL: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/mosaic-api-url}
       SOCIAL_CARE_PLATFORM_API_URL: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-url}
       SOCIAL_CARE_PLATFORM_API_TOKEN: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-token~true}
+      SOCIAL_CARE_SHOW_HISTORIC_DATA: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_show_historic_data~true}
     events:
       - http:
           path: /{proxy+}
@@ -132,7 +133,7 @@ resources:
                   Action:
                     - "s3:GetObject"
                   Resource: 'arn:aws:s3:::${self:custom.mongoDBImportBucket.${self:provider.stage}}/*'
-                  
+
 custom:
   vpc:
     development:


### PR DESCRIPTION
JIRA: https://hackney.atlassian.net/browse/SCS-595

### *What is the problem we're trying to solve*

We want to be able to toggle showing historic case notes and visits while we test the feature with the users.

### *What changes have we introduced*

Use the feature flag value set in AWS as an environment variable to determine whether or not code to retrieve historic case note or historic visit data is executed.

#### _Checklist_

- [X] Added tests to cover all new production code
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Test feature flag set up works in staging
- Clean up feature flag implementation after production release of historic mosaic data

Any feedback/suggestions would be appreciated 🙂 