### PR TITLE
Update make commands and README for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ shell:
 
 .PHONY: test
 test:
-	docker-compose up test-database & docker-compose build base-api-test && docker-compose up base-api-test
+	docker-compose build social-care-case-viewer-api-test && docker-compose up social-care-case-viewer-api-test
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,9 @@ shell:
 test:
 	docker-compose build social-care-case-viewer-api-test && docker-compose up social-care-case-viewer-api-test
 
-.PHONY: lint
-lint:
-	-dotnet tool install -g dotnet-format
-	dotnet tool update -g dotnet-format
-	dotnet format
+.PHONY: start-test-dbs
+start-test-dbs:
+	docker-compose up -d test-database && docker-compose up -d mongo-db
 
 .PHONY: restart-db
 restart-db:
@@ -30,3 +28,9 @@ restart-db:
 	-docker rm $$(docker ps -q --filter ancestor=test-database -a)
 	docker rmi test-database
 	docker-compose up -d test-database
+
+.PHONY: lint
+lint:
+	-dotnet tool install -g dotnet-format
+	dotnet tool update -g dotnet-format
+	dotnet format

--- a/README.md
+++ b/README.md
@@ -74,11 +74,43 @@ The application will be served at http://localhost:5000.
 
 ### Running the tests
 
-To run all tests and keep the test database running:
+There are two ways of running the tests: using the terminal and using an IDE.
+
+#### Using the terminal
+
+To run all tests, use:
 
 ```sh
-$ docker-compose up
+$ make test
 ```
+
+To run some tests i.e. single or a group, run the test databases in the background:
+
+```sh
+$ make start-test-dbs
+```
+
+And then you can filter through tests, using the `--filter` argument of the
+`dotnet test` command:
+
+```sh
+# E.g. for a specific test, use the test method name
+$ dotnet test --filter GivenHttpClientReturnsValidResponseThenGatewayReturnsListCaseNotesResponse
+# E.g. for a file, use the test class name
+$ dotnet test --filter SocialCarePlatformAPIGatewayTests
+```
+
+See [Microsoft's documentation on running selective unit tests](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest) for more information.
+
+#### Using an IDE
+
+Run the test databases in the background, using:
+
+```sh
+$ make start-test-dbs
+```
+
+This will allow you to run the tests as normal in your IDE.
 
 ## Active Contributors
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,5 +48,3 @@ services:
       - 5432:5432
     env_file:
       - database.env
-   
-  


### PR DESCRIPTION
This PR:

- ensures we're calling the right service for the `test` make command
- adds `start-test-dbs` make command to run the test databases in the background / detached mode
- updates the README with the above updates for testing and how to filter tests if you want to only run a selective few