### PR TITLE
Add GET endpoint to get a specific warning note with its associated reviews

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -715,6 +715,39 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
+        public void GetWarningNoteByIdReturns200WhenSuccessful()
+        {
+            var warningNoteId = _fixture.Create<long>();
+            var stubbedResponse = _fixture.Create<WarningNoteResponse>();
+
+            _mockWarningNoteUseCase
+                .Setup(x => x.ExecuteGetWarningNoteById(It.IsAny<long>()))
+                .Returns(stubbedResponse);
+
+            var response = _classUnderTest.GetWarningNoteById(warningNoteId) as OkObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(stubbedResponse);
+        }
+
+        [Test]
+        public void GetWarningNoteByIdReturns404IfNoWarningNoteIsFound()
+        {
+            var warningNoteId = _fixture.Create<long>();
+
+            _mockWarningNoteUseCase
+                .Setup(x => x.ExecuteGetWarningNoteById(It.IsAny<long>()))
+                .Throws(new DocumentNotFoundException($"No warning note found for the specified ID: {warningNoteId}"));
+
+            var response = _classUnderTest.GetWarningNoteById(warningNoteId) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(404);
+            response.Value.Should().Be($"No warning note found for the specified ID: {warningNoteId}");
+        }
+
+        [Test]
         public void PatchWarningNoteCallsTheUseCaseAndReturns204WhenSuccessful()
         {
             var request = TestHelpers.CreatePatchWarningNoteRequest().Item1;

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -186,7 +186,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 WarningNarrative = text,
                 ManagerName = text,
                 DiscussedWithManagerDate = dt,
-                CreatedBy = text
+                CreatedBy = text,
+                WarningNoteReviews = new List<WarningNoteReview>()
             };
 
             var response = dbWarningNote.ToDomain();

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -374,6 +374,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 DisclosedWithIndividual = dbWarningNote.DisclosedWithIndividual,
                 DisclosedDetails = dbWarningNote.DisclosedDetails,
                 Notes = dbWarningNote.Notes,
+                ReviewDate = dbWarningNote.ReviewDate?.ToString("s"),
                 NextReviewDate = dbWarningNote.NextReviewDate?.ToString("s"),
                 NoteType = dbWarningNote.NoteType,
                 Status = dbWarningNote.Status,
@@ -382,6 +383,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 WarningNarrative = dbWarningNote.WarningNarrative,
                 ManagerName = dbWarningNote.ManagerName,
                 DiscussedWithManagerDate = dbWarningNote.DiscussedWithManagerDate?.ToString("s"),
+                CreatedBy = dbWarningNote.CreatedBy,
                 WarningNoteReviews = new List<WarningNoteReviewResponse> { expectedWarningReviewResponse }
             };
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Bogus;
 using FluentAssertions;
 using MongoDB.Bson;
@@ -14,6 +13,7 @@ using Address = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using Person = SocialCareCaseViewerApi.V1.Infrastructure.Person;
 using PhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
 using PhoneNumberDomain = SocialCareCaseViewerApi.V1.Domain.PhoneNumber;
+using WarningNoteReview = SocialCareCaseViewerApi.V1.Infrastructure.WarningNoteReview;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Factories
 {
@@ -339,6 +339,55 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             };
 
             var result = ResponseFactory.ToResponse(person);
+
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void MapWarningNoteToResponseReturnsAnObjectWithFormattedDates()
+        {
+            var dbWarningNote = TestHelpers.CreateWarningNote();
+            var dbWarningNoteReview = TestHelpers.CreateWarningNoteReview(dbWarningNote.Id);
+            var reviewList = new List<WarningNoteReview> { dbWarningNoteReview };
+
+            var expectedWarningReviewResponse = new WarningNoteReviewResponse
+            {
+                Id = dbWarningNoteReview.Id,
+                WarningNoteId = dbWarningNoteReview.WarningNoteId,
+                ReviewDate = dbWarningNoteReview.ReviewDate?.ToString("s"),
+                DisclosedWithIndividual = dbWarningNoteReview.DisclosedWithIndividual,
+                Notes = dbWarningNoteReview.Notes,
+                ManagerName = dbWarningNoteReview.ManagerName,
+                DiscussedWithManagerDate = dbWarningNoteReview.DiscussedWithManagerDate?.ToString("s"),
+                CreatedAt = dbWarningNoteReview.CreatedAt?.ToString("s"),
+                CreatedBy = dbWarningNoteReview.CreatedBy,
+                LastModifiedAt = dbWarningNoteReview.LastModifiedAt?.ToString("s"),
+                LastModifiedBy = dbWarningNoteReview.LastModifiedBy
+            };
+
+            var expectedResponse = new WarningNoteResponse
+            {
+                Id = dbWarningNote.Id,
+                PersonId = dbWarningNote.PersonId,
+                StartDate = dbWarningNote.StartDate?.ToString("s"),
+                EndDate = dbWarningNote.EndDate?.ToString("s"),
+                DisclosedWithIndividual = dbWarningNote.DisclosedWithIndividual,
+                DisclosedDetails = dbWarningNote.DisclosedDetails,
+                Notes = dbWarningNote.Notes,
+                NextReviewDate = dbWarningNote.NextReviewDate?.ToString("s"),
+                NoteType = dbWarningNote.NoteType,
+                Status = dbWarningNote.Status,
+                DisclosedDate = dbWarningNote.DisclosedDate?.ToString("s"),
+                DisclosedHow = dbWarningNote.DisclosedHow,
+                WarningNarrative = dbWarningNote.WarningNarrative,
+                ManagerName = dbWarningNote.ManagerName,
+                DiscussedWithManagerDate = dbWarningNote.DiscussedWithManagerDate?.ToString("s"),
+                WarningNoteReviews = new List<WarningNoteReviewResponse> { expectedWarningReviewResponse }
+            };
+
+            var domainWarningNote = dbWarningNote.ToDomain(reviewList);
+
+            var result = domainWarningNote.ToResponse();
 
             result.Should().BeEquivalentTo(expectedResponse);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -749,6 +749,34 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             insertedRecord.CreatedBy.Should().Be(request.ReviewedBy);
             insertedRecord.LastModifiedBy.Should().Be(request.ReviewedBy);
         }
+
+        [Test]
+        public void GetWarningNoteByIdReturnsAReviewMadeOnTheWarningNote()
+        {
+            var (request, person, worker, warningNote) = TestHelpers.CreatePatchWarningNoteRequest();
+
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.WarningNotes.Add(warningNote);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTest.PatchWarningNote(request);
+
+            var response = _classUnderTest.GetReviewsForWarningNoteId(warningNote.Id);
+
+            response.Should().NotBeEmpty();
+            response.Count.Should().Be(1);
+
+            var expectedWarningNoteReview = response.FirstOrDefault();
+
+            expectedWarningNoteReview.WarningNoteId.Should().Be(warningNote.Id);
+            expectedWarningNoteReview.ReviewDate.Should().Be(request.ReviewDate);
+            expectedWarningNoteReview.Notes.Should().Be(request.ReviewNotes);
+            expectedWarningNoteReview.ManagerName.Should().Be(request.ManagerName);
+            expectedWarningNoteReview.DiscussedWithManagerDate.Should().Be(request.DiscussedWithManagerDate);
+            expectedWarningNoteReview.CreatedBy.Should().Be(request.ReviewedBy);
+            expectedWarningNoteReview.LastModifiedBy.Should().Be(request.ReviewedBy);
+        }
         #endregion
 
         private Worker SaveWorkerToDatabase(Worker worker)

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -820,6 +820,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             response.Should().BeEmpty();
         }
+
+        [Test]
+        public void GetReviewsForWarningNoteIdShouldNotReturnReviewsIfNoReviewsExists()
+        {
+            var newWarningNote = TestHelpers.CreateWarningNote();
+            DatabaseContext.WarningNotes.Add(newWarningNote);
+            DatabaseContext.SaveChanges();
+
+            var response = _classUnderTest.GetReviewsForWarningNoteId(newWarningNote.Id);
+
+            response.Should().BeEmpty();
+        }
         #endregion
 
         private Worker SaveWorkerToDatabase(Worker worker)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -289,7 +289,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.DisclosedHow, f => f.Random.String2(1, 50))
                 .RuleFor(w => w.WarningNarrative, f => f.Random.String2(1, 1000))
                 .RuleFor(w => w.ManagerName, f => f.Random.String2(1, 100))
-                .RuleFor(w => w.DiscussedWithManagerDate, f => f.Date.Recent());
+                .RuleFor(w => w.DiscussedWithManagerDate, f => f.Date.Recent())
+                .RuleFor(w => w.CreatedBy, f => f.Internet.Email());
         }
 
         public static (PatchWarningNoteRequest, InfrastructurePerson, Worker, WarningNote) CreatePatchWarningNoteRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -296,10 +296,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         public static (PatchWarningNoteRequest, InfrastructurePerson, Worker, WarningNote) CreatePatchWarningNoteRequest(
             long? warningNoteId = null,
             DateTime? reviewDate = null,
+            string? reviewedBy = null,
             DateTime? nextReviewDate = null,
             string? startingStatus = "open",
             string? requestStatus = "open",
             DateTime? endedDate = null,
+            string? endedBy = null,
             string? reviewNotes = null,
             string? managerName = null,
             DateTime? discussedWithManagerDate = null
@@ -312,11 +314,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             var patchWarningNoteRequest = new Faker<PatchWarningNoteRequest>()
                 .RuleFor(p => p.WarningNoteId, f => warningNoteId ?? warningNote.Id)
                 .RuleFor(p => p.ReviewDate, f => reviewDate ?? f.Date.Recent())
-                .RuleFor(p => p.ReviewedBy, f => worker.Email ?? f.Person.Email)
+                .RuleFor(p => p.ReviewedBy, f => reviewedBy ?? worker.Email)
                 .RuleFor(p => p.NextReviewDate, f => nextReviewDate ?? f.Date.Future())
                 .RuleFor(p => p.Status, f => requestStatus)
                 .RuleFor(p => p.EndedDate, f => endedDate ?? f.Date.Recent())
-                .RuleFor(p => p.EndedBy, f => worker.Email ?? f.Person.Email)
+                .RuleFor(p => p.EndedBy, f => endedBy ?? worker.Email)
                 .RuleFor(p => p.ReviewNotes, f => reviewNotes ?? f.Random.String2(1, 1000))
                 .RuleFor(p => p.ManagerName, f => managerName ?? f.Random.String2(1, 100))
                 .RuleFor(p => p.DiscussedWithManagerDate, f => discussedWithManagerDate ?? f.Date.Recent());

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -167,7 +167,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             return (updateAllocationRequest, worker, updatedByWorker, person, team);
         }
 
-        private static Worker CreateWorker(int? workerId = null)
+        public static Worker CreateWorker(int? workerId = null)
         {
             return new Faker<Worker>()
                 .RuleFor(w => w.Id, f => workerId ?? f.UniqueIndex + 1)
@@ -307,7 +307,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         {
             var person = CreatePerson();
             var worker = CreateWorker();
-            WarningNote warningNote = CreateWarningNote(personId: person.Id, status: startingStatus);
+            WarningNote warningNote = CreateWarningNote(person.Id, startingStatus);
 
             var patchWarningNoteRequest = new Faker<PatchWarningNoteRequest>()
                 .RuleFor(p => p.WarningNoteId, f => warningNoteId ?? warningNote.Id)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
-using Bogus.DataSets;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
@@ -324,6 +323,22 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(p => p.DiscussedWithManagerDate, f => discussedWithManagerDate ?? f.Date.Recent());
 
             return (patchWarningNoteRequest, person, worker, warningNote);
+        }
+
+        public static WarningNoteReview CreateWarningNoteReview(long warningNoteId)
+        {
+            return new Faker<WarningNoteReview>()
+                .RuleFor(r => r.Id, f => f.UniqueIndex)
+                .RuleFor(r => r.WarningNoteId, f => warningNoteId)
+                .RuleFor(r => r.ReviewDate, f => f.Date.Future())
+                .RuleFor(r => r.DisclosedWithIndividual, f => f.Random.Bool())
+                .RuleFor(r => r.Notes, f => f.Random.String2(1, 50))
+                .RuleFor(r => r.ManagerName, f => f.Person.FullName)
+                .RuleFor(r => r.DiscussedWithManagerDate, f => f.Date.Past())
+                .RuleFor(r => r.CreatedAt, f => f.Date.Past())
+                .RuleFor(r => r.CreatedBy, f => f.Person.FullName)
+                .RuleFor(r => r.LastModifiedAt, f => f.Date.Recent())
+                .RuleFor(r => r.LastModifiedBy, f => f.Person.FullName);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
@@ -6,10 +7,12 @@ using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase;
 using dbWarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
+using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 {
@@ -136,6 +139,54 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Verify(x => x.PatchWarningNote(request),
                                     Times.Once);
 
+        }
+
+        [Test]
+        public void ExecuteGetWarningNoteByIdCallsTheDatabaseGatewayWithAWarningNoteId()
+        {
+            var warningNoteId = _fixture.Create<long>();
+
+            _mockDatabaseGateway.Setup(
+                    x => x.GetWarningNoteById(It.IsAny<long>()))
+                .Returns(new WarningNote());
+
+            _classUnderTest.ExecuteGetWarningNoteById(warningNoteId);
+
+            _mockDatabaseGateway.Verify(
+                x => x.GetWarningNoteById(warningNoteId), Times.Once);
+
+        }
+
+        [Test]
+        public void ExecuteGetWarningNoteByIdReturnsTheExpectedResponse()
+        {
+            var warningNoteId = _fixture.Create<long>();
+
+            var warningNote = _fixture.Create<WarningNote>();
+
+            _mockDatabaseGateway.Setup(
+                    x => x.GetWarningNoteById(It.IsAny<long>()))
+                .Returns(warningNote);
+
+            var expectedResponse = warningNote.ToResponse();
+
+            var response = _classUnderTest.ExecuteGetWarningNoteById(warningNoteId);
+
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void ExecuteGetWarningNoteByIdThrowNotFoundErrorIfNoWarningNoteIsReturned()
+        {
+            var warningNoteId = _fixture.Create<long>();
+
+            _mockDatabaseGateway.Setup(
+                    x => x.GetWarningNoteById(It.IsAny<long>()))
+                .Returns((WarningNote) null);
+
+            Func<WarningNoteResponse> testDelegate = () => _classUnderTest.ExecuteGetWarningNoteById(warningNoteId);
+
+            testDelegate.Should().Throw<DocumentNotFoundException>();
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
@@ -11,6 +11,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public bool DisclosedWithIndividual { get; set; }
         public string DisclosedDetails { get; set; }
         public string Notes { get; set; }
+        public string ReviewDate { get; set; }
         public string NextReviewDate { get; set; }
         public string NoteType { get; set; }
         public string Status { get; set; }
@@ -19,6 +20,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public string WarningNarrative { get; set; }
         public string ManagerName { get; set; }
         public string DiscussedWithManagerDate { get; set; }
+        public string CreatedBy { get; set; }
         public List<WarningNoteReviewResponse> WarningNoteReviews { get; set; }
     }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace SocialCareCaseViewerApi.V1.Boundary.Response
+{
+    public class WarningNoteResponse
+    {
+        public long Id { get; set; }
+        public long PersonId { get; set; }
+        public string StartDate { get; set; }
+        public string EndDate { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
+        public string DisclosedDetails { get; set; }
+        public string Notes { get; set; }
+        public string NextReviewDate { get; set; }
+        public string NoteType { get; set; }
+        public string Status { get; set; }
+        public string DisclosedDate { get; set; }
+        public string DisclosedHow { get; set; }
+        public string WarningNarrative { get; set; }
+        public string ManagerName { get; set; }
+        public string DiscussedWithManagerDate { get; set; }
+        public List<WarningNoteReviewResponse> WarningNoteReviews { get; set; }
+    }
+
+    public class WarningNoteReviewResponse
+    {
+        public long Id { get; set; }
+        public long WarningNoteId { get; set; }
+        public string ReviewDate { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
+        public string Notes { get; set; }
+        public string ManagerName { get; set; }
+        public string DiscussedWithManagerDate { get; set; }
+        public string CreatedAt { get; set; }
+        public string CreatedBy { get; set; }
+        public string LastModifiedAt { get; set; }
+        public string LastModifiedBy { get; set; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -452,6 +452,26 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         }
 
         /// <summary>
+        /// Get a specific warning note along with any associated warning note reviews
+        /// </summary>
+        /// <response code="200">Success. Returns warning note and any related reviews for the specified ID</response>
+        /// <response code="404">No warning note found for the specified ID</response>
+        [ProducesResponseType(typeof(WarningNoteResponse), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("/warningNotes/{warningNoteId}")]
+        public IActionResult GetWarningNoteById(long warningNoteId)
+        {
+            try
+            {
+                return Ok(_warningNoteUseCase.ExecuteGetWarningNoteById(warningNoteId));
+            }
+            catch (DocumentNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+        }
+
+        /// <summary>
         /// Amend Warning Notes in response to a review and add a Warning Note Review to the database
         /// </summary>
         /// <param name="request"></param>

--- a/SocialCareCaseViewerApi/V1/Domain/WarningNote.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/WarningNote.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 
 namespace SocialCareCaseViewerApi.V1.Domain
 {
@@ -21,5 +23,6 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string ManagerName { get; set; }
         public DateTime? DiscussedWithManagerDate { get; set; }
         public string CreatedBy { get; set; }
+        public List<WarningNoteReview> WarningNoteReviews { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -95,7 +95,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             return teams.Select(t => t.ToDomain()).ToList();
         }
 
-        public static WarningNote ToDomain(this dbWarningNote dbWarningNote)
+        public static WarningNote ToDomain(this dbWarningNote dbWarningNote, List<WarningNoteReview> reviews = null)
         {
             return new WarningNote
             {
@@ -115,7 +115,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 WarningNarrative = dbWarningNote.WarningNarrative,
                 ManagerName = dbWarningNote.ManagerName,
                 DiscussedWithManagerDate = dbWarningNote.DiscussedWithManagerDate,
-                CreatedBy = dbWarningNote.CreatedBy
+                CreatedBy = dbWarningNote.CreatedBy,
+                WarningNoteReviews = reviews ?? new List<WarningNoteReview>()
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -9,7 +9,7 @@ using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using dbPhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
-using domainPhoneNumber = SocialCareCaseViewerApi.V1.Domain.PhoneNumber;
+using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
 namespace SocialCareCaseViewerApi.V1.Factories
 {
@@ -158,6 +158,47 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Address = displayAddress != null ? EntityFactory.DbAddressToAddressDomain(displayAddress) : null,
                 OtherNames = person.OtherNames?.Select(x => x.ToDomain())?.ToList(),
                 PhoneNumbers = person.PhoneNumbers?.Select(x => x.ToDomain())?.ToList()
+            };
+        }
+
+        public static WarningNoteResponse ToResponse(this WarningNote warningNote)
+        {
+            return new WarningNoteResponse
+            {
+                Id = warningNote.Id,
+                PersonId = warningNote.PersonId,
+                StartDate = warningNote.StartDate?.ToString("s"),
+                EndDate = warningNote.EndDate?.ToString("s"),
+                DisclosedWithIndividual = warningNote.DisclosedWithIndividual,
+                DisclosedDetails = warningNote.DisclosedDetails,
+                Notes = warningNote.Notes,
+                NextReviewDate = warningNote.NextReviewDate?.ToString("s"),
+                NoteType = warningNote.NoteType,
+                Status = warningNote.Status,
+                DisclosedDate = warningNote.DisclosedDate?.ToString("s"),
+                DisclosedHow = warningNote.DisclosedHow,
+                WarningNarrative = warningNote.WarningNarrative,
+                ManagerName = warningNote.ManagerName,
+                DiscussedWithManagerDate = warningNote.DiscussedWithManagerDate?.ToString("s"),
+                WarningNoteReviews = warningNote.WarningNoteReviews?.Select(x => x.ToResponse()).ToList()
+            };
+        }
+
+        private static WarningNoteReviewResponse ToResponse(this WarningNoteReview review)
+        {
+            return new WarningNoteReviewResponse
+            {
+                Id = review.Id,
+                WarningNoteId = review.WarningNoteId,
+                ReviewDate = review.ReviewDate?.ToString("s"),
+                DisclosedWithIndividual = review.DisclosedWithIndividual,
+                Notes = review.Notes,
+                ManagerName = review.ManagerName,
+                DiscussedWithManagerDate = review.DiscussedWithManagerDate?.ToString("s"),
+                CreatedAt = review.CreatedAt?.ToString("s"),
+                CreatedBy = review.CreatedBy,
+                LastModifiedAt = review.LastModifiedAt?.ToString("s"),
+                LastModifiedBy = review.LastModifiedBy
             };
         }
     }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -172,6 +172,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 DisclosedWithIndividual = warningNote.DisclosedWithIndividual,
                 DisclosedDetails = warningNote.DisclosedDetails,
                 Notes = warningNote.Notes,
+                ReviewDate = warningNote.ReviewDate?.ToString("s"),
                 NextReviewDate = warningNote.NextReviewDate?.ToString("s"),
                 NoteType = warningNote.NoteType,
                 Status = warningNote.Status,
@@ -180,6 +181,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 WarningNarrative = warningNote.WarningNarrative,
                 ManagerName = warningNote.ManagerName,
                 DiscussedWithManagerDate = warningNote.DiscussedWithManagerDate?.ToString("s"),
+                CreatedBy = warningNote.CreatedBy,
                 WarningNoteReviews = warningNote.WarningNoteReviews?.Select(x => x.ToResponse()).ToList()
             };
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -637,6 +637,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return warningNotes;
         }
 
+        public List<WarningNoteReview> GetReviewsForWarningNoteId(long warningNoteId)
+        {
+            var allReviews = _databaseContext.WarningNoteReview
+                .Where(x => x.WarningNoteId == warningNoteId);
+
+            return allReviews.ToList();
+        }
+
         public void PatchWarningNote(PatchWarningNoteRequest request)
         {
             WarningNote warningNote = _databaseContext.WarningNotes.Where(x => x.Id == request.WarningNoteId).FirstOrDefault();

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -671,6 +671,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 throw new PatchWarningNoteException($"Worker ({request.ReviewedBy}) not found");
             }
 
+
             warningNote.LastReviewDate = request.ReviewDate;
             warningNote.NextReviewDate = request.NextReviewDate;
             if (request.Status?.ToLower() == "closed")

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -637,12 +637,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return warningNotes;
         }
 
-        public List<WarningNoteReview> GetReviewsForWarningNoteId(long warningNoteId)
+        public Domain.WarningNote GetWarningNoteById(long warningNoteId)
         {
-            var allReviews = _databaseContext.WarningNoteReview
-                .Where(x => x.WarningNoteId == warningNoteId);
+            var warningNote = _databaseContext.WarningNotes.FirstOrDefault(x => x.Id == warningNoteId);
 
-            return allReviews.ToList();
+            var reviews = _databaseContext.WarningNoteReview
+                .Where(x => x.WarningNoteId == warningNoteId).ToList();
+
+            return warningNote?.ToDomain(reviews);
         }
 
         public void PatchWarningNote(PatchWarningNoteRequest request)

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -25,6 +25,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         PostWarningNoteResponse PostWarningNote(PostWarningNoteRequest request);
         void PatchWarningNote(PatchWarningNoteRequest request);
         IEnumerable<WarningNote> GetWarningNotes(long personId);
+        Domain.WarningNote GetWarningNoteById(long warningNoteId);
         Person GetPersonDetailsById(long id);
         void UpdatePerson(UpdatePersonRequest request);
     }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/WarningNoteReview.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/WarningNoteReview.cs
@@ -22,28 +22,29 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public bool DisclosedWithIndividual { get; set; }
 
         [Column("notes")]
+        [MaxLength(1000)]
         public string Notes { get; set; }
 
         [Column("managers_name")]
+        [MaxLength(100)]
         public string ManagerName { get; set; }
 
         [Column("date_manager_informed")]
         public DateTime? DiscussedWithManagerDate { get; set; }
-
-        // nav props
-        public WarningNote WarningNote { get; set; }
 
         // audit props
         [Column("sccv_created_at")]
         public DateTime? CreatedAt { get; set; }
 
         [Column("sccv_created_by")]
+        [MaxLength(300)]
         public string CreatedBy { get; set; }
 
         [Column("sccv_last_modified_at")]
         public DateTime? LastModifiedAt { get; set; }
 
         [Column("sccv_last_modified_by")]
+        [MaxLength(300)]
         public string LastModifiedBy { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IWarningNoteUseCase.cs
@@ -6,9 +6,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     public interface IWarningNoteUseCase
     {
         PostWarningNoteResponse ExecutePost(PostWarningNoteRequest request);
-
         void ExecutePatch(PatchWarningNoteRequest request);
-
         ListWarningNotesResponse ExecuteGet(long personId);
+        WarningNoteResponse ExecuteGetWarningNoteById(long warningNoteId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
@@ -28,6 +29,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             {
                 WarningNotes = warningNotes.Select(x => x.ToDomain()).ToList()
             };
+        }
+
+        public WarningNoteResponse ExecuteGetWarningNoteById(long warningNoteId)
+        {
+            var warningNote = _databaseGateway.GetWarningNoteById(warningNoteId);
+
+            if (warningNote == null) throw new DocumentNotFoundException($"No warning note found for the specified ID: {warningNoteId}");
+
+            return warningNote.ToResponse();
         }
 
         public void ExecutePatch(PatchWarningNoteRequest request)


### PR DESCRIPTION
**Any feedback/suggestions would be appreciated 🙂** 

## Link to JIRA ticket

[Create GET endpoint for retrieving a specific warning note with its associated reviews
](https://hackney.atlassian.net/browse/SCS-723)

## Describe this PR

When a caseworker views a specific warning note as part of the reviewing process, they should see a list of previous reviews for that specific warning note.

### *What changes have we introduced*
Created an endpoint `warningNote/{warningNoteId}` which, when called, would return the warning note with the specified ID and a list of all reviews (if any) saved for that warning note.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test calling the endpoint in Staging returns data as desired.