### PR TITLE
Fix include team data and worker allocations

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/GetWorkersUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/GetWorkersUseCaseTests.cs
@@ -234,7 +234,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             string email = "fakeemail@example.com",
             string firstName = "TestFirstName",
             string lastName = "TestLastName",
-            string role = "TestRole"
+            string role = "TestRole",
+            ICollection<WorkerTeam> workerTeams = null,
+            ICollection<AllocationSet> allocations = null
             )
         {
             return new Worker()
@@ -243,7 +245,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
                 Email = email,
                 FirstName = firstName,
                 LastName = lastName,
-                Role = role
+                Role = role,
+                WorkerTeams = workerTeams,
+                Allocations = allocations
             };
         }
     }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -58,7 +58,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 LastName = worker.LastName,
                 Role = worker.Role,
                 AllocationCount = worker?.Allocations == null ? 0 : worker.Allocations.Where(x => x.CaseStatus.ToUpper() == "OPEN").Count(),
-                Teams = includeTeamData ? worker.WorkerTeams.Select(x => new Team() { Id = x.Team.Id, Name = x.Team.Name }).ToList() : null
+                Teams = includeTeamData ? worker.WorkerTeams?.Select(x => new Team() { Id = x.Team.Id, Name = x.Team.Name }).ToList() : null
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -309,7 +309,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public Worker GetWorkerByEmail(string email)
         {
             return _databaseContext.Workers
-                .FirstOrDefault(worker => worker.Email == email);
+                .Where(worker => worker.Email == email)
+                .Include(x => x.Allocations)
+                .Include(x => x.WorkerTeams)
+                .ThenInclude(y => y.Team)
+                .FirstOrDefault();
         }
 
         public List<Team> GetTeamsByTeamId(int teamId)

--- a/SocialCareCaseViewerApi/V1/UseCase/GetWorkersUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/GetWorkersUseCase.cs
@@ -56,7 +56,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 return null;
             }
             var dbWorker = _databaseGateway.GetWorkerByWorkerId(workerId);
-            return dbWorker?.ToDomain(false);
+            return dbWorker?.ToDomain(true);
         }
 
         private Worker? GetByWorkerEmail(string email)
@@ -67,7 +67,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             }
 
             var dbWorker = _databaseGateway.GetWorkerByEmail(email);
-            return dbWorker?.ToDomain(false);
+            return dbWorker?.ToDomain(true);
         }
 
         private List<Worker>? GetByWorkerTeamId(int teamId)
@@ -88,7 +88,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 {
                     foreach (var workerTeam in workerTeams)
                     {
-                        domainWorkers.Add(workerTeam.Worker.ToDomain(false));
+                        domainWorkers.Add(workerTeam.Worker.ToDomain(true));
                     }
                 }
             }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

/workers endpoint returns inconsistent data:
search by email gets back allocationCount, search by team_id I get back 1 (that is the correct value)
teams is always null even if I am worker is part of a team

### *What changes have we introduced*

Include allocations and worker team details when getting worker by email

Set team information to be included with response

#### _Checklist_

- [x] Added tests to cover all new production code
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Staging check
