### PR TITLE
Remove require patch warning note data of birth

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
@@ -98,18 +98,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
-        public void ValidationFailsIfDateOfBirthIsNotProvided()
-        {
-            var request = GetValidRequest();
-            request.DateOfBirth = null;
-
-            var errors = ValidationHelper.ValidateModel(request);
-
-            Assert.AreEqual(1, errors.Count);
-            Assert.IsTrue(errors.First().ErrorMessage == "The DateOfBirth field is required.");
-        }
-
-        [Test]
         public void ValidationFailsIfEmailAddressIsNotInValidFormat()
         {
             var request = GetValidRequest();

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -329,7 +329,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 Gender = person.Gender,
                 LastName = person.LastName,
                 NhsNumber = person.NhsNumber.Value,
-                PersonId = person.Id,
+                Id = person.Id,
                 PreferredMethodOfContact = person.PreferredMethodOfContact,
                 Religion = person.Religion,
                 Restricted = person.Restricted,

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdatePersonRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdatePersonRequest.cs
@@ -25,7 +25,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         public string Gender { get; set; }
 
-        [Required]
         public DateTime? DateOfBirth { get; set; }
 
         public DateTime? DateOfDeath { get; set; }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
@@ -6,7 +6,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
 {
     public class GetPersonResponse
     {
-        public long PersonId { get; set; }
+        public long Id { get; set; }
 
         public string Title { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -150,7 +150,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Gender = person.Gender,
                 LastName = person.LastName,
                 NhsNumber = person.NhsNumber,
-                PersonId = person.Id,
+                Id = person.Id,
                 PreferredMethodOfContact = person.PreferredMethodOfContact,
                 Religion = person.Religion,
                 Restricted = person.Restricted,


### PR DESCRIPTION
## Link to JIRA ticket

No jira ticket.

## Describe this PR

### *What is the problem we're trying to solve*

Resident's don't need to be created with a date of birth, new patch endpoint required a date of birth which I have now removed.

Also aligned the response type from patching a resident and creating a resident, turned PersonId into Id. 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy to prod.
