### PR TITLE
Update the feature flag for production to be created set as true

### DIFF
--- a/terraform/production/feature_flags.tf
+++ b/terraform/production/feature_flags.tf
@@ -4,5 +4,5 @@ resource "aws_secretsmanager_secret" "show_historic_data_feature_flag" {
 
 resource "aws_secretsmanager_secret_version" "show_historic_data_feature_flag" {
   secret_id     = aws_secretsmanager_secret.show_historic_data_feature_flag.id
-  secret_string = "false"
+  secret_string = "true"
 }


### PR DESCRIPTION
We created secrets for both staging and production that would store values for our feature flag functionality.

Initially, set the value of the flag in production to be `false`, just in case any production releases needed to happen while we were still testing the feature in staging.

There haven't been any production releases yet and the feature has been approved to go live, so updating the value of the secret so that it's created set as `true` instead.

### *Follow up actions after merging PR*

Check that feature flag creation in production.
