### PR TITLE
Update Mosaic-Production deployment to deploy on development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,17 +271,17 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: master
+              only: development
       - assume-role-mosaic-production:
           context: api-assume-role-social-care-production-context
           requires:
             - permit-mosaic-production-release
           filters:
             branches:
-              only: master
+              only: development
       - deploy-to-mosaic-production:
           requires:
             - assume-role-mosaic-production
           filters:
             branches:
-              only: master
+              only: development


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/165, we updated the CircleCI and serverless config to deploy to Mosaic-Production in tandem with ProductionAPIs when `development` is merged into `master`.

But because we don't want to deploy to production yet, this means we can't test the deployment to Mosaic-Production.

### *What changes have we introduced*

This PR updates Mosaic-Production deployment to deploy on `development` so that we can test deploying to Mosaic-Production without having to merge `development` into `master`.

Once that's done, we'll update it back to be `on: master` again so this is only a temporary change.

### *Follow up actions after merging PR*

Ensure that config and connections are okay between the Lambdas and databases, etc.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-666