### PR TITLE
Endpoint to create team

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateTeamRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateTeamRequestTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Bogus;
 using FluentAssertions;
@@ -36,11 +35,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             {
                 var validationResponse = validator.Validate(request);
 
-                if (validationResponse == null)
-                {
-                    throw new NullReferenceException();
-                }
-
                 validationResponse.Should().NotBeNull();
                 validationResponse.IsValid.Should().Be(false);
                 validationResponse.ToString().Should().Be(expectedErrorMessage);
@@ -54,11 +48,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             var validator = new CreateTeamRequestValidator();
 
             var validationResponse = validator.Validate(createTeamRequest);
-
-            if (validationResponse == null)
-            {
-                throw new NullReferenceException();
-            }
 
             validationResponse.Should().NotBeNull();
             validationResponse.IsValid.Should().Be(true);

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateTeamRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreateTeamRequestTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using Bogus;
+using FluentAssertions;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
+{
+    [TestFixture]
+    public class CreateTeamRequestTests
+    {
+        private Faker _faker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _faker = new Faker();
+        }
+
+        [Test]
+        public void CreateTeamValidationReturnsErrorsWithInvalidProperties()
+        {
+            var badCreateTeamRequests = new List<(CreateTeamRequest, string)>
+            {
+                (TestHelpers.CreateTeamRequest(name: ""), "Team name must be provided"),
+                (TestHelpers.CreateTeamRequest(name: _faker.Random.String2(201)), "Team name has a maximum length of 200 characters"),
+                (TestHelpers.CreateTeamRequest(context: ""), "Context flag must be provided\nContext flag must be 'A' or 'C'"),
+                (TestHelpers.CreateTeamRequest(context: "B"), "Context flag must be 'A' or 'C'"),
+            };
+
+            var validator = new CreateTeamRequestValidator();
+
+            foreach (var (request, expectedErrorMessage) in badCreateTeamRequests)
+            {
+                var validationResponse = validator.Validate(request);
+
+                if (validationResponse == null)
+                {
+                    throw new NullReferenceException();
+                }
+
+                validationResponse.Should().NotBeNull();
+                validationResponse.IsValid.Should().Be(false);
+                validationResponse.ToString().Should().Be(expectedErrorMessage);
+            }
+        }
+
+        [Test]
+        public void ValidCreateTeamRequestReturnsNoErrorsOnValidation()
+        {
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+            var validator = new CreateTeamRequestValidator();
+
+            var validationResponse = validator.Validate(createTeamRequest);
+
+            if (validationResponse == null)
+            {
+                throw new NullReferenceException();
+            }
+
+            validationResponse.Should().NotBeNull();
+            validationResponse.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
@@ -32,6 +32,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 
             var response = _teamController.CreateTeam(createTeamRequest) as ObjectResult;
 
+            _teamsUseCase.Verify(x => x.ExecutePost(createTeamRequest), Times.Once);
             if (response == null)
             {
                 throw new NullReferenceException();

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
@@ -65,7 +65,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             const string errorMessage = "Failed to create team";
             var createTeamRequest = TestHelpers.CreateTeamRequest();
             _teamsUseCase.Setup(x => x.ExecutePost(createTeamRequest))
-                .Throws(new PostWorkerException(errorMessage));
+                .Throws(new PostTeamException(errorMessage));
 
             var response = _teamController.CreateTeam(createTeamRequest) as ObjectResult;
 

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
@@ -1,0 +1,81 @@
+using System;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Controllers;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class TeamsControllerTests
+    {
+        private TeamController _teamController;
+        private Mock<ITeamsUseCase> _teamsUseCase;
+
+        [SetUp]
+        public void Setup()
+        {
+            _teamsUseCase = new Mock<ITeamsUseCase>();
+            _teamController = new TeamController(_teamsUseCase.Object);
+        }
+
+        [Test]
+        public void CreateTeamReturns201StatusAndTeamWhenSuccessful()
+        {
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+            var team = TestHelpers.CreateTeamResponse(name: createTeamRequest.Name, context: createTeamRequest.Context);
+            _teamsUseCase.Setup(x => x.ExecutePost(createTeamRequest)).Returns(team);
+
+            var response = _teamController.CreateTeam(createTeamRequest) as ObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(201);
+            response.Value.Should().BeEquivalentTo(team);
+        }
+
+        [Test]
+        public void CreateTeamReturns400WhenValidationResultsIsNotValid()
+        {
+
+            var createTeamRequest = TestHelpers.CreateTeamRequest(name: "");
+
+            var response = _teamController.CreateTeam(createTeamRequest) as BadRequestObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(400);
+            response.Value.Should().Be("Team name must be provided");
+        }
+
+        [Test]
+        public void CreateTeamReturns422StatusWhenPostTeamExceptionThrown()
+        {
+            const string errorMessage = "Failed to create team";
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+            _teamsUseCase.Setup(x => x.ExecutePost(createTeamRequest))
+                .Throws(new PostWorkerException(errorMessage));
+
+            var response = _teamController.CreateTeam(createTeamRequest) as ObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(422);
+            response.Value.Should().Be(errorMessage);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -136,7 +136,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapTeamFromInfrastrcutureToDomain()
+        public void CanMapTeamFromInfrastructureToDomain()
         {
             var id = _faker.Random.Number();
             var name = _faker.Name.ToString();
@@ -149,13 +149,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 Context = context
             };
 
-            var exptectedResponse = new Team()
+            var expectedResponse = new Team()
             {
                 Id = id,
-                Name = name
+                Name = name,
+                Context = context
             };
 
-            dbTeam.ToDomain().Should().BeEquivalentTo(exptectedResponse);
+            dbTeam.ToDomain().Should().BeEquivalentTo(expectedResponse);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -420,7 +420,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var expectedResponse = new TeamResponse
             {
-                Id = domainTeam.Id, Context = domainTeam.Context, Name = domainTeam.Name
+                Id = domainTeam.Id,
+                Context = domainTeam.Context,
+                Name = domainTeam.Name
             };
 
             domainTeam.ToResponse().Should().BeEquivalentTo(expectedResponse);

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -412,5 +412,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             result.Should().BeEquivalentTo(expectedResponse);
         }
+
+        [Test]
+        public void CanMapTeamToTeamResponse()
+        {
+            var domainTeam = TestHelpers.CreateTeam().ToDomain();
+
+            var expectedResponse = new TeamResponse
+            {
+                Id = domainTeam.Id, Context = domainTeam.Context, Name = domainTeam.Name
+            };
+
+            domainTeam.ToResponse().Should().BeEquivalentTo(expectedResponse);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -386,7 +386,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void CreateTeamInsertsTeamIntoDatabaseAndReturnsCreatedWorker()
+        public void CreateTeamInsertsTeamIntoDatabaseAndReturnsCreatedTeam()
         {
             var createTeamRequest = TestHelpers.CreateTeamRequest();
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -386,7 +386,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void CreateTeamInsertsWorkerIntoDatabaseAndReturnsCreatedWorker()
+        public void CreateTeamInsertsTeamIntoDatabaseAndReturnsCreatedWorker()
         {
             var createTeamRequest = TestHelpers.CreateTeamRequest();
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -386,6 +386,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void CreateTeamInsertsWorkerIntoDatabaseAndReturnsCreatedWorker()
+        {
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+
+            var returnedTeam = _classUnderTest.CreateTeam(createTeamRequest);
+
+            returnedTeam.Name.Should().Be(createTeamRequest.Name);
+            returnedTeam.Context.Should().Be(createTeamRequest.Context);
+        }
+
+        [Test]
         public void GetTeamByTeamIdReturnsListOfTeamsWithWorkers()
         {
             var team = SaveTeamToDatabase(

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -406,5 +406,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(r => r.LastModifiedAt, f => f.Date.Recent())
                 .RuleFor(r => r.LastModifiedBy, f => f.Person.FullName);
         }
+
+        public static CreateTeamRequest CreateTeamRequest(string? name = null, string? context = null)
+        {
+            return new Faker<CreateTeamRequest>()
+                .RuleFor(t => t.Name, f => name ?? f.Random.String2(1, 200))
+                .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"));
+        }
+
+        public static TeamResponse CreateTeamResponse(long? id = null, string? name = null, string? context = null)
+        {
+            return new Faker<TeamResponse>()
+                .RuleFor(t => t.Id, f => id ?? f.UniqueIndex)
+                .RuleFor(t => t.Name, f => name ?? f.Random.String2(1, 200))
+                .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"));
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -296,12 +296,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.Name, f => teamName ?? f.Random.String2(200));
         }
 
-        public static Team CreateTeam(int? teamId = null)
+        public static Team CreateTeam(int? teamId = null, string? name = null, string? context = null)
         {
             return new Faker<Team>()
                 .RuleFor(t => t.Id, f => teamId ?? f.UniqueIndex + 1)
-                .RuleFor(t => t.Context, f => f.Random.String2(1))
-                .RuleFor(t => t.Name, f => f.Random.String2(1, 200));
+                .RuleFor(t => t.Context, f => name ?? f.Random.String2(1))
+                .RuleFor(t => t.Name, f => context ?? f.Random.String2(1, 200));
         }
 
         public static WarningNote CreateWarningNote(long? personId = null, string? status = null)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -300,7 +300,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         {
             return new Faker<Team>()
                 .RuleFor(t => t.Id, f => teamId ?? f.UniqueIndex + 1)
-                .RuleFor(t => t.Context, f => name ?? f.Random.String2(1))
+                .RuleFor(t => t.Context, f => name ?? f.Random.String2(1, "AC"))
                 .RuleFor(t => t.Name, f => context ?? f.Random.String2(1, 200));
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -414,7 +414,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"));
         }
 
-        public static TeamResponse CreateTeamResponse(long? id = null, string? name = null, string? context = null)
+        public static TeamResponse CreateTeamResponse(int? id = null, string? name = null, string? context = null)
         {
             return new Faker<TeamResponse>()
                 .RuleFor(t => t.Id, f => id ?? f.UniqueIndex)

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
@@ -1,6 +1,4 @@
-
 using System.Collections.Generic;
-using Bogus.DataSets;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -32,8 +30,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void GetTeamsByContextReturnsListTeamsResponse()
         {
             var request = new ListTeamsRequest();
-
-            var response = new ListTeamsResponse();
 
             _mockDatabaseGateway.Setup(x => x.GetTeams(It.IsAny<string>())).Returns(new List<DbTeam>());
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
@@ -1,10 +1,14 @@
 
 using System.Collections.Generic;
+using Bogus.DataSets;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
+using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase;
 using DbTeam = SocialCareCaseViewerApi.V1.Infrastructure.Team;
@@ -39,5 +43,38 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             Assert.IsInstanceOf<List<Team>>(result.Teams);
 
         }
+
+        [Test]
+        public void ExecutePostCallsDatabaseGateway()
+        {
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+            var team = TestHelpers.CreateTeam(name: createTeamRequest.Name, context: createTeamRequest.Context);
+            _mockDatabaseGateway.Setup(x => x.CreateTeam(createTeamRequest)).Returns(team);
+
+            _teamsUseCase.ExecutePost(createTeamRequest);
+
+            _mockDatabaseGateway.Verify(x => x.CreateTeam(createTeamRequest));
+            _mockDatabaseGateway.Verify(x => x.CreateTeam(It.Is<CreateTeamRequest>(w => w == createTeamRequest)), Times.Once());
+        }
+
+        [Test]
+        public void ExecutePostReturnsCreatedTeam()
+        {
+            var createTeamRequest = TestHelpers.CreateTeamRequest();
+            var team = TestHelpers.CreateTeam(name: createTeamRequest.Name, context: createTeamRequest.Context);
+            _mockDatabaseGateway.Setup(x => x.CreateTeam(createTeamRequest)).Returns(team);
+
+            var response = _teamsUseCase.ExecutePost(createTeamRequest);
+
+            response.Should().BeEquivalentTo(team.ToDomain().ToResponse());
+        }
+
+        // todo once we add GET team via team name
+        // [Test]
+        // public void ExecutePostThrowsPostTeamExceptionIfTeamNameAlreadyInUse()
+        // {
+        //     var createTeamRequest = TestHelpers.CreateTeamRequest();
+        //     var team = TestHelpers.CreateTeam(name: createTeamRequest.Name, context: createTeamRequest.Context);
+        // }
     }
 }

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -122,6 +122,7 @@ namespace SocialCareCaseViewerApi
             services.AddTransient<IValidator<UpdateAllocationRequest>, UpdateAllocationRequestValidator>();
             services.AddTransient<IValidator<CreateWorkerRequest>, CreateWorkerRequestValidator>();
             services.AddTransient<IValidator<PatchWarningNoteRequest>, PatchWarningNoteRequestValidator>();
+            services.AddTransient<IValidator<CreateTeamRequest>, CreateTeamRequestValidator>();
         }
 
         private static void ConfigureDbContext(IServiceCollection services)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateTeamRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreateTeamRequest.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+using FluentValidation;
+
+namespace SocialCareCaseViewerApi.V1.Boundary.Requests
+
+#nullable enable
+{
+    public class CreateTeamRequest
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = null!;
+
+        [JsonPropertyName("context")]
+        public string Context { get; set; } = null!;
+    }
+
+    public class CreateTeamRequestValidator : AbstractValidator<CreateTeamRequest>
+    {
+        public CreateTeamRequestValidator()
+        {
+            RuleFor(t => t.Name)
+                .NotNull().WithMessage("Team name must be provided")
+                .MinimumLength(1).WithMessage("Team name must be provided")
+                .MaximumLength(200).WithMessage("Team name has a maximum length of 200 characters");
+            RuleFor(w => w.Context)
+                .NotNull().WithMessage("Context flag must be provided")
+                .MinimumLength(1).WithMessage("Context flag must be provided")
+                .MaximumLength(1).WithMessage("Context flag must be no longer than 1 character")
+                .Matches("(?i:^A|C)").WithMessage("Context flag must be 'A' or 'C'");
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/TeamResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/TeamResponse.cs
@@ -1,0 +1,11 @@
+namespace SocialCareCaseViewerApi.V1.Boundary.Response
+{
+    public class TeamResponse
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Context { get; set; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -29,7 +29,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="422">Could not process request</response>
         [ProducesResponseType(typeof(TeamResponse), StatusCodes.Status201Created)]
         [HttpPost]
-        public IActionResult CreateWorker([FromBody] CreateTeamRequest request)
+        public IActionResult CreateTeam([FromBody] CreateTeamRequest request)
         {
             var validator = new CreateTeamRequestValidator();
             var validationResults = validator.Validate(request);

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Exceptions;
+
+namespace SocialCareCaseViewerApi.V1.Controllers
+{
+    [ApiController]
+    [Route("api/v1/teams")]
+    [Produces("application/json")]
+    [ApiVersion("1.0")]
+    public class TeamController : BaseController
+    {
+        public TeamController()
+        {
+
+        }
+
+        /// <summary>
+        /// Create a team
+        /// </summary>
+        /// <param name="request"></param>
+        /// <response code="201">Team created successfully</response>
+        /// <response code="400">Invalid CreateTeamRequest received</response>
+        /// <response code="422">Could not process request</response>
+        [ProducesResponseType(typeof(TeamResponse), StatusCodes.Status201Created)]
+        [HttpPost]
+        public IActionResult CreateWorker([FromBody] CreateTeamRequest request)
+        {
+            var validator = new CreateTeamRequestValidator();
+            var validationResults = validator.Validate(request);
+
+            if (!validationResults.IsValid)
+            {
+                return BadRequest(validationResults.ToString());
+            }
+
+            try
+            {
+                var createdTeam = new TeamResponse {Id = 1, Name = "placeholder", Context = "A"};
+                return CreatedAtAction("Team created successfully", createdTeam);
+            }
+            catch (PostTeamException e)
+            {
+                return UnprocessableEntity(e.Message);
+            }
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -41,7 +41,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
 
             try
             {
-                var createdTeam = new TeamResponse {Id = 1, Name = "placeholder", Context = "A"};
+                var createdTeam = _teamsUseCase.ExecutePost(request);
                 return CreatedAtAction("Team created successfully", createdTeam);
             }
             catch (PostTeamException e)

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
 namespace SocialCareCaseViewerApi.V1.Controllers
 {
@@ -12,9 +13,11 @@ namespace SocialCareCaseViewerApi.V1.Controllers
     [ApiVersion("1.0")]
     public class TeamController : BaseController
     {
-        public TeamController()
-        {
+        private readonly ITeamsUseCase _teamsUseCase;
 
+        public TeamController(ITeamsUseCase teamsUseCase)
+        {
+            _teamsUseCase = teamsUseCase;
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Domain/Team.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/Team.cs
@@ -5,5 +5,7 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public int Id { get; set; }
 
         public string Name { get; set; }
+
+        public string Context { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Exceptions/CustomExceptions.cs
+++ b/SocialCareCaseViewerApi/V1/Exceptions/CustomExceptions.cs
@@ -67,4 +67,9 @@ namespace SocialCareCaseViewerApi.V1.Exceptions
     {
         public GetTeamException(string message) : base(message) { }
     }
+
+    public class PostTeamException : Exception
+    {
+        public PostTeamException(string message) : base(message) { }
+    }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -89,7 +89,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
             return new Team
             {
                 Id = team.Id,
-                Name = team.Name
+                Name = team.Name,
+                Context = team.Context
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -192,7 +192,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static TeamResponse ToResponse(this Team team)
         {
-            return new TeamResponse {Id = team.Id, Name = team.Name, Context = team.Context};
+            return new TeamResponse { Id = team.Id, Name = team.Name, Context = team.Context };
         }
 
         private static WarningNoteReviewResponse ToResponse(this WarningNoteReview review)

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -192,7 +192,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static TeamResponse ToResponse(this Team team)
         {
-            return new TeamResponse {Id = team.Id, Name = team.Name, Context = team.Name};
+            return new TeamResponse {Id = team.Id, Name = team.Name, Context = team.Context};
         }
 
         private static WarningNoteReviewResponse ToResponse(this WarningNoteReview review)

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -9,6 +9,7 @@ using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using dbPhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
+using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
 namespace SocialCareCaseViewerApi.V1.Factories
@@ -187,6 +188,11 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CreatedBy = warningNote.CreatedBy,
                 WarningNoteReviews = warningNote.WarningNoteReviews?.Select(x => x.ToResponse()).ToList()
             };
+        }
+
+        public static TeamResponse ToResponse(this Team team)
+        {
+            return new TeamResponse {Id = team.Id, Name = team.Name, Context = team.Name};
         }
 
         private static WarningNoteReviewResponse ToResponse(this WarningNoteReview review)

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -555,7 +555,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public Team CreateTeam(CreateTeamRequest request)
         {
-            var team = new Team {Name = request.Name, Context = request.Context, WorkerTeams = new List<WorkerTeam>()};
+            var team = new Team { Name = request.Name, Context = request.Context, WorkerTeams = new List<WorkerTeam>() };
 
             _databaseContext.Teams.Add(team);
             _databaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -553,6 +553,16 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .ToList();
         }
 
+        public Team CreateTeam(CreateTeamRequest request)
+        {
+            var team = new Team {Name = request.Name, Context = request.Context, WorkerTeams = new List<WorkerTeam>()};
+
+            _databaseContext.Teams.Add(team);
+            _databaseContext.SaveChanges();
+
+            return team;
+        }
+
         //TODO: use db views or queries
         public List<dynamic> GetWorkerAllocations(List<Worker> workers)
         {

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -21,6 +21,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         Worker GetWorkerByWorkerId(int workerId);
         Worker GetWorkerByEmail(string email);
         List<Team> GetTeamsByTeamId(int teamId);
+        Team CreateTeam(CreateTeamRequest request);
         List<dynamic> GetWorkerAllocations(List<Worker> workers);
         List<Team> GetTeams(string context);
         UpdateAllocationResponse UpdateAllocation(UpdateAllocationRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
@@ -6,5 +6,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     public interface ITeamsUseCase
     {
         ListTeamsResponse ExecuteGet(ListTeamsRequest request);
+
+        TeamResponse ExecutePost(CreateTeamRequest request);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
@@ -8,7 +8,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 {
     public class TeamsUseCase : ITeamsUseCase
     {
-        private IDatabaseGateway _databaseGateway;
+        private readonly IDatabaseGateway _databaseGateway;
 
         public TeamsUseCase(IDatabaseGateway databaseGateway)
         {

--- a/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
@@ -21,5 +21,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             return new ListTeamsResponse() { Teams = EntityFactory.ToDomain(teams) };
         }
+
+        public TeamResponse ExecutePost(CreateTeamRequest request)
+        {
+
+            // todo check if team name already exists, if so throw an error
+
+            var team = _databaseGateway.CreateTeam(request);
+
+            return team.ToDomain().ToResponse();
+        }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[Backend API - Create Team](https://hackney.atlassian.net/jira/software/projects/SCS/boards/51?selectedIssue=SCS-797)

## Describe this PR

### *What is the problem we're trying to solve*

Currently we can't create teams via our API.
We are going to need this functionality anyway but also Creating a worker requires a team.
To debug locally we want to be able to make a team via a REST API instead of manually inserting into a database.

Basically this takes care of some future required work anyway and moves us a step closer to proper local development/debugging.

### *What changes have we introduced*

Create a new controller for Teams.

- Created a post endpoint which expects a team name, team context with validation.
- Added to the team usecase an execute post function. (todo is not allowing us to create a team when the team name is already taken, this will be done in following piece of work when we make a get team by team name API)
- Added database gateway function for saving the team to the database
- Updated entity factory to also return team context
- Created response factory method for returning a team response
- Tested all new/edited functionality


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
