### PR TITLE
Update CircleCI and serverless config to deploy to Mosaic-Production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  assume-role-and-persist-workspace-mosaic-production:
+    description: "Assumes deployment role and persists credentials across jobs"
+    parameters:
+      aws-account:
+        type: string
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: <<parameters.aws-account>>
+          profile_name: default
+          role: "circleci-assume-role"
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -73,7 +88,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless            
+          command: npm i -g serverless
       - run:
           name: Build lambda
           command: |
@@ -122,6 +137,11 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  assume-role-mosaic-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace-mosaic-production:
+          aws-account: $AWS_ACCOUNT_PRODUCTION
   # terraform-init-and-apply-to-development:
     # executor: docker-terraform
     # steps:
@@ -152,6 +172,11 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  deploy-to-mosaic-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "mosaic-prod"
 
 workflows:
   check-and-deploy-development:
@@ -184,7 +209,7 @@ workflows:
       - build-and-test:
           filters:
             branches:
-              only:    
+              only:
                 - master
                 - development
       - assume-role-staging:
@@ -201,7 +226,7 @@ workflows:
             - assume-role-staging
           filters:
             branches:
-              only: 
+              only:
                 - master
                 - development
       - deploy-to-staging:
@@ -229,6 +254,34 @@ workflows:
       - deploy-to-production:
           requires:
             - assume-role-production
+          filters:
+            branches:
+              only: master
+  check-and-deploy-mosaic-production:
+      jobs:
+      - build-and-test:
+          filters:
+            branches:
+              only:
+                - master
+                - development
+      - permit-mosaic-production-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - assume-role-mosaic-production:
+          context: api-assume-role-social-care-production-context
+          requires:
+            - permit-mosaic-production-release
+          filters:
+            branches:
+              only: master
+      - deploy-to-mosaic-production:
+          requires:
+            - assume-role-mosaic-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
           paths:
             - .aws
   assume-role-and-persist-workspace-mosaic-production:
-    description: "Assumes deployment role and persists credentials across jobs"
+    description: "Assumes deployment role and persists credentials across jobs for Mosaic-Production"
     parameters:
       aws-account:
         type: string

--- a/serverless.yml
+++ b/serverless.yml
@@ -152,6 +152,13 @@ custom:
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
+    mosaic-prod:
+      securityGroupIds:
+        - sg-048f37056608033d3
+      subnetIds:
+        - subnet-0665104ee973a21be
+        - subnet-005b74d8082f68a84
   mongoDBImportBucket:
     staging: qlik-bucket-csv-to-postgres-staging
     production: mosaic-social-care-csv-prod
+    mosaic-prod: social-care-case-viewer-api-qlik-bucket


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We want to move the service API to the Mosaic-Production AWS account as that is more restrictive than the Production-APIs account that it currently lives in.

To do this first though, we want to deploy the service API into both ProductionAPIs and Mosaic-Production at the same time and then when everything set up correctly and test, we can change where frontend points to and "switch off" the service API in ProductionAPIs.

### *What changes have we introduced*

This PR updates the CircleCI and serverless config to deploy to Mosaic-Production as a separate workflow.

What this means is when `development` is merged into `master`, CircleCI will deploy the service API in Mosaic-Production in parallel with deploying to ProductionAPIs.

### *Follow-up actions after merging PR*

We'll need to merge `development` into `master` (but need to check in with team about this - if not can create the S3 bucket needed in the meantime) and then make sure things have been configured correctly.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-608

