### PR TITLE
Update CircleCI config to deploy to Mosaic-Production on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,17 +271,17 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: development
+              only: master
       - assume-role-mosaic-production:
           context: api-assume-role-social-care-production-context
           requires:
             - permit-mosaic-production-release
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-mosaic-production:
           requires:
             - assume-role-mosaic-production
           filters:
             branches:
-              only: development
+              only: master


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We temporarily set the deployment to the new AWS account to be on `development` to get a quicker feedback loop
when debugging and fixing things for Mosaic-Production (see https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/170). However, now that we've got everything set up and tested, we can put this back to be aligned with deployment to ProductionAPIs.

### *What changes have we introduced*

This PR updates the CircleCI config to deploy to Mosaic-Production on `master` instead of `development`.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-666