### PR TITLE
Add support for 24hr timestamp format for sorting

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -247,6 +247,9 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
                     bool successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dataImportTimestamp);
                     if (successForDataImportTimestampFormat) return dataImportTimestamp;
+
+                    bool successForNonISO24hrTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime nonISO24hrTimestamp);
+                    if (successForNonISO24hrTimestampFormat) return nonISO24hrTimestamp;
                 }
                 else
                 {


### PR DESCRIPTION
## Link to JIRA ticket

This is a fix relating to the record history sorting bug in https://hackney.atlassian.net/browse/SCT-8

## Describe this PR

### *What is the problem we're trying to solve*

GetDateToSortBy method is missing parsing support for `dd/MM/yyyy HH:mm:ss` date time format, so those records always appear at the bottom of the list.

### *What changes have we introduced*

Added new parsing to GetDateToSortBy method so it can return valid DateTime object for records that have timestamp in that specific format.

This method is part of the ProcessDataGateway which is seriously lacking test coverage, so I would like to address that in a separate PR so we can start tackling that tech debt as well.

#### _Checklist_

- [x] Code pipeline builds correctly
