### PR TITLE
Return 200 and an empty list if no warning notes are found for a person

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -699,19 +699,21 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void GetWarningNoteReturns404IfDocumentNotFound()
+        public void GetWarningNoteWouldReturns200IfNoWarningNotesAreFoundForThePerson()
         {
             var testPersonId = _fixture.Create<long>();
 
+            var emptyWarningNotesResponse = new ListWarningNotesResponse();
+
             _mockWarningNoteUseCase
                 .Setup(x => x.ExecuteGet(It.IsAny<long>()))
-                .Throws(new DocumentNotFoundException("Document Not Found"));
+                .Returns(emptyWarningNotesResponse);
 
             var response = _classUnderTest.ListWarningNotes(testPersonId) as ObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(404);
-            response.Value.Should().Be("Document Not Found");
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(emptyWarningNotesResponse);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -552,22 +552,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetWarningNotesReturnsAnExceptionIfTheWarningNoteDoesNotExist()
+        public void GetWarningNotesReturnsANullIfNoWarningNotesExist()
         {
-            var testPersonId = _faker.Random.Int();
-            var differentPersonId = _faker.Random.Int();
+            var response = _classUnderTest.GetWarningNotes(123);
 
-            var warningNote = new WarningNote
-            {
-                PersonId = testPersonId
-            };
-            DatabaseContext.WarningNotes.Add(warningNote);
-            DatabaseContext.SaveChanges();
-
-            Action act = () => _classUnderTest.GetWarningNotes(differentPersonId);
-
-            act.Should().Throw<DocumentNotFoundException>()
-                .WithMessage($"No warning notes found relating to person id {differentPersonId}");
+            response.Should().BeNull();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
@@ -130,6 +130,22 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ExecuteGetReturnsEmptyResponseIfNoWarningNoteIsReturned()
+        {
+            var testPersonId = _fixture.Create<long>();
+
+            var expectedResponse = new ListWarningNotesResponse();
+
+            _mockDatabaseGateway.Setup(
+                    x => x.GetWarningNotes(It.IsAny<long>()))
+                .Returns((IEnumerable<dbWarningNote>) null);
+
+            var response = _classUnderTest.ExecuteGet(testPersonId);
+
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
         public void ExecutePatchCallsTheDatabaseGatewayOnce()
         {
             var request = _fixture.Create<PatchWarningNoteRequest>();

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -435,20 +435,13 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// Get all warning notes created for a specific person
         /// </summary>
         /// <response code="200">Success. Returns warning notes related to the specified ID</response>
-        /// <response code="404">No warning notes found for the specified ID</response>
+        /// <response code="500">Server error</response>
         [ProducesResponseType(typeof(ListWarningNotesResponse), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("residents/{personId}/warningNotes")]
         public IActionResult ListWarningNotes(long personId)
         {
-            try
-            {
-                return Ok(_warningNoteUseCase.ExecuteGet(personId));
-            }
-            catch (DocumentNotFoundException e)
-            {
-                return NotFound(e.Message);
-            }
+            return Ok(_warningNoteUseCase.ExecuteGet(personId));
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -632,7 +632,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var warningNotes = _databaseContext.WarningNotes
                 .Where(x => x.PersonId == personId);
 
-            if (warningNotes.FirstOrDefault() == null) throw new DocumentNotFoundException($"No warning notes found relating to person id {personId}");
+            if (warningNotes.FirstOrDefault() == null) return null;
 
             return warningNotes;
         }

--- a/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/WarningNoteUseCase.cs
@@ -27,7 +27,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             return new ListWarningNotesResponse
             {
-                WarningNotes = warningNotes.Select(x => x.ToDomain()).ToList()
+                WarningNotes = warningNotes?.Select(x => x.ToDomain()).ToList()
             };
         }
 


### PR DESCRIPTION
## Describe this PR

Previously, we were raising an exception when no warning notes were found for a person.
This changes the functionality so that if there are no warning notes for a person, this will return the response as an empty list with a status code of 200.

### *What changes have we introduced*

When no warning notes have been found for a specific person, we return an empty response instead of raising an exception.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test in Staging