### PR TITLE
Update/restricted flag to add resident

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/AddNewResidentRequestTests.cs
@@ -46,122 +46,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 EmailAddress = _faker.Internet.Email(),
                 PreferredMethodOfContact = "Email", //TOOD: set and test valid values?
                 ContextFlag = "A", //TOOD: set and test valid values,
-                CreatedBy = _faker.Internet.Email()
+                CreatedBy = _faker.Internet.Email(),
+                Restricted = "Y"
             };
         }
-
-        #region Model
-        [Test]
-        public void RequestHasTitle()
-        {
-            Assert.IsNull(_request.Title);
-        }
-
-        [Test]
-        public void RequestHasFirstName()
-        {
-            Assert.IsNull(_request.FirstName);
-        }
-
-        [Test]
-        public void RequestHasLastName()
-        {
-            Assert.IsNull(_request.LastName);
-        }
-
-        [Test]
-        public void RequestHasOtherNames()
-        {
-            Assert.IsNull(_request.OtherNames);
-        }
-
-        [Test]
-        public void RequestHasGender()
-        {
-            Assert.IsNull(_request.Gender);
-        }
-
-        [Test]
-        public void RequestHasDateOfBirth()
-        {
-            Assert.AreEqual(null, _request.DateOfBirth);
-        }
-
-        [Test]
-        public void RequestHasDateOfDeath()
-        {
-            Assert.IsNull(_request.DateOfDeath);
-        }
-
-
-        [Test]
-        public void RequestHasEthnicity()
-        {
-            Assert.IsNull(_request.Ethnicity);
-        }
-
-        [Test]
-        public void RequestHasFirstLanguage()
-        {
-            Assert.IsNull(_request.FirstLanguage);
-        }
-
-        [Test]
-        public void RequestHasReligion()
-        {
-            Assert.IsNull(_request.Religion);
-        }
-
-        [Test]
-        public void RequestHasSexualOrientation()
-        {
-            Assert.IsNull(_request.SexualOrientation);
-        }
-
-        [Test]
-        public void RequestHasNHSNumber()
-        {
-            Assert.IsNull(_request.NhsNumber);
-        }
-
-        [Test]
-        public void RequestHasAddress()
-        {
-            Assert.IsNull(_request.Address);
-        }
-
-        [Test]
-        public void RequestHasPhoneNumbers()
-        {
-            Assert.IsNull(_request.PhoneNumbers);
-        }
-
-        [Test]
-        public void RequestHasEmailAddress()
-        {
-            Assert.IsNull(_request.EmailAddress);
-        }
-
-        [Test]
-        public void RequestHasPreferredMethodOfContact()
-        {
-            Assert.IsNull(_request.PreferredMethodOfContact);
-        }
-
-        [Test]
-        public void RequestHasContextFlag()
-        {
-            Assert.IsNull(_request.ContextFlag);
-        }
-
-        [Test]
-        public void RequestHasCreatedBy()
-        {
-            Assert.IsNull(_request.CreatedBy);
-        }
-        #endregion
-
-        #region Model validation
 
         [Test]
         public void ValidationPassesWhenAllPropertiesAreSetWithValidValues()
@@ -266,6 +154,28 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             Assert.AreEqual(1, errors.Count);
             Assert.IsTrue(errors.First().ErrorMessage == "The CreatedBy field is not a valid e-mail address.");
         }
-        #endregion
+
+        [Test]
+        [TestCase("Y")]
+        [TestCase("N")]
+        public void ModelValidationSucceedsIfRestrictedIsProvidedAndTheValueIsValid(string restricted)
+        {
+            var request = GetValidRequest();
+            request.Restricted = restricted;
+
+            var errors = ValidationHelper.ValidateModel(request);
+            Assert.IsTrue(errors.Count == 0);
+        }
+
+        [Test]
+        public void ModelValidationFailsIfRestrictedIsProvidedButTheValueIsNotEitherYorN()
+        {
+            var request = GetValidRequest();
+            request.Restricted = "X";
+
+            var errors = ValidationHelper.ValidateModel(request);
+            Assert.IsTrue(errors.Count == 1);
+            Assert.IsTrue(errors.Any(x => x.ErrorMessage.Contains("The restricted must be 'Y' or 'N' only")));
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -209,6 +209,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             string otherNameLastTwo = _faker.Name.LastName();
 
             const string gender = "M";
+            const string restricted = "Y";
 
             OtherName otherNameOne = new OtherName() { FirstName = otherNameFirstOne, LastName = otherNameLastOne };
             OtherName otherNameTwo = new OtherName() { FirstName = otherNameFirstTwo, LastName = otherNameLastTwo };
@@ -277,7 +278,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
                 EmailAddress = emailAddress,
                 PreferredMethodOfContact = preferredMethodOfContact,
                 ContextFlag = contextFlag,
-                CreatedBy = createdBy
+                CreatedBy = createdBy,
+                Restricted = restricted
             };
 
             AddNewResidentResponse response = _classUnderTest.AddNewResident(request);
@@ -311,6 +313,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             Assert.AreEqual(emailAddress, person.EmailAddress);
             Assert.AreEqual(preferredMethodOfContact, person.PreferredMethodOfContact);
             Assert.AreEqual(contextFlag, person.AgeContext);
+            Assert.AreEqual(restricted, person.Restricted);
 
             //check that othernames were created with correct values
             Assert.AreEqual(2, person.OtherNames.Count);
@@ -349,89 +352,26 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             Assert.IsTrue(person.PhoneNumbers.All(x => x.CreatedBy == createdBy));
             Assert.IsTrue(person.PhoneNumbers.All(x => x.CreatedBy != null));
 
-            //TODO: create separate test setup for audit
-            //////person audit record
-            //var personRecord = DatabaseContext.Audits.First(x => x.KeyValues.RootElement.GetProperty("Id").GetInt64() == person.Id && x.EntityState == "Added" && x.TableName == "dm_persons");
-            //Assert.IsNotNull(personRecord.KeyValues.RootElement.GetProperty("Id").GetInt64());
+            //TODO: create separate test setup for audit            
+        }
 
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("Title").GetString() == person.Title);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("FirstName").GetString() == person.FirstName);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("LastName").GetString() == person.LastName);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("Gender").GetString() == person.Gender);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("DateOfBirth").GetDateTime() == person.DateOfBirth);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("DateOfDeath").GetDateTime() == person.DateOfDeath);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("Ethnicity").GetString() == person.Ethnicity);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("FirstLanguage").GetString() == person.FirstLanguage);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("Religion").GetString() == person.Religion);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("SexualOrientation").GetString() == person.SexualOrientation);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("NhsNumber").GetInt64() == person.NhsNumber);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("EmailAddress").GetString() == person.EmailAddress);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("PreferredMethodOfContact").GetString() == person.PreferredMethodOfContact);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("AgeContext").GetString() == person.AgeContext);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(personRecord.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
+        [Test]
+        public void CreatePersonRequestWithoutRestrictedValueSetShouldCreateRecordWithRestrictedValueSetToN()
+        {
+            AddNewResidentRequest request = new AddNewResidentRequest()
+            {
+                FirstName = _faker.Person.FirstName,
+                LastName = _faker.Person.LastName,
+                ContextFlag = "A",
+                CreatedBy = _faker.Internet.Email().ToString()
+            };
 
-            ////address record
-            //var addressRecord = DatabaseContext.Audits.First(x => x.TableName == "dm_addresses" && x.NewValues.RootElement.GetProperty("PersonId").GetInt64() == person.Id && x.EntityState == "Added");
-            //Assert.IsNotNull(addressRecord.KeyValues.RootElement.GetProperty("PersonAddressId").GetInt64());
+            var response = _classUnderTest.AddNewResident(request);
 
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("Uprn").GetInt64() == person.Addresses.First().Uprn);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("EndDate").GetString() == null);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("PersonId").GetInt64() == person.Addresses.First().PersonId);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("PostCode").GetString() == person.Addresses.First().PostCode);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(personRecord.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("AddressLines").GetString() == person.Addresses.First().AddressLines);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedAt").GetString() == null);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedBy").GetString() == null);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("IsDisplayAddress").GetString() == person.Addresses.First().IsDisplayAddress);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("DataIsFromDmPersonsBackup").GetString() == person.Addresses.First().DataIsFromDmPersonsBackup);
+            Person person = DatabaseContext.Persons.First(x => x.Id == response.Id);
 
-            ////other names
-            //var otherNamesRecordOne = DatabaseContext.Audits.First(x => x.TableName == "sccv_person_other_name" && x.NewValues.RootElement.GetProperty("FirstName").GetString() == otherNameFirstOne && x.EntityState == "Added");
-            //Assert.IsNotNull(otherNamesRecordOne.KeyValues.RootElement.GetProperty("Id").GetInt64());
-
-            //Assert.AreEqual(otherNamesRecordOne.NewValues.RootElement.GetProperty("FirstName").GetString(), otherNameFirstOne);
-            //Assert.AreEqual(otherNamesRecordOne.NewValues.RootElement.GetProperty("LastName").GetString(), otherNameLastOne);
-            //Assert.AreEqual(otherNamesRecordOne.NewValues.RootElement.GetProperty("PersonId").GetInt64(), person.Id);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(personRecord.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedAt").GetString() == null);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedBy").GetString() == null);
-
-            //var otherNamesRecordTwo = DatabaseContext.Audits.First(x => x.TableName == "sccv_person_other_name" && x.NewValues.RootElement.GetProperty("FirstName").GetString() == otherNameFirstTwo && x.EntityState == "Added");
-            //Assert.IsNotNull(otherNamesRecordTwo.KeyValues.RootElement.GetProperty("Id").GetInt64());
-
-            //Assert.AreEqual(otherNamesRecordTwo.NewValues.RootElement.GetProperty("FirstName").GetString(), otherNameFirstTwo);
-            //Assert.AreEqual(otherNamesRecordTwo.NewValues.RootElement.GetProperty("LastName").GetString(), otherNameLastTwo);
-            //Assert.AreEqual(otherNamesRecordTwo.NewValues.RootElement.GetProperty("PersonId").GetInt64(), person.Id);
-            //Assert.IsTrue(personRecord.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(personRecord.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedAt").GetString() == null);
-            //Assert.IsTrue(addressRecord.NewValues.RootElement.GetProperty("LastModifiedBy").GetString() == null);
-
-            ////phone numbers
-            //var phoneNumberRecordOne = DatabaseContext.Audits.First(x => x.TableName == "dm_telephone_numbers" && x.NewValues.RootElement.GetProperty("Number").GetString() == phoneNumberOne.ToString() && x.EntityState == "Added");
-
-            //Assert.AreEqual(phoneNumberRecordOne.NewValues.RootElement.GetProperty("Type").GetString(), phoneNumberTypeOne);
-            //Assert.AreEqual(phoneNumberRecordOne.NewValues.RootElement.GetProperty("Number").GetString(), phoneNumberOne.ToString());
-            //Assert.AreEqual(phoneNumberRecordOne.NewValues.RootElement.GetProperty("PersonId").GetInt64(), person.Id);
-
-            //Assert.IsTrue(phoneNumberRecordOne.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(phoneNumberRecordOne.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
-            //Assert.IsTrue(phoneNumberRecordOne.NewValues.RootElement.GetProperty("LastModifiedAt").GetString() == null);
-            //Assert.IsTrue(phoneNumberRecordOne.NewValues.RootElement.GetProperty("LastModifiedBy").GetString() == null);
-
-            //var phoneNumberRecordTwo = DatabaseContext.Audits.First(x => x.TableName == "dm_telephone_numbers" && x.NewValues.RootElement.GetProperty("Number").GetString() == phoneNumberTwo.ToString() && x.EntityState == "Added");
-
-            //Assert.AreEqual(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("Type").GetString(), phoneNumberTypeTwo);
-            //Assert.AreEqual(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("Number").GetString(), phoneNumberTwo.ToString());
-            //Assert.AreEqual(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("PersonId").GetInt64(), person.Id);
-
-            //Assert.IsTrue(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("CreatedBy").GetString() == person.CreatedBy);
-            //Assert.IsNotNull(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("CreatedAt").GetDateTime());
-            //Assert.IsTrue(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("LastModifiedAt").GetString() == null);
-            //Assert.IsTrue(phoneNumberRecordTwo.NewValues.RootElement.GetProperty("LastModifiedBy").GetString() == null);
+            response.Should().NotBeNull();
+            person.Restricted.Should().Be("N");
         }
 
         #region Warning Notes

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/AddNewResidentRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/AddNewResidentRequest.cs
@@ -61,5 +61,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [Required]
         [EmailAddress]
         public string CreatedBy { get; set; }
+
+        [MaxLength(1)]
+        [RegularExpression("(?i:^Y|N)", ErrorMessage = "The restricted must be 'Y' or 'N' only.")]
+        public string Restricted { get; set; } = "N";
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -348,7 +348,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 //calculated and additional values
                 FullName = $"{request.FirstName} {request.LastName}",
                 DataIsFromDmPersonsBackup = "N",
-                CreatedBy = request.CreatedBy
+                CreatedBy = request.CreatedBy,
+                Restricted = request.Restricted 
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -349,7 +349,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 FullName = $"{request.FirstName} {request.LastName}",
                 DataIsFromDmPersonsBackup = "N",
                 CreatedBy = request.CreatedBy,
-                Restricted = request.Restricted 
+                Restricted = request.Restricted
             };
         }
 


### PR DESCRIPTION
## Link to JIRA ticket
This is part of the endpoints alignment for create/edit/view person feature


## Describe this PR

Add restricted property to AddNewResidentRequest object. This will enable front end to use the same form for create and edit person pages.

### *What changes have we introduced*

Added a new property to the request. It's not mandatory and will be set to "N" by default, so this can be deployed whether the front end provides the value or not.

I've also removed some commented out code and obsolete boundary object property tests. 

#### _Checklist_

- [x ] Added tests to cover all new production code

### *Follow up actions after merging PR*

Inform front end devs that the restricted value can now be provided when creating new person records.
