### PR TITLE
Update Staging Postgres RDS instance class

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,6 +1,6 @@
-# INSTRUCTIONS: 
-# 1) ENSURE YOU POPULATE THE LOCALS 
-# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# INSTRUCTIONS:
+# 1) ENSURE YOU POPULATE THE LOCALS
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
 # 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
 # 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
 # 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
@@ -16,10 +16,10 @@ data "aws_region" "current" {}
 
 terraform {
   backend "s3" {
-    bucket  = "terraform-state-staging-apis" 
+    bucket  = "terraform-state-staging-apis"
     encrypt = true
     region  = "eu-west-2"
-    key     = "services/social-care-case-viewer-api/state" 
+    key     = "services/social-care-case-viewer-api/state"
   }
 }
 
@@ -33,7 +33,7 @@ data "aws_subnet_ids" "staging" {
   vpc_id = data.aws_vpc.staging_vpc.id
   filter {
     name   = "tag:Type"
-    values = ["private"] 
+    values = ["private"]
   }
 }
  data "aws_ssm_parameter" "social_care_postgres_db_password" {
@@ -43,7 +43,7 @@ data "aws_subnet_ids" "staging" {
  data "aws_ssm_parameter" "social_care_postgres_username" {
    name = "/social-care-case-viewer-api/staging/postgres-username"
  }
- 
+
 module "postgres_db_staging" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
   environment_name = "staging"
@@ -54,7 +54,7 @@ module "postgres_db_staging" {
   subnet_ids = data.aws_subnet_ids.staging.ids
   db_engine = "postgres"
   db_engine_version = "11." //DMS does not work well with v12, use 11. to ignore minor version upgrades
-  db_instance_class = "db.t2.micro"
+  db_instance_class = "db.t3.medium"
   db_allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"
   db_username = data.aws_ssm_parameter.social_care_postgres_username.value


### PR DESCRIPTION
- The module used to create this Postgres instance was updated to have storage encryption set to true.
- This, however, triggered terraform to destroy and recreate our RDS instance.
- The RDS instance was not recreated because the instance class `t2.micro` does not support storage encryption.
- Updating to `t3.medium` which allows storage encryption and matches the instance class being used in production.