### PR TITLE
fixed typo for Ethnicity

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
@@ -36,7 +36,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 Gender = "M", //TODO: set and test valid values
                 DateOfBirth = DateTime.Now.AddYears(-30),
                 DateOfDeath = DateTime.Now,
-                Ethnicity = "Ethinicity",
+                Ethnicity = "Ethnicity",
                 FirstLanguage = "English",
                 Religion = "Religion",
                 SexualOrientation = "Sexual orientation",

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
@@ -35,7 +35,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 Gender = "M",
                 DateOfBirth = DateTime.Now.AddYears(-30),
                 DateOfDeath = DateTime.Now,
-                Ethnicity = "Ethinicity",
+                Ethnicity = "Ethnicity",
                 FirstLanguage = "English",
                 Religion = "Religion",
                 SexualOrientation = "Sexual orientation",

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -323,7 +323,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 SexualOrientation = person.SexualOrientation,
                 ContextFlag = person.AgeContext,
                 CreatedBy = person.CreatedBy,
-                Ethinicity = person.Ethnicity,
+                Ethnicity = person.Ethnicity,
                 FirstLanguage = person.FirstLanguage,
                 FirstName = person.FirstName,
                 Gender = person.Gender,

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
@@ -20,7 +20,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
 
         public DateTime? DateOfDeath { get; set; }
 
-        public string Ethinicity { get; set; }
+        public string Ethnicity { get; set; }
 
         public string FirstLanguage { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -144,7 +144,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 ContextFlag = person.AgeContext,
                 CreatedBy = person.CreatedBy,
                 EmailAddress = person.EmailAddress,
-                Ethinicity = person.Ethnicity,
+                Ethnicity = person.Ethnicity,
                 FirstLanguage = person.FirstLanguage,
                 FirstName = person.FirstName,
                 Gender = person.Gender,


### PR DESCRIPTION
## Describe this PR

### typo in resident API

`GET /residents/:id` is returning an object with the typo `ethinicity` instead of `ethnicity`.

This PR is simply fixing that.

#### _Checklist_

- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Aligning the FE
