### PR TITLE
Add feature flag for using note type for form name in historic case notes

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -13,6 +13,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 {
     public class ResponseFactoryTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE", "true");
+        }
+
         [Test]
         public void CanMapResidentAndAddressFromDomainToResponse()
         {
@@ -73,6 +79,50 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
 
             result.Should().BeEquivalentTo(expectedDocument);
+        }
+
+        [Test]
+        public void HistoricalCaseNotesToDomainReturnsNoteTypeForFormNameIfFeatureFlagIsOn()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE", "true");
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo(historicalCaseNote.NoteType);
+        }
+
+        [Test]
+        public void HistoricalCaseNotesToDomainReturnsTitleForFormNameIfFeatureFlagIsFalse()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE", "false");
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo(historicalCaseNote.CaseNoteTitle);
+        }
+
+        [Test]
+        public void HistoricalCaseNotesToDomainReturnsTitleForFormNameIfFeatureFlagIsAnEmptyString()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE", "");
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo(historicalCaseNote.CaseNoteTitle);
+        }
+
+        [Test]
+        public void HistoricalCaseNotesToDomainReturnsTitleForFormNameIfFeatureFlagIsNull()
+        {
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE", null);
+            var historicalCaseNote = TestHelpers.CreateCaseNote();
+
+            var result = ResponseFactory.HistoricalCaseNotesToDomain(historicalCaseNote);
+
+            result.GetValue("form_name").AsString.Should().BeEquivalentTo(historicalCaseNote.CaseNoteTitle);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -58,6 +58,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static BsonDocument HistoricalCaseNotesToDomain(CaseNote note)
         {
+            var useNoteTypeForFormName = Environment.GetEnvironmentVariable("SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE") is ("true");
+
             return new BsonDocument(
                 new List<BsonElement>
                 {
@@ -65,7 +67,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     new BsonElement("mosaic_id", note.MosaicId),
                     new BsonElement("worker_email", note.CreatedByEmail ?? ""),
                     new BsonElement("form_name_overall", "Historical_Case_Note"),
-                    new BsonElement("form_name", FormatFormNameForHistoricCaseNote(note.NoteType)),
+                    new BsonElement("form_name", useNoteTypeForFormName ? FormatFormNameForHistoricCaseNote(note.NoteType) : note.CaseNoteTitle),
                     new BsonElement("title", note.CaseNoteTitle),
                     new BsonElement("timestamp", note.CreatedOn.ToString("dd/MM/yyyy H:mm:ss")), //format used in imported data so have to match for now
                     new BsonElement("is_historical", true) //flag for front end

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,6 +36,7 @@ functions:
       SOCIAL_CARE_PLATFORM_API_URL: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-url}
       SOCIAL_CARE_PLATFORM_API_TOKEN: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-token~true}
       SOCIAL_CARE_SHOW_HISTORIC_DATA: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_show_historic_data~true}
+      SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_fix_historic_case_note_response~true}
     events:
       - http:
           path: /{proxy+}

--- a/terraform/staging/feature_flags.tf
+++ b/terraform/staging/feature_flags.tf
@@ -6,3 +6,12 @@ resource "aws_secretsmanager_secret_version" "show_historic_data_feature_flag" {
   secret_id     = aws_secretsmanager_secret.show_historic_data_feature_flag.id
   secret_string = "true"
 }
+
+resource "aws_secretsmanager_secret" "fix_historic_case_note_response_feature_flag" {
+  name = "social_care_case_viewer_api_fix_historic_case_note_response"
+}
+
+resource "aws_secretsmanager_secret_version" "fix_historic_case_note_response_feature_flag" {
+  secret_id     = aws_secretsmanager_secret.fix_historic_case_note_response_feature_flag.id
+  secret_string = "false"
+}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In a previous PR #202, we aimed to fix the fact that historic case notes were
returning the incorrect data for `form_name` i.e. record type by using the
case note title instead of note type for the `api/v1/cases` endpoint i.e.
records history in the frontend. This meant that it would be aligned with
other records and with the `api/v1/casenotes/{id}` endpoint which is correctly
returning the note type for form name.

However, it's been raised that this should be feature flagged for now
as we don't want to yet to make this change.

### *What changes have we introduced*

This PR therefore adds a new feature flag so when:

- it's `"true"`, we use `noteType` for `form_name`
- it's `"false"` or `""` or `null`, we use `caseNoteTitle` i.e. what it was before

### *Follow up actions after merging PR*

Add secret for feature flag in production via the console.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-708
