### PR TITLE
Fix sorting of newly created case notes in records history

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateCaseNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateCaseNoteRequestTests.cs
@@ -29,7 +29,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 FirstName = _faker.Person.FirstName,
                 LastName = _faker.Person.LastName,
                 WorkerEmail = _faker.Internet.Email(),
-                DateOfBirth = DateTime.Now.AddYears(-20).ToString(),
+                DateOfBirth = DateTime.Now.AddYears(-20),
+                DateOfEvent = DateTime.Now.AddDays(-3),
                 PersonId = 5,
                 ContextFlag = "A",
                 CaseFormData = _faker.Random.String()

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateCaseNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateCaseNoteRequest.cs
@@ -21,7 +21,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [EmailAddress]
         public string WorkerEmail { get; set; }
 
-        public string DateOfBirth { get; set; }
+        public DateTime? DateOfBirth { get; set; }
 
         public DateTime? DateOfEvent { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateCaseNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateCaseNoteRequest.cs
@@ -23,6 +23,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         public string DateOfBirth { get; set; }
 
+        public DateTime? DateOfEvent { get; set; }
+
         [Required]
         [Range(1, int.MaxValue)]
         public int PersonId { get; set; }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -175,7 +175,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             GenericCaseNote note = new GenericCaseNote()
             {
                 Timestamp = DateTime.Now.ToString("dd/MM/yyy hh:mm"),
-                DateOfBirth = request.DateOfBirth.ToString(),
+                DateOfBirth = request.DateOfBirth?.ToString(),
                 FirstName = request.FirstName,
                 LastName = request.LastName,
                 FormName = request.FormName,

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -175,7 +175,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             GenericCaseNote note = new GenericCaseNote()
             {
                 Timestamp = DateTime.Now.ToString("dd/MM/yyy hh:mm"),
-                DateOfBirth = request.DateOfBirth?.ToString(),
+                DateOfBirth = request.DateOfBirth?.ToString("dd/MM/yyy"),
                 DateOfEvent = request.DateOfEvent?.ToString(),
                 FirstName = request.FirstName,
                 LastName = request.LastName,

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -176,6 +176,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             {
                 Timestamp = DateTime.Now.ToString("dd/MM/yyy hh:mm"),
                 DateOfBirth = request.DateOfBirth?.ToString(),
+                DateOfEvent = request.DateOfEvent?.ToString(),
                 FirstName = request.FirstName,
                 LastName = request.LastName,
                 FormName = request.FormName,

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -240,19 +240,21 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             static DateTime? GetDateToSortBy(CareCaseData x)
             {
-                DateTime? dt = null;
-
                 if (string.IsNullOrEmpty(x.DateOfEvent))
                 {
                     bool success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
-                    if (success) dt = timeStamp;
+                    if (success) return timeStamp;
                 }
                 else
                 {
                     bool success = DateTime.TryParseExact(x.DateOfEvent, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEvent);
-                    if (success) dt = dateOfEvent;
+                    if (success) return dateOfEvent;
+
+                    bool successForISOFormat = DateTime.TryParseExact(x.DateOfEvent, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEventISOFormat);
+                    if (success) return dateOfEventISOFormat;
                 }
-                return dt;
+
+                return null;
             }
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -251,7 +251,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     if (success) return dateOfEvent;
 
                     bool successForISOFormat = DateTime.TryParseExact(x.DateOfEvent, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEventISOFormat);
-                    if (success) return dateOfEventISOFormat;
+                    if (successForISOFormat) return dateOfEventISOFormat;
                 }
 
                 return null;

--- a/SocialCareCaseViewerApi/V1/Infrastructure/GenericCaseNote.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/GenericCaseNote.cs
@@ -10,5 +10,8 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
     {
         [JsonProperty("date_of_birth")]
         public string DateOfBirth { get; set; }
+
+        [JsonProperty("date_of_event")]
+        public string DateOfEvent { get; set; }
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

For newly created case notes, they appear at the bottom of the records history when they should appear at the top. This is because date of event was missing from the request which meant there was no date to sort by.

Also when testing this in staging, we also discovered a smol bug with the date of birth causing an issue when creating a case note with a null DOB.

### *What changes have we introduced*

This PR:

- fixes the null date of birth by doing a null check when doing `To.String()`
- makes sure we use date of event when creating a case note
- allows sorting for ISO format date of event

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check that these changes fix the issues in staging and add tests for `ToEntity` for `CreateCaseNoteRequest`.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-592