### PR TITLE
Fix GET warning notes

### DIFF
--- a/SocialCareCaseViewerApi/V1/Infrastructure/WarningNote.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/WarningNote.cs
@@ -16,46 +16,49 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public long PersonId { get; set; }
 
         [Column("start_date")]
-        [Required]
         public DateTime? StartDate { get; set; }
 
         [Column("review_date")]
-        [Required]
         public DateTime? ReviewDate { get; set; }
 
         [Column("end_date")]
         public DateTime? EndDate { get; set; }
 
         [Column("individual_notified")]
-        [Required]
-        public Boolean DisclosedWithIndividual { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
 
         [Column("notification_details")]
+        [MaxLength(1000)]
         public string DisclosedDetails { get; set; }
 
         [Column("review_details")]
-        [Required]
+        [MaxLength(1000)]
         public string Notes { get; set; }
 
         [Column("next_review_date")]
         public DateTime? NextReviewDate { get; set; }
 
         [Column("note_type")]
+        [MaxLength(50)]
         public string NoteType { get; set; }
 
         [Column("status")]
+        [MaxLength(50)]
         public string Status { get; set; }
 
         [Column("date_informed")]
         public DateTime? DisclosedDate { get; set; }
 
         [Column("how_informed")]
+        [MaxLength(50)]
         public string DisclosedHow { get; set; }
 
         [Column("warning_narrative")]
+        [MaxLength(1000)]
         public string WarningNarrative { get; set; }
 
         [Column("managers_name")]
+        [MaxLength(100)]
         public string ManagerName { get; set; }
 
         [Column("date_manager_informed")]
@@ -69,12 +72,14 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public DateTime? CreatedAt { get; set; }
 
         [Column("sccv_created_by")]
+        [MaxLength(300)]
         public string CreatedBy { get; set; }
 
         [Column("sccv_last_modified_at")]
         public DateTime? LastModifiedAt { get; set; }
 
         [Column("sccv_last_modified_by")]
+        [MaxLength(300)]
         public string LastModifiedBy { get; set; }
 
         public object Clone()


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/SCS-717

## Describe this PR

When the GET `warningnotes/{id}` is called, the API returns a 500.

From investigating the logs, the error returned by the lambda read:
`Unknown error responding to request: InvalidCastException: System.InvalidCastException: Column is null`

It looks like Entity Framework returns this error when we've set up columns as required in the infrastructure when the actual database schema has the columns as NULLABLE.

### *What changes have we introduced*

This removes the extra `[required]` tags on columns that are nullable according to the database schema from within the Warning Notes Infrastructure Class

#### _Checklist_
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Refactor the GET warning notes endpoint to match a more RESTful API endpoint structure 
i.e `GET /residents/{personId}/warningNotes`