### PR TITLE
Fix historic case note response for records history and viewing case note details

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -97,8 +97,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasASCInBrackets()
         {
-            var historicalCaseNote = TestHelpers.CreateCaseNote();
-            historicalCaseNote.NoteType = "Case Summary (ASC)";
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "Case Summary (ASC)");
 
             var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
 
@@ -108,8 +107,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasYOTInBrackets()
         {
-            var historicalCaseNote = TestHelpers.CreateCaseNote();
-            historicalCaseNote.NoteType = "Home Visit (YOT)";
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "Home Visit (YOT)");
 
             var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
 
@@ -119,8 +117,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasYHInBrackets()
         {
-            var historicalCaseNote = TestHelpers.CreateCaseNote();
-            historicalCaseNote.NoteType = "Manager's Decisions (YH)";
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "Manager's Decisions (YH)");
 
             var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
 
@@ -151,8 +148,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void ToResponseForCaseNoteReturnsCaseNoteMappedToCaseNoteResponse()
         {
-            var historicalCaseNote = TestHelpers.CreateCaseNote();
-            historicalCaseNote.CreatedOn = new DateTime(2021, 3, 1, 15, 30, 0);
+            var historicalCaseNote = TestHelpers.CreateCaseNote(createdOn: new DateTime(2021, 3, 1, 15, 30, 0));
 
             var expectedCaseNoteResponse = new CaseNoteResponse()
             {
@@ -185,8 +181,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void ToResponseForCaseNoteReturnsNoteTypeWithoutBracketsAndWhitespaceForFormName()
         {
-            var historicalCaseNote = TestHelpers.CreateCaseNote();
-            historicalCaseNote.NoteType = "Manager's Decisions (YH)";
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "Manager's Decisions (YH)");
 
             var result = ResponseFactory.ToResponse(historicalCaseNote);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -170,5 +170,27 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             result.Should().BeEquivalentTo(expectedCaseNoteResponse);
         }
+
+        [Test]
+        public void ToResponseForCaseNoteReturnsCaseNoteAsAStringForFormNameWhenNoteTypeIsNull()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = null;
+
+            var result = ResponseFactory.ToResponse(historicalCaseNote);
+
+            result.FormName.Should().Be("Case note");
+        }
+
+        [Test]
+        public void ToResponseForCaseNoteReturnsNoteTypeWithoutBracketsAndWhitespaceForFormName()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = "Manager's Decisions (YH)";
+
+            var result = ResponseFactory.ToResponse(historicalCaseNote);
+
+            result.FormName.Should().Be("Manager's Decisions");
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -95,6 +95,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void HistoricalCaseNotesToDomainReturnsCaseNoteAsAStringWhenNoteTypeIsAnEmptyString()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "");
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo("Case note");
+        }
+
+        [Test]
         public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasASCInBrackets()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "Case Summary (ASC)");
@@ -172,6 +182,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             historicalCaseNote.NoteType = null;
+
+            var result = ResponseFactory.ToResponse(historicalCaseNote);
+
+            result.FormName.Should().Be("Case note");
+        }
+
+        [Test]
+        public void ToResponseForCaseNoteReturnsCaseNoteAsAStringForFormNameWhenNoteTypeIsAnEmptyString()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote(noteType: "");
 
             var result = ResponseFactory.ToResponse(historicalCaseNote);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -73,6 +73,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                     new BsonElement("worker_email", historicalCaseNote.CreatedByEmail),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
                     new BsonElement("form_name", historicalCaseNote.NoteType),
+                    new BsonElement("title", historicalCaseNote.CaseNoteTitle),
                     new BsonElement("timestamp", historicalCaseNote.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")),
                     new BsonElement("is_historical", true)
             });

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -83,6 +83,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void WhenNoteTypeIsNullReturnsCaseNoteAsAString()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = null;
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo("Case note");
+        }
+
+        [Test]
         public void CanMapVisitToBsonDocument()
         {
             var visit = TestHelpers.CreateVisit();

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -149,19 +149,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapHistoricalCaseNoteToCaseNoteResponse()
+        public void ToResponseForCaseNoteReturnsCaseNoteMappedToCaseNoteResponse()
         {
-            var historicalCaseNote = new CaseNote()
-            {
-                MosaicId = "1",
-                CaseNoteId = "123",
-                CaseNoteTitle = "Case Note Title",
-                CaseNoteContent = "Some case note content.",
-                CreatedByName = "John Smith",
-                CreatedByEmail = "john.smith@email.com",
-                NoteType = "Case Summary (ASC)",
-                CreatedOn = new DateTime(2021, 3, 1, 15, 30, 0),
-            };
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.CreatedOn = new DateTime(2021, 3, 1, 15, 30, 0);
 
             var expectedCaseNoteResponse = new CaseNoteResponse()
             {
@@ -177,14 +168,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var result = ResponseFactory.ToResponse(historicalCaseNote);
 
-            Assert.AreEqual(expectedCaseNoteResponse.RecordId, result.RecordId);
-            Assert.AreEqual(expectedCaseNoteResponse.PersonId, result.PersonId);
-            Assert.AreEqual(expectedCaseNoteResponse.Title, result.Title);
-            Assert.AreEqual(expectedCaseNoteResponse.Content, result.Content);
-            Assert.AreEqual(expectedCaseNoteResponse.DateOfEvent, result.DateOfEvent);
-            Assert.AreEqual(expectedCaseNoteResponse.OfficerName, result.OfficerName);
-            Assert.AreEqual(expectedCaseNoteResponse.OfficerEmail, result.OfficerEmail);
-            Assert.AreEqual(expectedCaseNoteResponse.FormName, result.FormName);
+            result.Should().BeEquivalentTo(expectedCaseNoteResponse);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -95,6 +95,39 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void WhenNoteTypeHasASCInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = "Case Summary (ASC)";
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo("Case Summary");
+        }
+
+        [Test]
+        public void WhenNoteTypeHasYOTInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = "Home Visit (YOT)";
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo("Home Visit");
+        }
+
+        [Test]
+        public void WhenNoteTypeHasYHInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        {
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+            historicalCaseNote.NoteType = "Manager's Decisions (YH)";
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo("Manager's Decisions");
+        }
+
+        [Test]
         public void CanMapVisitToBsonDocument()
         {
             var visit = TestHelpers.CreateVisit();

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -72,7 +72,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                     new BsonElement("mosaic_id", historicalCaseNote.MosaicId),
                     new BsonElement("worker_email", historicalCaseNote.CreatedByEmail),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", historicalCaseNote.CaseNoteTitle),
+                    new BsonElement("form_name", historicalCaseNote.NoteType),
                     new BsonElement("timestamp", historicalCaseNote.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")),
                     new BsonElement("is_historical", true)
             });

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -63,7 +63,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapCaseNoteToBsonDocument()
+        public void HistoricalCaseNotesToDomainReturnsCaseNoteMappedToDomain()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             var expectedDocument = new BsonDocument(
@@ -84,7 +84,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void WhenNoteTypeIsNullReturnsCaseNoteAsAString()
+        public void HistoricalCaseNotesToDomainReturnsCaseNoteAsAStringWhenNoteTypeIsNull()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             historicalCaseNote.NoteType = null;
@@ -95,7 +95,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void WhenNoteTypeHasASCInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasASCInBrackets()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             historicalCaseNote.NoteType = "Case Summary (ASC)";
@@ -106,7 +106,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void WhenNoteTypeHasYOTInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasYOTInBrackets()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             historicalCaseNote.NoteType = "Home Visit (YOT)";
@@ -117,7 +117,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void WhenNoteTypeHasYHInBracketsReturnsFormNameWithoutThemAndWhitespace()
+        public void HistoricalCaseNotesToDomainReturnsFormNameWithoutBracketsAndWhitespaceWhenNoteTypeHasYHInBrackets()
         {
             var historicalCaseNote = TestHelpers.CreateCaseNote();
             historicalCaseNote.NoteType = "Manager's Decisions (YH)";

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -33,13 +33,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(v => v.CreatedByName, f => f.Person.FullName);
         }
 
-        public static CaseNote CreateCaseNote()
+        public static CaseNote CreateCaseNote(string? noteType = null, DateTime? createdOn = null)
         {
             return new Faker<CaseNote>()
                 .RuleFor(c => c.CaseNoteId, f => f.UniqueIndex.ToString())
                 .RuleFor(c => c.MosaicId, f => f.UniqueIndex.ToString())
-                .RuleFor(c => c.CreatedOn, f => f.Date.Past())
-                .RuleFor(c => c.NoteType, f => f.Random.String2(50))
+                .RuleFor(c => c.CreatedOn, f => createdOn ?? f.Date.Past())
+                .RuleFor(c => c.NoteType, f => noteType ?? f.Random.String2(50))
                 .RuleFor(c => c.CaseNoteContent, f => f.Random.String2(50))
                 .RuleFor(c => c.CaseNoteTitle, f => f.Random.String2(50))
                 .RuleFor(c => c.CreatedByEmail, f => f.Person.Email)

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -66,6 +66,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
                     new BsonElement("form_name", note.NoteType ?? "Case note"),
+                    new BsonElement("title", note.CaseNoteTitle),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end
                 }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -65,7 +65,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("mosaic_id", note.MosaicId),
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", note.CaseNoteTitle ?? ""),
+                    new BsonElement("form_name", note.NoteType ?? ""),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end
                 }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -1,9 +1,8 @@
-using System;
+using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-using Newtonsoft.Json.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Infrastructure;
@@ -58,6 +57,10 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static BsonDocument HistoricalCaseNotesToDomain(CaseNote note)
         {
+            string pattern = @"\([^()]*\)$"; // Match brackets at the end e.g. (ASC)
+            var formName = note.NoteType ?? "Case note";
+            var formattedFormName = Regex.Replace(formName, pattern, "").TrimEnd();
+
             return new BsonDocument(
                 new List<BsonElement>
                 {
@@ -65,7 +68,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("mosaic_id", note.MosaicId),
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", note.NoteType ?? "Case note"),
+                    new BsonElement("form_name", formattedFormName),
                     new BsonElement("title", note.CaseNoteTitle),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -65,7 +65,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("mosaic_id", note.MosaicId),
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", note.NoteType ?? ""),
+                    new BsonElement("form_name", note.NoteType ?? "Case note"),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end
                 }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
@@ -121,7 +122,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         private static string FormatFormNameForHistoricCaseNote(string noteType)
         {
             string pattern = @"\([^()]*\)$"; // Match brackets at the end e.g. (ASC)
-            var formName = noteType ?? "Case note";
+            var formName = String.IsNullOrEmpty(noteType) ? "Case note" : noteType;
             var formattedFormName = Regex.Replace(formName, pattern, "").TrimEnd();
 
             return formattedFormName;

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -57,10 +57,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static BsonDocument HistoricalCaseNotesToDomain(CaseNote note)
         {
-            string pattern = @"\([^()]*\)$"; // Match brackets at the end e.g. (ASC)
-            var formName = note.NoteType ?? "Case note";
-            var formattedFormName = Regex.Replace(formName, pattern, "").TrimEnd();
-
             return new BsonDocument(
                 new List<BsonElement>
                 {
@@ -68,7 +64,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("mosaic_id", note.MosaicId),
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", formattedFormName),
+                    new BsonElement("form_name", FormatFormNameForHistoricCaseNote(note.NoteType)),
                     new BsonElement("title", note.CaseNoteTitle),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end
@@ -104,7 +100,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 DateOfEvent = historicalCaseNote.CreatedOn.ToString("s"),
                 OfficerName = historicalCaseNote.CreatedByName,
                 OfficerEmail = historicalCaseNote.CreatedByEmail,
-                FormName = historicalCaseNote.NoteType
+                FormName = FormatFormNameForHistoricCaseNote(historicalCaseNote.NoteType)
             };
         }
 
@@ -120,6 +116,15 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 AllocationCount = worker.AllocationCount,
                 Teams = worker.Teams
             };
+        }
+
+        private static string FormatFormNameForHistoricCaseNote(string noteType)
+        {
+            string pattern = @"\([^()]*\)$"; // Match brackets at the end e.g. (ASC)
+            var formName = noteType ?? "Case note";
+            var formattedFormName = Regex.Replace(formName, pattern, "").TrimEnd();
+
+            return formattedFormName;
         }
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In the records history for a person, the “Record type” or `form_name` or “form type” returned for historic case notes is set to the `title` of it. This makes it difficult to filter by type on the frontend because the type for a historic case note is not generic.

### *What changes have we introduced*

This PR resolves the above by updating the `ResponseFactory#HistoricalCaseNotesToDomain` and `ResponseFactory#ToResponse` for a `CaseNote` which ensures that for records history i.e. `api/v1/cases`:

- we return `NoteType` for `form_name` to allow for filtering by type
- we continue to return `Title` via added `title` attribute

and for both records history and view historic case note by ID i.e. `api/v1/casenotes/{id}`:

- if `NoteType` is null, we return `"Case note"`
- if `NoteType` includes brackets e.g. `"Manager's Decisions (YH)"`, we return `"Manager's Decisions"`

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Notify frontend of changes.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-708
