### PR TITLE
Add mosaic_id to ResponseFactory#HistoricalCaseNotesToDomain

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -66,6 +66,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         public void CanMapHistoricalCaseNoteToBsonDocument()
         {
             string caseNoteId = "1";
+            string mosaicId = "123";
             string email = "first.last@domain.com";
             DateTime createdOn = DateTime.Now;
             string noteType = "Historical note";
@@ -74,6 +75,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             CaseNote historicalCaseNote = new CaseNote()
             {
                 CaseNoteId = caseNoteId,
+                MosaicId = mosaicId,
                 CreatedByEmail = email,
                 NoteType = noteType,
                 CreatedOn = createdOn,
@@ -84,6 +86,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                         new List<BsonElement>
                         {
                                 new BsonElement("_id", caseNoteId),
+                                new BsonElement("mosaic_id", mosaicId),
                                 new BsonElement("worker_email", email),
                                 new BsonElement("form_name_overall", "Historical_Case_Note"),
                                 new BsonElement("form_name", noteTitle),
@@ -96,6 +99,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             var result = ResponseFactory.HistoricalCaseNotesToDomain(notes);
 
             Assert.AreEqual(expectedDocument.GetElement("_id"), result.First().GetElement("_id"));
+            Assert.AreEqual(expectedDocument.GetElement("mosaic_id"), result.First().GetElement("mosaic_id"));
             Assert.AreEqual(expectedDocument.GetElement("worker_email"), result.First().GetElement("worker_email"));
             Assert.AreEqual(expectedDocument.GetElement("form_name_overall"), result.First().GetElement("form_name_overall"));
             Assert.AreEqual(expectedDocument.GetElement("form_name"), result.First().GetElement("form_name"));

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -65,6 +65,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                         new List<BsonElement>
                         {
                                 new BsonElement("_id", note.CaseNoteId ?? ""),
+                                new BsonElement("mosaic_id", note.MosaicId ?? ""),
                                 new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                                 new BsonElement("form_name_overall", "Historical_Case_Note"),
                                 new BsonElement("form_name", note.CaseNoteTitle ?? ""),


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In order for frontend to be able to link to a view details page for a historic case note, it needs the ID of a person i.e. `mosaic_id` when calling the `api/v1/cases` API endpoint.

### *What changes have we introduced*

This PR add `mosaic_id` to `ResponseFactory#HistoricalCaseNotesToDomain` which is used by `ProcessDataGateway` -> `ProcessDataUseCase` -> `SocialCareCaseViewerApiController#ListCases`.
