### PR TITLE
Return an empty list if no warning notes for a person is found

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -673,7 +673,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         {
             var testPersonId = _fixture.Create<long>();
 
-            var emptyWarningNotesResponse = new ListWarningNotesResponse();
+            var emptyWarningNotesResponse = new ListWarningNotesResponse
+            {
+                WarningNotes = new List<WarningNote>()
+            };
 
             _mockWarningNoteUseCase
                 .Setup(x => x.ExecuteGet(It.IsAny<long>()))

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -715,11 +715,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetWarningNotesReturnsANullIfNoWarningNotesExist()
+        public void GetWarningNotesReturnsAnEmptyListIfNoWarningNotesExist()
         {
             var response = _classUnderTest.GetWarningNotes(123);
 
-            response.Should().BeNull();
+            response.Should().BeEmpty();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/WarningNoteUseCaseTests.cs
@@ -134,15 +134,21 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var testPersonId = _fixture.Create<long>();
 
-            var expectedResponse = new ListWarningNotesResponse();
+            var expectedResponse = new ListWarningNotesResponse
+            {
+                WarningNotes = new List<WarningNote>()
+            };
+
+            var emptyList = Enumerable.Empty<dbWarningNote>();
 
             _mockDatabaseGateway.Setup(
                     x => x.GetWarningNotes(It.IsAny<long>()))
-                .Returns((IEnumerable<dbWarningNote>) null);
+                .Returns(emptyList);
 
             var response = _classUnderTest.ExecuteGet(testPersonId);
 
             response.Should().BeEquivalentTo(expectedResponse);
+            response.WarningNotes.Should().BeEmpty();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -706,12 +706,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public IEnumerable<WarningNote> GetWarningNotes(long personId)
         {
-            var warningNotes = _databaseContext.WarningNotes
+            return _databaseContext.WarningNotes
                 .Where(x => x.PersonId == personId);
-
-            if (warningNotes.FirstOrDefault() == null) return null;
-
-            return warningNotes;
         }
 
         public Domain.WarningNote GetWarningNoteById(long warningNoteId)


### PR DESCRIPTION
## Describe this PR

From testing the feature on staging, if a person has no warning notes, an `Oops, an error occurred` message is displayed. 
From checking the response from the backend, we found that if a person has no warning notes, the response was returning `warningNotes: null` instead of `warningNotes: [ ]`.

### *What changes have we introduced*

If a person has no warning notes, the gateway would return an empty list rather than null.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test that the above error message does not pop up if a person has no warning notes.
