### PR TITLE
Remove feature flag for historic case notes

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -227,38 +227,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         #region Case notes
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueListCaseNotesByPersonIdReturnsAResponseWithNoCaseNoteData()
+        public void ListCaseNotesByPersonIdReturns200WhenSuccessful()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
-
-            var request = new ListCaseNotesRequest { Id = "1" };
-
-            var response = _classUnderTest.ListCaseNotes(request) as ObjectResult;
-
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeNull();
-        }
-
-        [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNullListCaseNotesByPersonIdReturnsAResponseWithNoCaseNoteData()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
-
-            var request = new ListCaseNotesRequest { Id = "1" };
-
-            var response = _classUnderTest.ListCaseNotes(request) as ObjectResult;
-
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeNull();
-        }
-
-        [Test]
-        public void WhenShowHistoricDataFeatureFlagIsTrueListCaseNotesByPersonIdReturns200WhenSuccessful()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             var request = new ListCaseNotesRequest { Id = "1" };
 
             var notesList = _fixture.Create<ListCaseNotesResponse>();
@@ -278,6 +248,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
             var request = new GetCaseNotesRequest { Id = "1" };
 
+            var note = _fixture.Create<CaseNoteResponse>();
+
+            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
+
             var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
 
             response.Should().NotBeNull();
@@ -291,6 +265,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         {
             Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
             var request = new GetCaseNotesRequest { Id = "1" };
+
+            var note = _fixture.Create<CaseNoteResponse>();
+
+            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
 
             var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
 

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -289,9 +288,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void GivenAValidPersonIdWhenListCaseNotesIsCalledTheControllerReturnsCorrectJsonResponse()
         {
-            string personId = "123";
-            var request = new ListCaseNotesRequest() { Id = personId };
-            var response = new ListCaseNotesResponse() { CaseNotes = new List<CaseNote>() };
+            const string personId = "123";
+            var request = new ListCaseNotesRequest { Id = personId };
+            var response = new ListCaseNotesResponse { CaseNotes = new List<CaseNote>() };
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetByPersonId(personId)).Returns(response);
 
             var actualResponse = _classUnderTest.ListCaseNotes(request);

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -243,45 +243,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNullGetCaseNotesByNoteIdReturnsAResponseWithNoCaseNoteData()
+        public void GettingASingleCaseNoteByNoteIdReturns200WhenSuccessful()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
-            var request = new GetCaseNotesRequest { Id = "1" };
-
-            var note = _fixture.Create<CaseNoteResponse>();
-
-            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
-
-            var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
-
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeNull();
-        }
-
-
-        [Test]
-        public void WhenShowHistoricDataFeatureFlagIsNotEqualToTrueGetCaseNotesByNoteIdReturnsAResponseWithNoCaseNoteData()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
-            var request = new GetCaseNotesRequest { Id = "1" };
-
-            var note = _fixture.Create<CaseNoteResponse>();
-
-            _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>())).Returns(note);
-
-            var response = _classUnderTest.GetCaseNoteById(request) as ObjectResult;
-
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeNull();
-        }
-
-        [Test]
-        public void WhenShowHistoricDataFeatureFlagIsTrueGetCaseNotesByNoteIdReturns200WhenSuccessful()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             var request = new GetCaseNotesRequest { Id = "1" };
 
             var note = _fixture.Create<CaseNoteResponse>();
@@ -298,8 +261,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void GetCaseNotesByNoteIdReturns404WhenNoMatchingCaseNoteId()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             var request = new GetCaseNotesRequest { Id = "1" };
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
@@ -314,8 +275,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void GetCaseNotesByNoteIdReturns500WhenSocialCarePlatformApiExceptionIs500()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             var request = new GetCaseNotesRequest { Id = "1" };
 
             _mockCaseNotesUseCase.Setup(x => x.ExecuteGetById(It.IsAny<string>()))
@@ -327,11 +286,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             response.StatusCode.Should().Be(500);
         }
 
-        [Test, Description("ShowHistoricDataFeatureFlagIsSetToTrue")]
+        [Test]
         public void GivenAValidPersonIdWhenListCaseNotesIsCalledTheControllerReturnsCorrectJsonResponse()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             string personId = "123";
             var request = new ListCaseNotesRequest() { Id = personId };
             var response = new ListCaseNotesResponse() { CaseNotes = new List<CaseNote>() };

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/ProcessDataGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/ProcessDataGateway.Tests.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using AutoFixture;
-using FluentAssertions;
-using MongoDB.Bson;
 using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
-using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Infrastructure;
-using JsonConvert = Newtonsoft.Json.JsonConvert;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 {
@@ -65,36 +59,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             //     responseList.First().FormName.Should().BeEquivalentTo(stubbedCaseData.FormName);
         }
 
-        #region ShowHistoricDataFeatureFlagTests
+        #region ShowHistoricDataAsPartOfRecordsHistory
 
         [Test]
-        public void WhenFeatureFlagIsTrueProcessDataCanCallSocialCarePlatformGatewayForListOfCaseNotes()
+        public void ProcessDataCanCallSocialCarePlatformGatewayForAListOfHistoricCaseNotes()
         {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "true");
-
             _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
 
             _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Once);
-        }
-
-        [Test]
-        public void WhenFeatureFlagIsNotTrueProcessDataShouldNotCallSocialCarePlatformGatewayForListOfCaseNotes()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", "false");
-
-            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
-
-            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Never());
-        }
-
-        [Test]
-        public void WhenFeatureFlagIsNullProcessDataShouldNotCallSocialCarePlatformGatewayForListOfCaseNotes()
-        {
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA", null);
-
-            _classUnderTest.GetProcessData(_fixture.Create<ListCasesRequest>(), It.IsAny<string>());
-
-            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetCaseNotesByPersonId(It.IsAny<string>()), Times.Never());
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -285,26 +285,19 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("casenotes/{id}")]
         public IActionResult GetCaseNoteById([FromQuery] GetCaseNotesRequest request)
         {
-            var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
-
-            if (showHistoricData != null && showHistoricData.Equals("true"))
+            try
             {
-                try
-                {
-                    return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
-                }
-                catch (SocialCarePlatformApiException ex)
-                {
-                    if (ex.Message == "404")
-                    {
-                        return StatusCode(404);
-                    }
-
-                    return StatusCode(500);
-                }
+                return Ok(_caseNotesUseCase.ExecuteGetById(request.Id));
             }
+            catch (SocialCarePlatformApiException ex)
+            {
+                if (ex.Message == "404")
+                {
+                    return StatusCode(404);
+                }
 
-            return StatusCode(200, null);
+                return StatusCode(500);
+            }
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -269,11 +269,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("casenotes/person/{id}")]
         public IActionResult ListCaseNotes([FromQuery] ListCaseNotesRequest request)
         {
-            var showHistoricData = Environment.GetEnvironmentVariable("SOCIAL_CARE_SHOW_HISTORIC_DATA");
-
-            return showHistoricData != null && showHistoricData.Equals("true")
-                ? Ok(_caseNotesUseCase.ExecuteGetByPersonId(request.Id))
-                : StatusCode(200, null);
+            return Ok(_caseNotesUseCase.ExecuteGetByPersonId(request.Id));
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -291,12 +291,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             }
             catch (SocialCarePlatformApiException ex)
             {
-                if (ex.Message == "404")
-                {
-                    return StatusCode(404);
-                }
-
-                return StatusCode(500);
+                return StatusCode(ex.Message == "404" ? 404 : 500);
             }
         }
 


### PR DESCRIPTION
We had feature flags set up to toggle showing historic case notes in the social care interim solution.

The feature is now live in production and so we no longer need to have the feature flags set on showing historic case note data.

However, as we are still developing the feature to allow historic visits to be viewable, the feature flag set up for viewing historic visit data will remain the code. 

### *What changes have we introduced*

This removes the reliance on the feature flags for obtaining historic case notes, i.e.
- Remove checking for the value of the feature flag when calling either the `list-all` or `get-by-Id` historic case note endpoints.
- Remove/edit historic case note tests that used feature flags.

#### _Checklist_

- [X] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*
- Test endpoints still work in staging
- Merge into production