### PR TITLE
Removes status from the POST request body for creating a warning note

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PostWarningNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PostWarningNoteRequestTests.cs
@@ -73,12 +73,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
-        public void RequestHasStatus()
-        {
-            _classUnderTest.Status.Should().Be(null);
-        }
-
-        [Test]
         public void RequestHasDisclosedDate()
         {
             _classUnderTest.DisclosedDate.Should().Be(null);
@@ -204,27 +198,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
-        public void ValidationFailsIfStatusIsLongerThan50Characters()
-        {
-            var request = GetValidPostWarningNoteRequest();
-            request.Status = new string('a', 51);
-            var error = ValidationHelper.ValidateModel(request);
-
-            error.Count.Should().Be(1);
-            error.Should().Contain(x => x.ErrorMessage.Contains("Character limit of 50 exceeded"));
-        }
-
-        [Test]
-        public void ValidationPassesIfStatusIsNull()
-        {
-            var request = GetValidPostWarningNoteRequest();
-            request.Status = null;
-            var error = ValidationHelper.ValidateModel(request);
-
-            error.Count.Should().Be(0);
-        }
-
-        [Test]
         public void ValidationFailsIfDisclosedHowIsLongerThan50Characters()
         {
             var request = GetValidPostWarningNoteRequest();
@@ -314,7 +287,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 
         private PostWarningNoteRequest GetValidPostWarningNoteRequest()
         {
-            return new PostWarningNoteRequest()
+            return new PostWarningNoteRequest
             {
                 PersonId = _fixture.Create<long>(),
                 StartDate = DateTime.Now,
@@ -324,7 +297,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 DisclosedDetails = _fixture.Create<string>(),
                 Notes = _fixture.Create<string>(),
                 NoteType = _fixture.Create<string>(),
-                Status = _fixture.Create<string>(),
                 DisclosedDate = DateTime.Now,
                 DisclosedHow = _fixture.Create<string>(),
                 WarningNarrative = _fixture.Create<string>(),

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -214,7 +214,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 ReviewDate = dt,
                 NextReviewDate = dt,
                 NoteType = text,
-                Status = text,
                 DisclosedDate = dt,
                 DisclosedHow = text,
                 WarningNarrative = text,

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PostWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PostWarningNoteRequest.cs
@@ -32,9 +32,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [StringLength(50, ErrorMessage = "Character limit of 50 exceeded")]
         public string NoteType { get; set; }
 
-        [StringLength(50, ErrorMessage = "Character limit of 50 exceeded")]
-        public string Status { get; set; }
-
         public DateTime? DisclosedDate { get; set; }
 
         [StringLength(50, ErrorMessage = "Character limit of 50 exceeded")]


### PR DESCRIPTION
When we first create a warning note, we want to set the status to "open".

Since we set this value upon the creation of a new warning note,
this removes the value as a request parameter for POST.