### PR TITLE
Get visit endpoint service api

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
@@ -29,6 +30,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         private Mock<ICaseNotesUseCase> _mockCaseNotesUseCase;
         private Mock<IVisitsUseCase> _mockVisitsUseCase;
         private Mock<IWarningNoteUseCase> _mockWarningNoteUseCase;
+        private Mock<IGetVisitByVisitIdUseCase> _mockGetVisitByVisitIdUseCase;
 
         private Fixture _fixture;
 
@@ -44,10 +46,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             _mockCaseNotesUseCase = new Mock<ICaseNotesUseCase>();
             _mockVisitsUseCase = new Mock<IVisitsUseCase>();
             _mockWarningNoteUseCase = new Mock<IWarningNoteUseCase>();
+            _mockGetVisitByVisitIdUseCase = new Mock<IGetVisitByVisitIdUseCase>();
 
             _classUnderTest = new SocialCareCaseViewerApiController(_mockGetAllUseCase.Object, _mockAddNewResidentUseCase.Object,
             _mockProcessDataUseCase.Object, _mockAllocationsUseCase.Object, _mockGetWorkersUseCase.Object, _mockTeamsUseCase.Object,
-            _mockCaseNotesUseCase.Object, _mockVisitsUseCase.Object, _mockWarningNoteUseCase.Object);
+            _mockCaseNotesUseCase.Object, _mockVisitsUseCase.Object, _mockWarningNoteUseCase.Object, _mockGetVisitByVisitIdUseCase.Object);
             _fixture = new Fixture();
         }
 
@@ -409,6 +412,33 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             response.Value.Should().BeNull();
         }
 
+
+        [Test]
+        public void GetVisitByVisitIdReturns200StatusAndVisitWhenSuccessful()
+        {
+            var visit = TestHelper.CreateVisitEntity();
+            _mockGetVisitByVisitIdUseCase.Setup(x => x.Execute(long.Parse(visit.Id))).Returns(visit);
+
+            var response = _classUnderTest.GetVisitByVisitId(long.Parse(visit.Id)) as OkObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(visit);
+        }
+
+        [Test]
+        public void GetVisitByVisitIdReturns404StatusAndNullWhenUnsuccessful()
+        {
+            var response = _classUnderTest.GetVisitByVisitId(1L) as OkObjectResult;
+
+            response.Should().BeNull();
+            response?.StatusCode.Should().Be(200);
+        }
         #endregion
 
         #region WarningNotes

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
@@ -172,6 +172,44 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void GivenHttpClientReturnsValidResponseThenGatewayReturnsVisitResponse()
+        {
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"
+                {
+                    ""mosaicId"": ""1"",
+                    ""title"": ""Visit title"",
+                    ""content"": ""Visit content""
+                 }")
+
+            }).Verifiable();
+
+            _httpClient = new HttpClient(mockHttpMessageHandler.Object)
+            {
+                BaseAddress = _mockBaseUri
+            };
+
+            _socialCarePlatformAPIGateway = new SocialCarePlatformAPIGateway(_httpClient);
+
+            var response = _socialCarePlatformAPIGateway.GetVisitByVisitId(1);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual("1", response.MosaicId);
+            Assert.AreEqual("Visit title", response.Title);
+            Assert.AreEqual("Visit content", response.Content);
+        }
+
+        [Test]
         public void GivenHttpClientReturnsValidResponseButDeserialisationFailsThenGatewayThrowsSocialCarePlatformApiExceptionWithCorrectMessage()
         {
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelper.cs
@@ -1,0 +1,19 @@
+using Bogus;
+using SocialCareCaseViewerApi.V1.Domain;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Helpers
+{
+    public static class TestHelper
+    {
+        public static Visit CreateVisitEntity()
+        {
+            return new Faker<Visit>()
+                .RuleFor(v => v.Id, f => f.UniqueIndex.ToString())
+                .RuleFor(v => v.Content, f => f.Random.String2(200))
+                .RuleFor(v => v.Title, f => f.Random.String2(50))
+                .RuleFor(v => v.CreatedOn, f => f.Date.Past(1))
+                .RuleFor(v => v.CreatedByEmail, f => f.Person.Email)
+                .RuleFor(v => v.MosaicId, f => f.UniqueIndex.ToString());
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/GetVisitByVisitIdUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/GetVisitByVisitIdUseCaseTests.cs
@@ -1,0 +1,42 @@
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.UseCase;
+
+namespace SocialCareCaseViewerApi.Tests.V1.UseCase
+{
+    public class GetVisitByVisitIdUseCaseTests
+    {
+        private Mock<ISocialCarePlatformAPIGateway> _mockSocialCarePlatformApiGateway;
+        private GetVisitByVisitIdUseCase _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockSocialCarePlatformApiGateway = new Mock<ISocialCarePlatformAPIGateway>();
+            _classUnderTest = new GetVisitByVisitIdUseCase(_mockSocialCarePlatformApiGateway.Object);
+        }
+
+        [Test]
+        public void GetVisitByVisitIdReturnsNullWhenNoVisitWithIdExists()
+        {
+            var response = _classUnderTest.Execute(0L);
+
+            response.Should().BeNull();
+        }
+
+        [Test]
+        public void GetVisitByVisitIdReturnsVisitWhenVisitWithIdExists()
+        {
+            var visit = TestHelper.CreateVisitEntity();
+            _mockSocialCarePlatformApiGateway.Setup(x => x.GetVisitByVisitId(long.Parse(visit.Id))).Returns(visit);
+
+            var response = _classUnderTest.Execute(long.Parse(visit.Id));
+
+            response.Should().BeEquivalentTo(visit);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -144,6 +144,7 @@ namespace SocialCareCaseViewerApi
             services.AddScoped<ICaseNotesUseCase, CaseNotesUseCase>();
             services.AddScoped<IVisitsUseCase, VisitsUseCase>();
             services.AddScoped<IWarningNoteUseCase, WarningNoteUseCase>();
+            services.AddScoped<IGetVisitByVisitIdUseCase, GetVisitByVisitIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -5,6 +5,7 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.IIS.Core;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
@@ -31,11 +32,12 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         private readonly ICaseNotesUseCase _caseNotesUseCase;
         private readonly IVisitsUseCase _visitsUseCase;
         private readonly IWarningNoteUseCase _warningNoteUseCase;
+        private readonly IGetVisitByVisitIdUseCase _getVisitByVisitIdUseCase;
 
         public SocialCareCaseViewerApiController(IGetAllUseCase getAllUseCase, IAddNewResidentUseCase addNewResidentUseCase,
             IProcessDataUseCase processDataUseCase, IAllocationsUseCase allocationUseCase, IGetWorkersUseCase getWorkersUseCase,
             ITeamsUseCase teamsUseCase, ICaseNotesUseCase caseNotesUseCase, IVisitsUseCase visitsUseCase,
-            IWarningNoteUseCase warningNotesUseCase)
+            IWarningNoteUseCase warningNotesUseCase, IGetVisitByVisitIdUseCase getVisitByVisitIdUseCase)
         {
             _getAllUseCase = getAllUseCase;
             _processDataUseCase = processDataUseCase;
@@ -46,6 +48,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             _caseNotesUseCase = caseNotesUseCase;
             _visitsUseCase = visitsUseCase;
             _warningNoteUseCase = warningNotesUseCase;
+            _getVisitByVisitIdUseCase = getVisitByVisitIdUseCase;
         }
 
         /// <summary>
@@ -289,6 +292,28 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             {
                 return StatusCode(ex.Message == "404" ? 404 : 500);
             }
+        }
+
+        /// <summary>
+        /// Get visit by visit id
+        /// </summary>
+        /// <response code="200">Success. Returns a matching visit</response>
+        /// <response code="404">No visit found for visit id</response>
+        /// <response code="500">Server error</response>
+        [ProducesResponseType(typeof(Visit), StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        [HttpGet]
+        [Route("visits/{visitId:long}")]
+        public IActionResult GetVisitByVisitId(long visitId)
+        {
+            var response = _getVisitByVisitIdUseCase.Execute(visitId);
+
+            if (response == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(response);
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
@@ -10,5 +10,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         CaseNote GetCaseNoteById(string id);
 
         ListVisitsResponse GetVisitsByPersonId(string id);
+
+        Visit GetVisitByVisitId(long id);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
@@ -40,6 +40,12 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return GetDataFromSocialCarePlatformAPI<ListVisitsResponse>(path);
         }
 
+        public Visit GetVisitByVisitId(long id)
+        {
+            var path = $"visits/{id}";
+            return GetDataFromSocialCarePlatformAPI<Visit>(path);
+        }
+
         private T GetDataFromSocialCarePlatformAPI<T>(string path)
         {
             try

--- a/SocialCareCaseViewerApi/V1/UseCase/GetVisitByVisitIdUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/GetVisitByVisitIdUseCase.cs
@@ -1,0 +1,21 @@
+using SocialCareCaseViewerApi.V1.Domain;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+
+namespace SocialCareCaseViewerApi.V1.UseCase
+{
+    public class GetVisitByVisitIdUseCase : IGetVisitByVisitIdUseCase
+    {
+        private readonly ISocialCarePlatformAPIGateway _socialCarePlatformAPIGateway;
+
+        public GetVisitByVisitIdUseCase(ISocialCarePlatformAPIGateway socialCarePlatformAPIGateway)
+        {
+            _socialCarePlatformAPIGateway = socialCarePlatformAPIGateway;
+        }
+
+        public Visit Execute(long id)
+        {
+            return _socialCarePlatformAPIGateway.GetVisitByVisitId(id);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IGetVisitByVisitIdUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IGetVisitByVisitIdUseCase.cs
@@ -1,0 +1,9 @@
+using SocialCareCaseViewerApi.V1.Domain;
+
+namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
+{
+    public interface IGetVisitByVisitIdUseCase
+    {
+        Visit Execute(long id);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

[Add visit endpoint to service API to retrieve and return visit itself](https://hackney.atlassian.net/jira/software/projects/SCS/boards/51?selectedIssue=SCS-517)

## Describe this PR

### *What is the problem we're trying to solve*

We want to be able to return all the visit details for a single visit when requested with the visit id.

### *What changes have we introduced*

Created a new API endpoint for visit id that returns associated visit.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Make FE aware.
