### PR TITLE
Fix incorrect subnets for Mosaic-Production in serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -157,8 +157,8 @@ custom:
         - sg-0d8739383f0960389
         - sg-0d92164e9f5d53800
       subnetIds:
-        - subnet-0665104ee973a21be
-        - subnet-005b74d8082f68a84
+        - subnet-0c39cd286eeaff2b2
+        - subnet-04c42d0aafb3738ad
   mongoDBImportBucket:
     staging: qlik-bucket-csv-to-postgres-staging
     production: mosaic-social-care-csv-prod


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

When testing the endpoint for getting a case note (i.e. testing the connection between the platform API and the service API), the service API in Mosaic-Production times out.

Looking at the VPC config for the service API and platform API, I noticed that the subnets for both were different. After making the subnets that the service API are in the same as the platform API and testing the endpoint all was good! ✅  

### *What changes have we introduced*

This PR updates the subnets for the service API to be the same as the platform API which are in the private subnets in Mosaic-Production.

### *Follow up actions after merging PR*

Update the platform API's serverless config as this is defined incorrectly and not the same as what it is in AWS.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-666