### PR TITLE
Refactor get all warning notes endpoint path

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -12,8 +12,10 @@ using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
 using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 {
@@ -644,17 +646,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void PostWarningNoteReturns201WhenSuccessful()
         {
-            var PostWarningNoteResponse = _fixture.Create<PostWarningNoteResponse>();
-            var PostWarningNoteRequest = new PostWarningNoteRequest();
+            var postWarningNoteResponse = _fixture.Create<PostWarningNoteResponse>();
+            var postWarningNoteRequest = new PostWarningNoteRequest();
 
             _mockWarningNoteUseCase
-                .Setup(x => x.ExecutePost(PostWarningNoteRequest))
-                .Returns(PostWarningNoteResponse);
-            var response = _classUnderTest.PostWarningNote(PostWarningNoteRequest) as CreatedAtActionResult;
+                .Setup(x => x.ExecutePost(postWarningNoteRequest))
+                .Returns(postWarningNoteResponse);
+            var response = _classUnderTest.PostWarningNote(postWarningNoteRequest) as CreatedAtActionResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(201);
-            response.Value.Should().BeEquivalentTo(PostWarningNoteResponse);
+            response.Value.Should().BeEquivalentTo(postWarningNoteResponse);
         }
 
         [Test]
@@ -674,13 +676,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void GetWarningNoteReturns200AndGetWarningNoteResponseWhenSuccessful()
         {
+            var testPersonId = _fixture.Create<long>();
             var stubbedWarningNoteResponse = _fixture.Create<List<WarningNote>>();
 
             _mockWarningNoteUseCase
-                .Setup(x => x.ExecuteGet(It.IsAny<GetWarningNoteRequest>()))
+                .Setup(x => x.ExecuteGet(It.IsAny<long>()))
                 .Returns(stubbedWarningNoteResponse);
 
-            var response = _classUnderTest.GetWarningNote(new GetWarningNoteRequest()) as OkObjectResult;
+            var response = _classUnderTest.GetWarningNote(testPersonId) as OkObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
@@ -688,13 +691,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void GetWarningNoteReturns404IfDocumentNotDound()
+        public void GetWarningNoteReturns404IfDocumentNotFound()
         {
+            var testPersonId = _fixture.Create<long>();
+
             _mockWarningNoteUseCase
-                .Setup(x => x.ExecuteGet(It.IsAny<GetWarningNoteRequest>()))
+                .Setup(x => x.ExecuteGet(It.IsAny<long>()))
                 .Throws(new DocumentNotFoundException("Document Not Found"));
 
-            var response = _classUnderTest.GetWarningNote(new GetWarningNoteRequest()) as ObjectResult;
+            var response = _classUnderTest.GetWarningNote(testPersonId) as ObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(404);

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -677,17 +677,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         public void GetWarningNoteReturns200AndGetWarningNoteResponseWhenSuccessful()
         {
             var testPersonId = _fixture.Create<long>();
-            var stubbedWarningNoteResponse = _fixture.Create<List<WarningNote>>();
+            var stubbedWarningNotesResponse = _fixture.Create<ListWarningNotesResponse>();
 
             _mockWarningNoteUseCase
                 .Setup(x => x.ExecuteGet(It.IsAny<long>()))
-                .Returns(stubbedWarningNoteResponse);
+                .Returns(stubbedWarningNotesResponse);
 
-            var response = _classUnderTest.GetWarningNote(testPersonId) as OkObjectResult;
+            var response = _classUnderTest.ListWarningNotes(testPersonId) as OkObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(stubbedWarningNoteResponse);
+            response.Value.Should().BeEquivalentTo(stubbedWarningNotesResponse);
         }
 
         [Test]
@@ -699,7 +699,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
                 .Setup(x => x.ExecuteGet(It.IsAny<long>()))
                 .Throws(new DocumentNotFoundException("Document Not Found"));
 
-            var response = _classUnderTest.GetWarningNote(testPersonId) as ObjectResult;
+            var response = _classUnderTest.ListWarningNotes(testPersonId) as ObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(404);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -563,23 +563,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void GetWarningNotesReturnsTheExpectedWarningNote()
         {
-            WarningNote warningNote = new WarningNote()
+            var testPersonId = _faker.Random.Int();
+            var differentPersonId = _faker.Random.Int();
+
+            var warningNote = new WarningNote
             {
-                PersonId = 12345
+                PersonId = testPersonId
             };
-            WarningNote wrongWarningNote = new WarningNote()
+
+            var wrongWarningNote = new WarningNote
             {
-                PersonId = 67890
+                PersonId = differentPersonId
             };
+
             DatabaseContext.WarningNotes.Add(warningNote);
             DatabaseContext.WarningNotes.Add(wrongWarningNote);
             DatabaseContext.SaveChanges();
 
-            var request = _fixture.Build<GetWarningNoteRequest>()
-                            .With(x => x.PersonId, warningNote.PersonId)
-                            .Create();
-
-            var response = _classUnderTest.GetWarningNotes(request);
+            var response = _classUnderTest.GetWarningNotes(testPersonId);
 
             response.Should().ContainSingle();
             response.Should().ContainEquivalentOf(warningNote);
@@ -589,22 +590,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void GetWarningNotesReturnsAnExceptionIfTheWarningNoteDoesNotExist()
         {
-            WarningNote warningNote = new WarningNote()
+            var testPersonId = _faker.Random.Int();
+            var differentPersonId = _faker.Random.Int();
+
+            var warningNote = new WarningNote
             {
-                PersonId = 12345
+                PersonId = testPersonId
             };
             DatabaseContext.WarningNotes.Add(warningNote);
             DatabaseContext.SaveChanges();
 
-            var request = new GetWarningNoteRequest()
-            {
-                PersonId = 67890
-            };
-
-            Action act = () => _classUnderTest.GetWarningNotes(request);
+            Action act = () => _classUnderTest.GetWarningNotes(differentPersonId);
 
             act.Should().Throw<DocumentNotFoundException>()
-                .WithMessage($"No warning notes found relating to person id {request.PersonId}");
+                .WithMessage($"No warning notes found relating to person id {differentPersonId}");
         }
         #endregion
     }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -588,6 +588,42 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void GetWarningNotesReturnsAListOfWarningNotesForASpecificPerson()
+        {
+            var testPersonId = _faker.Random.Int();
+            var differentPersonId = _faker.Random.Int();
+
+            var firstNote = new WarningNote
+            {
+                PersonId = testPersonId,
+                Notes = "I am one note"
+            };
+
+            var secondNote = new WarningNote
+            {
+                PersonId = testPersonId,
+                Notes = "I am another note"
+            };
+
+            var separateWarningNote = new WarningNote
+            {
+                PersonId = differentPersonId
+            };
+
+            DatabaseContext.WarningNotes.Add(firstNote);
+            DatabaseContext.WarningNotes.Add(secondNote);
+            DatabaseContext.WarningNotes.Add(separateWarningNote);
+            DatabaseContext.SaveChanges();
+
+            var response = _classUnderTest.GetWarningNotes(testPersonId);
+
+            response.Count().Should().Be(2);
+            response.Should().ContainEquivalentOf(firstNote);
+            response.Should().ContainEquivalentOf(secondNote);
+            response.Should().NotContain(separateWarningNote);
+        }
+
+        [Test]
         public void GetWarningNotesReturnsAnExceptionIfTheWarningNoteDoesNotExist()
         {
             var testPersonId = _faker.Random.Int();

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
@@ -80,11 +80,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void ExecuteGetReturnsAGetWarningNoteResponse()
         {
+            var testPersonId = _fixture.Create<long>();
+
             _mockDatabaseGateway.Setup(
-                x => x.GetWarningNotes(It.IsAny<GetWarningNoteRequest>()))
+                x => x.GetWarningNotes(It.IsAny<long>()))
                 .Returns(new List<dbWarningNote>());
 
-            var response = _classUnderTest.ExecuteGet(new GetWarningNoteRequest());
+            var response = _classUnderTest.ExecuteGet(testPersonId);
 
             response.Should().NotBeNull();
             response.Should().BeOfType<List<WarningNote>>();
@@ -93,30 +95,33 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void ExecuteGetCallsTheDatabaseGateWayWithAParameter()
         {
+            var testPersonId = _fixture.Create<long>();
+
             _mockDatabaseGateway.Setup(
-                x => x.GetWarningNotes(It.IsAny<GetWarningNoteRequest>()))
+                x => x.GetWarningNotes(It.IsAny<long>()))
                 .Returns(new List<dbWarningNote>());
 
-            var request = new GetWarningNoteRequest();
-
-            _classUnderTest.ExecuteGet(request);
+            _classUnderTest.ExecuteGet(testPersonId);
             _mockDatabaseGateway.Verify(
-                x => x.GetWarningNotes(request), Times.Once);
+                x => x.GetWarningNotes(testPersonId), Times.Once);
         }
 
         [Test]
         public void ExecuteGetReturnsTheExpectedResponse()
         {
+            var testPersonId = _fixture.Create<long>();
+
             var stubbedWarningNote = _fixture.Build<dbWarningNote>()
                                     .Without(x => x.Person)
                                     .Create();
+
             var stubbedList = new List<dbWarningNote>
             {
                 stubbedWarningNote
             };
 
             _mockDatabaseGateway.Setup(
-                x => x.GetWarningNotes(It.IsAny<GetWarningNoteRequest>()))
+                x => x.GetWarningNotes(It.IsAny<long>()))
                 .Returns(stubbedList);
 
             var expectedResponse = new List<WarningNote>
@@ -124,7 +129,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
                     stubbedWarningNote.ToDomain()
                 };
 
-            var response = _classUnderTest.ExecuteGet(new GetWarningNoteRequest());
+            var response = _classUnderTest.ExecuteGet(testPersonId);
 
             response.Should().BeEquivalentTo(expectedResponse);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
@@ -9,7 +10,6 @@ using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase;
 using dbWarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
-using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 {
@@ -89,7 +89,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var response = _classUnderTest.ExecuteGet(testPersonId);
 
             response.Should().NotBeNull();
-            response.Should().BeOfType<List<WarningNote>>();
+            response.Should().BeOfType<ListWarningNotesResponse>();
         }
 
         [Test]
@@ -111,23 +111,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var testPersonId = _fixture.Create<long>();
 
-            var stubbedWarningNote = _fixture.Build<dbWarningNote>()
+            var stubbedWarningNotesList = _fixture.Build<dbWarningNote>()
                                     .Without(x => x.Person)
-                                    .Create();
-
-            var stubbedList = new List<dbWarningNote>
-            {
-                stubbedWarningNote
-            };
+                                    .CreateMany().ToList();
 
             _mockDatabaseGateway.Setup(
                 x => x.GetWarningNotes(It.IsAny<long>()))
-                .Returns(stubbedList);
+                .Returns(stubbedWarningNotesList);
 
-            var expectedResponse = new List<WarningNote>
-                {
-                    stubbedWarningNote.ToDomain()
-                };
+            var expectedResponse = new ListWarningNotesResponse
+            {
+                WarningNotes = stubbedWarningNotesList.Select(wn => wn.ToDomain()).ToList()
+            };
 
             var response = _classUnderTest.ExecuteGet(testPersonId);
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/ListWarningNotesResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/ListWarningNotesResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using SocialCareCaseViewerApi.V1.Domain;
+
+namespace SocialCareCaseViewerApi.V1.Boundary.Response
+{
+    public class ListWarningNotesResponse
+    {
+        public List<WarningNote> WarningNotes { get; set; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -388,19 +388,18 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         }
 
         /// <summary>
-        /// Get warning notes by person id
+        /// Get all warning notes created for a specific person
         /// </summary>
-        /// <param name="request"></param>
         /// <response code="200">Success. Returns warning notes related to the specified ID</response>
         /// <response code="404">No warning notes found for the specified ID</response>
         [ProducesResponseType(typeof(List<WarningNote>), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("warningnotes/{id}")]
-        public IActionResult GetWarningNote([FromQuery] GetWarningNoteRequest request)
+        [Route("residents/{personId}/warningNotes")]
+        public IActionResult GetWarningNote(long personId)
         {
             try
             {
-                return Ok(_warningNoteUseCase.ExecuteGet(request));
+                return Ok(_warningNoteUseCase.ExecuteGet(personId));
             }
             catch (DocumentNotFoundException e)
             {

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -392,10 +392,10 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// </summary>
         /// <response code="200">Success. Returns warning notes related to the specified ID</response>
         /// <response code="404">No warning notes found for the specified ID</response>
-        [ProducesResponseType(typeof(List<WarningNote>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ListWarningNotesResponse), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("residents/{personId}/warningNotes")]
-        public IActionResult GetWarningNote(long personId)
+        public IActionResult ListWarningNotes(long personId)
         {
             try
             {

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -550,12 +550,12 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return response;
         }
 
-        public IEnumerable<WarningNote> GetWarningNotes(GetWarningNoteRequest request)
+        public IEnumerable<WarningNote> GetWarningNotes(long personId)
         {
             var warningNotes = _databaseContext.WarningNotes
-                .Where(x => x.PersonId == request.PersonId);
+                .Where(x => x.PersonId == personId);
 
-            if (warningNotes.FirstOrDefault() == null) throw new DocumentNotFoundException($"No warning notes found relating to person id {request.PersonId}");
+            if (warningNotes.FirstOrDefault() == null) throw new DocumentNotFoundException($"No warning notes found relating to person id {personId}");
 
             return warningNotes;
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -23,6 +23,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         List<Team> GetTeams(string context);
         UpdateAllocationResponse UpdateAllocation(UpdateAllocationRequest request);
         PostWarningNoteResponse PostWarningNote(PostWarningNoteRequest request);
-        IEnumerable<WarningNote> GetWarningNotes(GetWarningNoteRequest request);
+        IEnumerable<WarningNote> GetWarningNotes(long personId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/WarningNote.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/WarningNote.cs
@@ -16,46 +16,49 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public long PersonId { get; set; }
 
         [Column("start_date")]
-        [Required]
         public DateTime? StartDate { get; set; }
 
         [Column("review_date")]
-        [Required]
         public DateTime? ReviewDate { get; set; }
 
         [Column("end_date")]
         public DateTime? EndDate { get; set; }
 
         [Column("individual_notified")]
-        [Required]
-        public Boolean DisclosedWithIndividual { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
 
         [Column("notification_details")]
+        [MaxLength(1000)]
         public string DisclosedDetails { get; set; }
 
         [Column("review_details")]
-        [Required]
+        [MaxLength(1000)]
         public string Notes { get; set; }
 
         [Column("next_review_date")]
         public DateTime? NextReviewDate { get; set; }
 
         [Column("note_type")]
+        [MaxLength(50)]
         public string NoteType { get; set; }
 
         [Column("status")]
+        [MaxLength(50)]
         public string Status { get; set; }
 
         [Column("date_informed")]
         public DateTime? DisclosedDate { get; set; }
 
         [Column("how_informed")]
+        [MaxLength(50)]
         public string DisclosedHow { get; set; }
 
         [Column("warning_narrative")]
+        [MaxLength(1000)]
         public string WarningNarrative { get; set; }
 
         [Column("managers_name")]
+        [MaxLength(100)]
         public string ManagerName { get; set; }
 
         [Column("date_manager_informed")]
@@ -69,12 +72,14 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public DateTime? CreatedAt { get; set; }
 
         [Column("sccv_created_by")]
+        [MaxLength(300)]
         public string CreatedBy { get; set; }
 
         [Column("sccv_last_modified_at")]
         public DateTime? LastModifiedAt { get; set; }
 
         [Column("sccv_last_modified_by")]
+        [MaxLength(300)]
         public string LastModifiedBy { get; set; }
 
         public object Clone()

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
@@ -8,6 +8,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     public interface IWarningNoteUseCase
     {
         PostWarningNoteResponse ExecutePost(PostWarningNoteRequest request);
-        List<WarningNote> ExecuteGet(GetWarningNoteRequest request);
+        List<WarningNote> ExecuteGet(long personId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
@@ -1,13 +1,11 @@
-using System.Collections.Generic;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
-using SocialCareCaseViewerApi.V1.Domain;
 
 namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface IWarningNoteUseCase
     {
         PostWarningNoteResponse ExecutePost(PostWarningNoteRequest request);
-        List<WarningNote> ExecuteGet(long personId);
+        ListWarningNotesResponse ExecuteGet(long personId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
-using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
@@ -22,12 +20,14 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return _databaseGateway.PostWarningNote(request);
         }
 
-        public List<WarningNote> ExecuteGet(long personId)
+        public ListWarningNotesResponse ExecuteGet(long personId)
         {
             var warningNotes = _databaseGateway.GetWarningNotes(personId);
 
-            var response = warningNotes.Select(x => x.ToDomain()).ToList();
-            return response;
+            return new ListWarningNotesResponse
+            {
+                WarningNotes = warningNotes.Select(x => x.ToDomain()).ToList()
+            };
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
@@ -22,9 +22,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return _databaseGateway.PostWarningNote(request);
         }
 
-        public List<WarningNote> ExecuteGet(GetWarningNoteRequest request)
+        public List<WarningNote> ExecuteGet(long personId)
         {
-            var warningNotes = _databaseGateway.GetWarningNotes(request);
+            var warningNotes = _databaseGateway.GetWarningNotes(personId);
 
             var response = warningNotes.Select(x => x.ToDomain()).ToList();
             return response;


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/SCS-717

## Describe this PR

### *What is the problem we're trying to solve*

We identified that the GET endpoint for retrieving all the warning notes created for a person should also follow a more RESTful pattern. This endpoint should return all warning notes for a specific person and should NOT imply that a warning note's ID is required.

### *What changes have we introduced*

This changes the path for retrieving all warning notes for a specific person to be:
`/residents/{personId}/warningNotes`

This also adds a change from a [PR](https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/206) that was merged into `master` to `development` (See commit dd5edb9)

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated, relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test in staging that updated path works and created warning notes can be retrieved.