### PR TITLE
Update GetCaseNoteById API endpoint to return 404s

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -253,6 +253,34 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
+        public void GetCaseNotesByNoteIdReturns404WhenNoMatchingCaseNoteId()
+        {
+            var request = new GetCaseNotesRequest() { Id = "1" };
+
+            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
+                .Throws(new SocialCarePlatformApiException("404"));
+
+            var response = _classUnderTest.GetCaseNoteById(request) as StatusCodeResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
+        public void GetCaseNotesByNoteIdReturns500WhenSocialCarePlatformApiExceptionIs500()
+        {
+            var request = new GetCaseNotesRequest() { Id = "1" };
+
+            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
+                .Throws(new SocialCarePlatformApiException("500"));
+
+            var response = _classUnderTest.GetCaseNoteById(request) as StatusCodeResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(500);
+        }
+
+        [Test]
         public void GivenAValidPersonIdWhenListCaseNotesIsCalledTheControllerReturnsCorrectJsonResponse()
         {
             string personId = "123";

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -285,7 +285,21 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("casenotes/{id}")]
         public IActionResult GetCaseNoteById([FromQuery] GetCaseNotesRequest request)
         {
-            return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
+            try
+            {
+                return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
+            }
+            catch (SocialCarePlatformApiException ex)
+            {
+                if (ex.Message == "404")
+                {
+                    return StatusCode(404);
+                }
+                else
+                {
+                    return StatusCode(500);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Currently, the API endpoint: `api/v1/casenotes/{id}` returns a `500` response when the platform API can't find a case note with the provided ID instead of a `404`.

### *What changes have we introduced*

This PR updates `SocialCareCaseViewerApiController#GetCaseNoteById` to catch the `SocialCarePlatformApiException` and when it's a `404` return `404 Not Found`.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-514