### PR TITLE
Hotfix - Remove DOB requirement from adding a resident request

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
@@ -199,18 +199,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
-        public void ValidationFailsIfDateOfBirthIsNotProvided()
-        {
-            var request = GetValidRequest();
-            request.DateOfBirth = null;
-
-            var errors = ValidationHelper.ValidateModel(request);
-
-            Assert.AreEqual(1, errors.Count);
-            Assert.IsTrue(errors.First().ErrorMessage == "The DateOfBirth field is required.");
-        }
-
-        [Test]
         public void ValidationFailsIfEmailAddressIsNotInValidFormat()
         {
             var request = GetValidRequest();

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/AddNewResidentRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/AddNewResidentRequest.cs
@@ -21,7 +21,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         public string Gender { get; set; }
 
-        [Required]
         public DateTime? DateOfBirth { get; set; }
 
         public DateTime? DateOfDeath { get; set; }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In the frontend, we've removed the requirement for date of birth to be entered however this isn't reflected in the backend which means that users are experiencing an error when trying to add a resident.

### *What changes have we introduced*

This PR removes the requirement of `DateOfBirth` in the `AddNewResidentRequest`.

### *Follow up actions after merging PR*

Test that it removes the error in staging and then deploy to production.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-722
