### PR TITLE
Remove leading '/' from the GET warning note by Id route

### DIFF
--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -451,7 +451,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="404">No warning note found for the specified ID</response>
         [ProducesResponseType(typeof(WarningNoteResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("/warningNotes/{warningNoteId}")]
+        [Route("warningnotes/{warningNoteId}")]
         public IActionResult GetWarningNoteById(long warningNoteId)
         {
             try


### PR DESCRIPTION
Currently troubleshooting why the endpoint returned a 404 when called, and one of the errors in the lambda logs states: "Request does not contain domain name information but is derived from APIGatewayProxyFunction."

From inspecting the code, we found a leading '/' in the route name, and for the other routes, we don't have a leading '/'.

This also changes the "warningNotes" to "warningnotes" in the path.