### PR TITLE
use 24h format in timestamp

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -403,7 +403,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 .Build<CreateCaseNoteRequest>()
                 .With(x => x.ContextFlag, _faker.Random.String2(1))
                 .With(x => x.CaseFormData, "{\"prop_one\": \"value one\",  \"prop_two\": \"value two\"}")
-                .Create();      
+                .Create();
 
             GenericCaseNote note = new GenericCaseNote()
             {

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -19,6 +19,9 @@ using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
 using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using AutoFixture;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Factories
 {
@@ -26,11 +29,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
     public class EntityFactoryTests
     {
         private Faker _faker;
+        private Fixture _fixture;
 
         [SetUp]
         public void SetUp()
         {
             _faker = new Faker();
+            _fixture = new Fixture();
         }
 
         #region ToDomain
@@ -391,6 +396,65 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
         }
 
+        [Test]
+        public void CanMapCreateCaseNoteRequestToCaseNotesDocument()
+        {
+            CreateCaseNoteRequest request = _fixture
+                .Build<CreateCaseNoteRequest>()
+                .With(x => x.ContextFlag, _faker.Random.String2(1))
+                .With(x => x.CaseFormData, "{\"prop_one\": \"value one\",  \"prop_two\": \"value two\"}")
+                .Create();      
+
+            GenericCaseNote note = new GenericCaseNote()
+            {
+                DateOfBirth = request.DateOfBirth?.ToString("dd/MM/yyy"),
+                DateOfEvent = request.DateOfEvent?.ToString(),
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                FormName = request.FormName,
+                FormNameOverall = request.FormNameOverall,
+                WorkerEmail = request.WorkerEmail,
+                MosaicId = request.PersonId.ToString()
+            };
+
+            var result = request.ToEntity();
+
+            dynamic formData = JsonConvert.DeserializeObject(result.CaseFormData);
+
+            //take the generated timestamp value and use it in the expected result
+            note.Timestamp = formData["timestamp"];
+
+            JObject coreProperties = JObject.Parse(JsonConvert.SerializeObject(note));
+
+            coreProperties.Merge(JObject.Parse(request.CaseFormData));
+
+            var expectedResult = new CaseNotesDocument()
+            {
+                CaseFormData = coreProperties.ToString()
+            };
+
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Test]
+        public void CreateCaseNoteRequestToCaseNotesDocumentUsesCorrectDateTimeFormatForTimestamp()
+        {
+            CreateCaseNoteRequest request = _fixture
+               .Build<CreateCaseNoteRequest>()
+               .With(x => x.ContextFlag, _faker.Random.String2(1))
+               .With(x => x.CaseFormData, "{\"prop_one\": \"value one\",  \"prop_two\": \"value two\"}")
+               .Create();
+
+            var result = request.ToEntity();
+
+            dynamic formData = JsonConvert.DeserializeObject(result.CaseFormData);
+
+            string timestamp = formData["timestamp"];
+
+            (DateTime.TryParseExact(timestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date)).Should().BeTrue();
+        }
+
         #endregion
     }
 }
+

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -180,7 +180,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         {
             GenericCaseNote note = new GenericCaseNote()
             {
-                Timestamp = DateTime.UtcNow.ToString("dd/MM/yyyy H:mm:ss"),
+                Timestamp = DateTime.UtcNow.ToString("dd/MM/yyyy HH:mm:ss"),
                 DateOfBirth = request.DateOfBirth?.ToString("dd/MM/yyy"),
                 DateOfEvent = request.DateOfEvent?.ToString(),
                 FirstName = request.FirstName,

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -180,7 +180,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         {
             GenericCaseNote note = new GenericCaseNote()
             {
-                Timestamp = DateTime.Now.ToString("dd/MM/yyy hh:mm"),
+                Timestamp = DateTime.UtcNow.ToString("dd/MM/yyyy H:mm:ss"),
                 DateOfBirth = request.DateOfBirth?.ToString("dd/MM/yyy"),
                 DateOfEvent = request.DateOfEvent?.ToString(),
                 FirstName = request.FirstName,


### PR DESCRIPTION
## Link to JIRA ticket

This is related to the sorting issue addresses in https://hackney.atlassian.net/browse/SCT-8

## Describe this PR

### *What is the problem we're trying to solve*

Currently the timestamp is not using 24hr format so the records end up with times that are causing issues with sorting

### *What changes have we introduced*

Change the timestamp to use UTC time and 24h hour format. Further development work is required to standardise all date times to ISO, but this fix will improve the captured data in the meantime. 
