### PR TITLE
Troubleshoot POST/GET warning note mismatch

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Domain/WarningNoteTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Domain/WarningNoteTests.cs
@@ -16,87 +16,42 @@ namespace SocialCareCaseViewerApi.Tests.V1.Domain
         }
 
         [Test]
-        public void WarningNoteHasId()
+        public void WarningNoteContainsTheRelevantInformationAboutItself()
         {
+            // Unique ID
             _classUnderTest.Id.Should().Be(0);
-        }
 
-        [Test]
-        public void WarningNoteHasPersonId()
-        {
+            // Current Status
+            _classUnderTest.Status.Should().BeNull();
+
+            // Associated with a specific resident
             _classUnderTest.PersonId.Should().Be(0);
-        }
 
-        [Test]
-        public void WarningNoteHasStartDate()
-        {
-            _classUnderTest.StartDate.Should().Be(null);
-        }
+            // Start and End Dates
+            _classUnderTest.StartDate.Should().BeNull();
+            _classUnderTest.EndDate.Should().BeNull();
 
-        [Test]
-        public void WarningNoteHasEndDate()
-        {
-            _classUnderTest.EndDate.Should().Be(null);
-        }
+            // Review Details
+            _classUnderTest.ReviewDate.Should().BeNull();
+            _classUnderTest.NextReviewDate.Should().BeNull();
 
-        [Test]
-        public void WarningNoteHasIndividualNotified()
-        {
-            _classUnderTest.DisclosedWithIndividual.Should().Be(false);
-        }
+            // Creator of the Note
+            _classUnderTest.CreatedBy.Should().BeNull();
 
-        [Test]
-        public void WarningNoteHasNotificationDetails()
-        {
-            _classUnderTest.DisclosedDetails.Should().Be(null);
-        }
+            // Details about notifying an individual
+            _classUnderTest.DisclosedWithIndividual.Should().BeFalse();
+            _classUnderTest.DisclosedDetails.Should().BeNull();
+            _classUnderTest.DisclosedDate.Should().BeNull();
+            _classUnderTest.DisclosedHow.Should().BeNull();
 
-        [Test]
-        public void WarningNoteHasReviewDetails()
-        {
-            _classUnderTest.Notes.Should().Be(null);
-        }
+            // Warning Note Content
+            _classUnderTest.Notes.Should().BeNull();
+            _classUnderTest.NoteType.Should().BeNull();
+            _classUnderTest.WarningNarrative.Should().BeNull();
 
-        [Test]
-        public void WarningNoteHasNoteType()
-        {
-            _classUnderTest.NoteType.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasStatus()
-        {
-            _classUnderTest.Status.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasDateInformed()
-        {
-            _classUnderTest.DisclosedDate.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasHowInformed()
-        {
-            _classUnderTest.DisclosedHow.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasWarningNarrative()
-        {
-            _classUnderTest.WarningNarrative.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasManagersName()
-        {
-            _classUnderTest.ManagerName.Should().Be(null);
-        }
-
-        [Test]
-        public void WarningNoteHasDateManagerInformed()
-        {
-            _classUnderTest.DiscussedWithManagerDate.Should().Be(null);
+            // Informing a Manager
+            _classUnderTest.ManagerName.Should().BeNull();
+            _classUnderTest.DiscussedWithManagerDate.Should().BeNull();
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -144,10 +144,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         public void CanMapWarningNoteFromDatabaseEntityToDomainObject()
         {
             long number = _faker.Random.Number();
-            DateTime dt = DateTime.Now;
-            string text = _faker.Random.String();
+            var dt = DateTime.Now;
+            var text = _faker.Random.String();
 
-            var dbWarningNote = new dbWarningNote()
+            var dbWarningNote = new dbWarningNote
             {
                 Id = number,
                 PersonId = number,
@@ -156,6 +156,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 DisclosedWithIndividual = true,
                 DisclosedDetails = text,
                 Notes = text,
+                ReviewDate = dt,
                 NextReviewDate = dt,
                 NoteType = text,
                 Status = text,
@@ -163,10 +164,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 DisclosedHow = text,
                 WarningNarrative = text,
                 ManagerName = text,
-                DiscussedWithManagerDate = dt
+                DiscussedWithManagerDate = dt,
+                CreatedBy = text
             };
 
-            var expectedResponse = new WarningNote()
+            var expectedResponse = new WarningNote
             {
                 Id = number,
                 PersonId = number,
@@ -175,6 +177,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 DisclosedWithIndividual = true,
                 DisclosedDetails = text,
                 Notes = text,
+                ReviewDate = dt,
                 NextReviewDate = dt,
                 NoteType = text,
                 Status = text,
@@ -182,7 +185,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 DisclosedHow = text,
                 WarningNarrative = text,
                 ManagerName = text,
-                DiscussedWithManagerDate = dt
+                DiscussedWithManagerDate = dt,
+                CreatedBy = text
             };
 
             var response = dbWarningNote.ToDomain();

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -196,6 +196,59 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void CanMapPostWarningNoteRequestToDatabaseObject()
+        {
+            long number = _faker.Random.Number();
+            var dt = DateTime.Now;
+            var text = _faker.Random.String();
+
+            var request = new PostWarningNoteRequest
+            {
+                PersonId = number,
+                StartDate = dt,
+                EndDate = dt,
+                DisclosedWithIndividual = true,
+                DisclosedDetails = text,
+                Notes = text,
+                ReviewDate = dt,
+                NextReviewDate = dt,
+                NoteType = text,
+                Status = text,
+                DisclosedDate = dt,
+                DisclosedHow = text,
+                WarningNarrative = text,
+                ManagerName = text,
+                DiscussedWithManagerDate = dt,
+                CreatedBy = text
+            };
+
+            var expectedResponse = new dbWarningNote
+            {
+                PersonId = number,
+                StartDate = dt,
+                EndDate = dt,
+                DisclosedWithIndividual = true,
+                DisclosedDetails = text,
+                Notes = text,
+                ReviewDate = dt,
+                NextReviewDate = dt,
+                NoteType = text,
+                Status = "open",
+                DisclosedDate = dt,
+                DisclosedHow = text,
+                WarningNarrative = text,
+                ManagerName = text,
+                DiscussedWithManagerDate = dt,
+                CreatedBy = text
+            };
+
+            var response = request.ToDatabaseEntity();
+
+            response.Should().BeOfType<dbWarningNote>();
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
         public void CanMapPhoneNumberFromDatabaseEntityToDomainObject()
         {
             dbPhoneNumber phoneNumber = DatabaseGatewayHelper.CreatePhoneNumberEntity(_faker.Random.Long());

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -285,7 +285,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.DisclosedDetails, f => f.Random.String2(1, 1000))
                 .RuleFor(w => w.Notes, f => f.Random.String2(1, 1000))
                 .RuleFor(w => w.NoteType, f => f.Random.String2(1, 50))
-                .RuleFor(w => w.Status, f => status ?? f.Random.String2(1, 50))
+                .RuleFor(w => w.Status, f => status ?? "open")
                 .RuleFor(w => w.DisclosedDate, f => f.Date.Recent())
                 .RuleFor(w => w.DisclosedHow, f => f.Random.String2(1, 50))
                 .RuleFor(w => w.WarningNarrative, f => f.Random.String2(1, 1000))

--- a/SocialCareCaseViewerApi/V1/Domain/WarningNote.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/WarningNote.cs
@@ -8,11 +8,11 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public long PersonId { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
-        public Boolean DisclosedWithIndividual { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
         public string DisclosedDetails { get; set; }
         public string Notes { get; set; }
+        public DateTime? ReviewDate { get; set; }
         public DateTime? NextReviewDate { get; set; }
-
         public string NoteType { get; set; }
         public string Status { get; set; }
         public DateTime? DisclosedDate { get; set; }
@@ -20,5 +20,6 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string WarningNarrative { get; set; }
         public string ManagerName { get; set; }
         public DateTime? DiscussedWithManagerDate { get; set; }
+        public string CreatedBy { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -201,6 +201,29 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CaseFormData = coreProps.ToString()
             };
         }
+
+        public static dbWarningNote ToDatabaseEntity(this PostWarningNoteRequest request)
+        {
+            return new dbWarningNote
+            {
+                PersonId = request.PersonId,
+                StartDate = request.StartDate,
+                EndDate = request.EndDate,
+                ReviewDate = request.ReviewDate,
+                NextReviewDate = request.NextReviewDate,
+                DisclosedWithIndividual = request.DisclosedWithIndividual,
+                DisclosedDetails = request.DisclosedDetails,
+                Notes = request.Notes,
+                NoteType = request.NoteType,
+                Status = "open",
+                DisclosedDate = request.DisclosedDate,
+                DisclosedHow = request.DisclosedHow,
+                WarningNarrative = request.WarningNarrative,
+                ManagerName = request.ManagerName,
+                DiscussedWithManagerDate = request.DiscussedWithManagerDate,
+                CreatedBy = request.CreatedBy
+            };
+        }
         #endregion
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -106,6 +106,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 DisclosedWithIndividual = dbWarningNote.DisclosedWithIndividual,
                 DisclosedDetails = dbWarningNote.DisclosedDetails,
                 Notes = dbWarningNote.Notes,
+                ReviewDate = dbWarningNote.ReviewDate,
                 NextReviewDate = dbWarningNote.NextReviewDate,
                 NoteType = dbWarningNote.NoteType,
                 Status = dbWarningNote.Status,
@@ -113,7 +114,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 DisclosedHow = dbWarningNote.DisclosedHow,
                 WarningNarrative = dbWarningNote.WarningNarrative,
                 ManagerName = dbWarningNote.ManagerName,
-                DiscussedWithManagerDate = dbWarningNote.DiscussedWithManagerDate
+                DiscussedWithManagerDate = dbWarningNote.DiscussedWithManagerDate,
+                CreatedBy = dbWarningNote.CreatedBy
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -576,47 +576,28 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         #region Warning Notes
         public PostWarningNoteResponse PostWarningNote(PostWarningNoteRequest request)
         {
-            Person person = _databaseContext.Persons.FirstOrDefault(x => x.Id == request.PersonId);
+            var person = _databaseContext.Persons.FirstOrDefault(x => x.Id == request.PersonId);
 
             if (person == null)
             {
                 throw new PostWarningNoteException($"Person with given id ({request.PersonId}) not found");
             }
 
-            //TODO: Extract request to domain process to EntityFactory
-            WarningNote warningNote = new WarningNote
-            {
-                PersonId = request.PersonId,
-                StartDate = request.StartDate,
-                EndDate = request.EndDate,
-                ReviewDate = request.ReviewDate,
-                NextReviewDate = request.NextReviewDate,
-                DisclosedWithIndividual = request.DisclosedWithIndividual,
-                DisclosedDetails = request.DisclosedDetails,
-                Notes = request.Notes,
-                NoteType = request.NoteType,
-                Status = "open",
-                DisclosedDate = request.DisclosedDate,
-                DisclosedHow = request.DisclosedHow,
-                WarningNarrative = request.WarningNarrative,
-                ManagerName = request.ManagerName,
-                DiscussedWithManagerDate = request.DiscussedWithManagerDate,
-                CreatedBy = request.CreatedBy
-            };
+            var warningNote = request.ToDatabaseEntity();
 
             _databaseContext.WarningNotes.Add(warningNote);
             _databaseContext.SaveChanges();
 
-            PostWarningNoteResponse response = new PostWarningNoteResponse()
+            var response = new PostWarningNoteResponse
             {
                 WarningNoteId = warningNote.Id
             };
 
             // try
             // {
-            DateTime dt = DateTime.Now;
+            var dt = DateTime.Now;
 
-            WarningNoteCaseNote note = new WarningNoteCaseNote()
+            var note = new WarningNoteCaseNote
             {
                 FirstName = person.FirstName,
                 LastName = person.LastName,
@@ -628,7 +609,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 WarningNoteId = warningNote.Id.ToString()
             };
 
-            CaseNotesDocument caseNotesDocument = new CaseNotesDocument()
+            var caseNotesDocument = new CaseNotesDocument
             {
                 CaseFormData = JsonConvert.SerializeObject(note)
             };

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -584,11 +584,13 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             }
 
             //TODO: Extract request to domain process to EntityFactory
-            WarningNote warningNote = new WarningNote()
+            WarningNote warningNote = new WarningNote
             {
                 PersonId = request.PersonId,
                 StartDate = request.StartDate,
                 EndDate = request.EndDate,
+                ReviewDate = request.ReviewDate,
+                NextReviewDate = request.NextReviewDate,
                 DisclosedWithIndividual = request.DisclosedWithIndividual,
                 DisclosedDetails = request.DisclosedDetails,
                 Notes = request.Notes,


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*
While testing the current GET all warning notes endpoint in staging, we identified that some of the attributes in the POST request were missing when the warning note was retrieved using the GET.

### *What changes have we introduced*

- Adds the missing attributes to the domain object that retrieved warning note data is mapped to (see 0178624)
- Refactors the domain object test and checks that the missing attributes are returned within the object.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [X] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test bug is fixed in Staging