### PR TITLE
resolve new worker team id being same as existing worker team

### DIFF
--- a/SocialCareCaseViewerApi/V1/Infrastructure/WorkerTeam.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/WorkerTeam.cs
@@ -8,6 +8,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
     {
         [Key]
         [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
 


### PR DESCRIPTION
## Link to JIRA ticket

No ticket.

## Describe this PR

### *What is the problem we're trying to solve*

WorkerTeams objects were being created with an ID that already existed in the database causing exceptions.

### *What changes have we introduced*

Added an attribute that should ensure the ID created for a WorkerTeam is unique. 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy to prod
