### PR TITLE
Update some environment variables to be decrypted in serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -53,12 +53,12 @@ functions:
     package:
       artifact: ./MongoDBImport/bin/release/netcoreapp3.1/mongodb-import.zip
     environment:
-      CONNECTION_STRING: Host=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-port};Database=social_care;Username=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-username};Password=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-password}
-      SCCV_MONGO_CONN_STRING: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/docdb-conn-string}
+      CONNECTION_STRING: Host=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-port};Database=social_care;Username=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-username};Password=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-password~true}
+      SCCV_MONGO_CONN_STRING: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/docdb-conn-string~true}
       SCCV_MONGO_DB_NAME: ${ssm:/social-care-docdb/${self:provider.stage}/docdb-name}
       SCCV_MONGO_COLLECTION_NAME: ${ssm:/social-care-docdb/${self:provider.stage}/docdb-collection}
       SCCV_MONGO_COLLECTION_NAME_TEMP: ${ssm:/social-care-docdb/${self:provider.stage}/docdb-collection-temp}
-      RDS_CA_2019: ${ssm:/social-care-docdb/${self:provider.stage}/docdb-public-key}
+      RDS_CA_2019: ${ssm:/social-care-docdb/${self:provider.stage}/docdb-public-key~true}
       SCCV_MONGO_IMPORT_COLLECTION_NAME: ${ssm:/social-care-docdb-import/${self:provider.stage}/collection-name}
       SCCV_MONGO_IMPORT_FILE_NAME: ${ssm:/social-care-docdb-import/${self:provider.stage}/file-name}
   postgreSQLImport:


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

After deploying to Mosaic-Production, it was noticed that the environment variables for the MongoDB Lambda were not decrypted which meant that the values weren't as we expected and the Lambda can't connect to the MongoDB.

### *What changes have we introduced*

This PR updates the serverless config to decrypt the SSM parameters needed for the MongoDB Import Lambda in Mosaic-Production.

### *Follow up actions after merging PR*

Double check environment variables values in Mosaic-Production and check import works.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-666