### PR TITLE
Fix: Add a limit to the length of the generated ethnicity property

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -186,7 +186,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(p => p.FullName, f => f.Person.FullName)
                 .RuleFor(p => p.DateOfBirth, f => f.Person.DateOfBirth)
                 .RuleFor(p => p.DateOfDeath, f => f.Date.Recent())
-                .RuleFor(p => p.Ethnicity, f => f.Address.Country())
+                .RuleFor(p => p.Ethnicity, f => f.Random.String2(0, 30))
                 .RuleFor(p => p.FirstLanguage, f => f.Random.String2(10, 100))
                 .RuleFor(p => p.Religion, f => f.Random.String2(10, 80))
                 .RuleFor(p => p.EmailAddress, f => f.Person.Email)


### PR DESCRIPTION
It looks like a gateway test fails the [build](https://app.circleci.com/pipelines/github/LBHackney-IT/social-care-case-viewer-api/832/workflows/d4e09983-0e5f-4b0f-a617-298eb4dc0c42/jobs/2248/parallel-runs/0/steps/0-104) intermittently.

Error generated: Npgsql.PostgresException : 22001: value too long for type character varying(33)

This could be as a result of the faker class generating an ethnicity that is greater than the max length
defined in the schema for that column.

This replaces the faker method `country` with a random string with a set max length value for the generated ethnicity,
When this property is saved in the database, the value saved would be less than the max length.