### PR TITLE
Handle creating worker with duplicate email address

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -214,11 +214,25 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
                 .WithMessage($"Team with Name {createWorkerRequest.Teams[0].Name} and ID {createWorkerRequest.Teams[0].Id} not found");
         }
 
+        [Test]
+        public void CreateWorkerWithDuplicateEmailThrowsPostWorkerException()
+        {
+            var (createWorkerRequest, _) = CreateWorkerAndAddToDatabase(true);
+            var (createWorkerRequestDuplicate, _) = CreateWorkerAndAddToDatabase(true, createWorkerRequest.EmailAddress);
+
+            _classUnderTest.CreateWorker(createWorkerRequest);
+            Action act = () => _classUnderTest.CreateWorker(createWorkerRequestDuplicate);
+
+            act.Should().Throw<PostWorkerException>()
+                .WithMessage($"Worker with Email {createWorkerRequestDuplicate.EmailAddress} already exists");
+        }
+
         private (CreateWorkerRequest, List<Team>) CreateWorkerAndAddToDatabase(
-            bool addTeamsToDatabase = true
+            bool addTeamsToDatabase = true,
+            string workerEmail = null
             )
         {
-            var createWorkerRequest = TestHelpers.CreateWorkerRequest();
+            var createWorkerRequest = TestHelpers.CreateWorkerRequest(email: workerEmail);
 
             var createdTeams = new List<Team>();
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -441,6 +441,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public Worker CreateWorker(CreateWorkerRequest createWorkerRequest)
         {
+            if (GetWorkerByEmail(createWorkerRequest.EmailAddress) != null)
+            {
+                throw new PostWorkerException($"Worker with Email {createWorkerRequest.EmailAddress} already exists");
+            }
+
             var worker = new Worker
             {
                 Role = createWorkerRequest.Role,


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/jira/software/projects/SCS/boards/51?selectedIssue=SCS-655)

## Describe this PR

### *What is the problem we're trying to solve*

Previously a duplicate email would return 500 server error as the schema does not allow for duplicate emails in our worker table.

Much nicer to handle this ourselves, return appropriate error response and message.

### *What changes have we introduced*

Added a check to see if a worker exists with the requested email, if so return exception.

Added appropriate test.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test all of creating a worker integrates with frontend and deploy to prod.
