### PR TITLE
Data import timestamp format support for case sorting

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -245,7 +245,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     bool success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
                     if (success) return timeStamp;
 
-                    bool successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dataImportTimestamp);
+                    bool successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dataImportTimestamp);
                     if (successForDataImportTimestampFormat) return dataImportTimestamp;
                 }
                 else

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -244,6 +244,9 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 {
                     bool success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
                     if (success) return timeStamp;
+
+                    bool successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dataImportTimestamp);
+                    if (successForDataImportTimestampFormat) return dataImportTimestamp;
                 }
                 else
                 {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-8

## Describe this PR

Currently some case records have timestamp in non-ISO format i.e. dd/MM/yyyy hh:mm. The current parsing in the ProcessDataGateway fails for these records so the records always appear at the bottom of the case history list.

Please note our MongoDB test coverage hasn't been setup properly yet, so this is a quick fix without test coverage for existing method to unblock the Conversation 3 form launch.

### *What changes have we introduced*

This update adds parsing support for this date format, so those records can be sorted correctly together with other records.

#### _Checklist_
- [x] Code pipeline builds correctly