### PR TITLE
Rename fix historic case notes response feature flag

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,7 @@ functions:
       SOCIAL_CARE_PLATFORM_API_URL: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-url}
       SOCIAL_CARE_PLATFORM_API_TOKEN: ${ssm:/social-care-case-viewer-api/${self:provider.stage}/social-care-platform-api-token~true}
       SOCIAL_CARE_SHOW_HISTORIC_DATA: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_show_historic_data~true}
-      SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_fix_historic_case_note_response~true}
+      SOCIAL_CARE_FIX_HISTORIC_CASE_NOTE_RESPONSE: ${ssm:/aws/reference/secretsmanager/social_care_case_viewer_api_fix_historic_case_notes_response~true}
     events:
       - http:
           path: /{proxy+}

--- a/terraform/staging/feature_flags.tf
+++ b/terraform/staging/feature_flags.tf
@@ -1,17 +1,8 @@
-resource "aws_secretsmanager_secret" "show_historic_data_feature_flag" {
-  name = "social_care_case_viewer_api_show_historic_data"
+resource "aws_secretsmanager_secret" "fix_historic_case_notes_response_feature_flag" {
+  name = "social_care_case_viewer_api_fix_historic_case_notes_response"
 }
 
-resource "aws_secretsmanager_secret_version" "show_historic_data_feature_flag" {
-  secret_id     = aws_secretsmanager_secret.show_historic_data_feature_flag.id
-  secret_string = "true"
-}
-
-resource "aws_secretsmanager_secret" "fix_historic_case_note_response_feature_flag" {
-  name = "social_care_case_viewer_api_fix_historic_case_note_response"
-}
-
-resource "aws_secretsmanager_secret_version" "fix_historic_case_note_response_feature_flag" {
-  secret_id     = aws_secretsmanager_secret.fix_historic_case_note_response_feature_flag.id
+resource "aws_secretsmanager_secret_version" "fix_historic_case_notes_response_feature_flag" {
+  secret_id     = aws_secretsmanager_secret.fix_historic_case_notes_response_feature_flag.id
   secret_string = "false"
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Due to a mismatch of Terraform in `master` and `development` and
CircleCI running Terraform for staging on both branches, Terraform
is unable to create (again) the feature flag for fixing the historic
case note response. As a result, we need to rename it as it was
previously created but then scheduled for deletion because `master`
has no Terraform related to it and you can't create a new secret with
the same name that's scheduled for deletion.

![image](https://user-images.githubusercontent.com/42817036/115680445-783bed00-a34b-11eb-9694-d7a88e4dce93.png)

### *What changes have we introduced*

This PR renames the feature flag for fixing historic case notes response and removes the show historic data feature flag.
