### PR TITLE
Refactor(SCT-199): Create unique endpoint for GET team by team name or id

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetTeamsRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetTeamsRequestTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
@@ -12,14 +10,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
     [TestFixture]
     public class GetTeamsRequestTests
     {
-        private Faker _faker;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _faker = new Faker();
-        }
-
         [Test]
         public void GetTeamsRequestValidationWithInvalidPropertiesReturnsError()
         {
@@ -28,8 +18,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: "d"), "Context flag must be 'A' or 'C'"),
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: ""), "Context flag must be 'A' or 'C'"),
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: "aa"), "Context flag must be 1 character in length"),
-                (TestHelpers.CreateGetTeamsRequest(name: ""), "Team name must be at least 1 character"),
-                (TestHelpers.CreateGetTeamsRequest(name: _faker.Random.String2(201)), "Team name has a maximum length of 200 characters")
             };
 
             var validator = new GetTeamsRequestValidator();

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetTeamsRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetTeamsRequestTests.cs
@@ -25,7 +25,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         {
             var badGetTeamsRequests = new List<(GetTeamsRequest, string)>()
             {
-                (TestHelpers.CreateGetTeamsRequest(true), "Must provide either a team ID, team name or context flag"),
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: "d"), "Context flag must be 'A' or 'C'"),
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: ""), "Context flag must be 'A' or 'C'"),
                 (TestHelpers.CreateGetTeamsRequest(contextFlag: "aa"), "Context flag must be 1 character in length"),

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
@@ -29,6 +29,36 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
+        public void GetTeamByTeamIdReturns200AndTeamWhenSuccessful()
+        {
+            var team = TestHelpers.CreateTeam();
+            _teamsUseCase.Setup(x => x.ExecuteGetById(team.Id)).Returns(team.ToDomain().ToResponse());
+
+            var response = _teamController.GetTeamById(team.Id) as ObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(team.ToDomain().ToResponse());
+        }
+
+        [Test]
+        public void GetTeamByTeamIdReturns404WhenTeamNotFound()
+        {
+            var response = _teamController.GetTeamById(1) as NotFoundResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
         public void GetTeamsReturns200AndTeamsWhenSuccessful()
         {
             var request = TestHelpers.CreateGetTeamsRequest();

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/TeamsControllerTests.cs
@@ -7,11 +7,9 @@ using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
-using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
-using Team = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 {
@@ -59,6 +57,36 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
+        public void GetTeamByTeamNameReturns200AndTeamWhenSuccessful()
+        {
+            var team = TestHelpers.CreateTeam();
+            _teamsUseCase.Setup(x => x.ExecuteGetByName(team.Name)).Returns(team.ToDomain().ToResponse());
+
+            var response = _teamController.GetTeamByName(team.Name) as ObjectResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(team.ToDomain().ToResponse());
+        }
+
+        [Test]
+        public void GetTeamByTeamNameReturns404WhenTeamNotFound()
+        {
+            var response = _teamController.GetTeamByName("fake team name") as NotFoundResult;
+
+            if (response == null)
+            {
+                throw new NullReferenceException();
+            }
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
         public void GetTeamsReturns200AndTeamsWhenSuccessful()
         {
             var request = TestHelpers.CreateGetTeamsRequest();
@@ -79,7 +107,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void GetTeamsReturns404WhenNoTeamsFound()
+        public void GetTeamsReturns200AndEmptyListWhenNoTeamsFound()
         {
             var request = TestHelpers.CreateGetTeamsRequest();
             var teamsList = new ListTeamsResponse()
@@ -87,14 +115,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
                 Teams = new List<TeamResponse>()
             };
             _teamsUseCase.Setup(x => x.ExecuteGet(request)).Returns(teamsList);
-            var response = _teamController.GetTeams(request) as NotFoundObjectResult;
+            var response = _teamController.GetTeams(request) as OkObjectResult;
 
             if (response == null)
             {
                 throw new NullReferenceException();
             }
-            response.StatusCode.Should().Be(404);
-            response.Value.Should().Be("No team found");
+            response.StatusCode.Should().Be(200);
+            ((ListTeamsResponse) response.Value).Teams.Should().BeEmpty();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -420,15 +420,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"));
         }
 
-        public static GetTeamsRequest CreateGetTeamsRequest(bool setFieldsNull = false, string? name = null, string? contextFlag = null)
+        public static GetTeamsRequest CreateGetTeamsRequest(string? contextFlag = null)
         {
-            if (setFieldsNull)
-            {
-                return new GetTeamsRequest { Name = null, ContextFlag = null };
-            }
-
             return new Faker<GetTeamsRequest>()
-                .RuleFor(t => t.Name, f => name ?? f.Random.String2(200))
                 .RuleFor(t => t.ContextFlag, f => contextFlag ?? f.Random.String2(1, "ACac"));
         }
     }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -420,15 +420,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"));
         }
 
-        public static GetTeamsRequest CreateGetTeamsRequest(bool setFieldsNull = false, int? id = null, string? name = null, string? contextFlag = null)
+        public static GetTeamsRequest CreateGetTeamsRequest(bool setFieldsNull = false, string? name = null, string? contextFlag = null)
         {
             if (setFieldsNull)
             {
-                return new GetTeamsRequest { Id = null, Name = null, ContextFlag = null };
+                return new GetTeamsRequest { Name = null, ContextFlag = null };
             }
 
             return new Faker<GetTeamsRequest>()
-                .RuleFor(t => t.Id, f => id ?? f.UniqueIndex)
                 .RuleFor(t => t.Name, f => name ?? f.Random.String2(200))
                 .RuleFor(t => t.ContextFlag, f => contextFlag ?? f.Random.String2(1, "ACac"));
         }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Diagnostics;
 using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
@@ -25,6 +26,25 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             _mockDatabaseGateway = new Mock<IDatabaseGateway>();
             _teamsUseCase = new TeamsUseCase(_mockDatabaseGateway.Object);
+        }
+
+        [Test]
+        public void GetTeamsByTeamIdReturnsTeamResponseWhenTeamExists()
+        {
+            var team = TestHelpers.CreateTeam();
+            _mockDatabaseGateway.Setup(x => x.GetTeamByTeamId(team.Id)).Returns(team);
+
+            var response = _teamsUseCase.ExecuteGetById(team.Id);
+
+            response.Should().BeEquivalentTo(team.ToDomain().ToResponse());
+        }
+
+        [Test]
+        public void GetTeamsByTeamIdReturnsNullWhenTeamDoesNotExists()
+        {
+            var response = _teamsUseCase.ExecuteGetById(1);
+
+            response.Should().BeNull();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/TeamsUseCaseTests.cs
@@ -32,7 +32,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = TestHelpers.CreateGetTeamsRequest();
             var team = TestHelpers.CreateTeam();
-            request.Id = null;
             request.Name = null;
 
             _mockDatabaseGateway.Setup(x => x.GetTeamsByTeamContextFlag(request.ContextFlag)).Returns(new List<DbTeam> { team });
@@ -40,28 +39,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var result = _teamsUseCase.ExecuteGet(request);
 
             _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Once);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Never);
-
-            result.Teams.FirstOrDefault().Id.Should().Be(team.Id);
-            result.Teams.FirstOrDefault().Context.Should().BeEquivalentTo(team.Context);
-            result.Teams.FirstOrDefault().Name.Should().BeEquivalentTo(team.Name);
-        }
-
-        [Test]
-        public void GetTeamsByIdReturnsListTeamsResponse()
-        {
-            var request = TestHelpers.CreateGetTeamsRequest();
-            var team = TestHelpers.CreateTeam();
-            request.ContextFlag = null;
-            request.Name = null;
-
-            _mockDatabaseGateway.Setup(x => x.GetTeamByTeamId(request.Id ?? 0)).Returns(team);
-
-            var result = _teamsUseCase.ExecuteGet(request);
-
-            _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Once);
             _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Never);
 
             result.Teams.FirstOrDefault().Id.Should().Be(team.Id);
@@ -74,7 +51,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = TestHelpers.CreateGetTeamsRequest();
             var team = TestHelpers.CreateTeam();
-            request.Id = null;
             request.ContextFlag = null;
 
             _mockDatabaseGateway.Setup(x => x.GetTeamByTeamName(request.Name)).Returns(team);
@@ -82,7 +58,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var result = _teamsUseCase.ExecuteGet(request);
 
             _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Never);
             _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Once);
 
             result.Teams.FirstOrDefault().Id.Should().Be(team.Id);
@@ -98,34 +73,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var result = _teamsUseCase.ExecuteGet(request);
 
             _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Never);
             _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Never);
 
             result.Teams.Should().BeEmpty();
         }
 
         [Test]
-        public void GetTeamsPrioritisesIdOverNameAndContext()
-        {
-            var request = TestHelpers.CreateGetTeamsRequest();
-
-            _teamsUseCase.ExecuteGet(request);
-
-            _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Once);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Never);
-        }
-
-        [Test]
         public void GetTeamsPrioritisesNameOverContext()
         {
             var request = TestHelpers.CreateGetTeamsRequest();
-            request.Id = null;
 
             _teamsUseCase.ExecuteGet(request);
 
             _mockDatabaseGateway.Verify(x => x.GetTeamsByTeamContextFlag(request.ContextFlag), Times.Never);
-            _mockDatabaseGateway.Verify(x => x.GetTeamByTeamId(request.Id ?? 0), Times.Never);
             _mockDatabaseGateway.Verify(x => x.GetTeamByTeamName(request.Name), Times.Once);
         }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/GetTeamsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/GetTeamsRequest.cs
@@ -6,20 +6,14 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class GetTeamsRequest
     {
-        [FromQuery(Name = "name")]
-        public string? Name { get; set; }
-
         [FromQuery(Name = "context_flag")]
-        public string? ContextFlag { get; set; }
+        public string ContextFlag { get; set; } = null!;
     }
 
     public class GetTeamsRequestValidator : AbstractValidator<GetTeamsRequest>
     {
         public GetTeamsRequestValidator()
         {
-            RuleFor(t => t.Name)
-                .MinimumLength(1).WithMessage("Team name must be at least 1 character")
-                .MaximumLength(200).WithMessage("Team name has a maximum length of 200 characters");
             RuleFor(t => t.ContextFlag)
                 .MaximumLength(1).WithMessage("Context flag must be 1 character in length")
                 .Matches("(?i:^A|C)").WithMessage("Context flag must be 'A' or 'C'");

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/GetTeamsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/GetTeamsRequest.cs
@@ -6,9 +6,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class GetTeamsRequest
     {
-        [FromQuery(Name = "id")]
-        public int? Id { get; set; }
-
         [FromQuery(Name = "name")]
         public string? Name { get; set; }
 
@@ -20,8 +17,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
     {
         public GetTeamsRequestValidator()
         {
-            RuleFor(t => t).Must(t => t.Name != null || t.ContextFlag != null || t.Id != null)
-                .WithMessage("Must provide either a team ID, team name or context flag");
             RuleFor(t => t.Name)
                 .MinimumLength(1).WithMessage("Team name must be at least 1 character")
                 .MaximumLength(200).WithMessage("Team name has a maximum length of 200 characters");

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -21,6 +21,28 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         }
 
         /// <summary>
+        /// Get a team by team id
+        /// </summary>
+        /// <response code="200">Successful request and team returned</response>
+        /// <response code="404">No team found for request</response>
+        /// <response code="500">Server error</response>
+        [ProducesResponseType(typeof(TeamResponse), StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        [HttpGet]
+        [Route("id/{id:int}")]
+        public IActionResult GetTeamById(int id)
+        {
+            var team = _teamsUseCase.ExecuteGetById(id);
+
+            if (team == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(team);
+        }
+
+        /// <summary>
         /// Get a list of teams by context
         /// </summary>
         /// <response code="200">Successful request and teams returned</response>

--- a/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/TeamController.cs
@@ -43,6 +43,28 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         }
 
         /// <summary>
+        /// Get a team by team name
+        /// </summary>
+        /// <response code="200">Successful request and team returned</response>
+        /// <response code="404">No team found for request</response>
+        /// <response code="500">Server error</response>
+        [ProducesResponseType(typeof(TeamResponse), StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        [HttpGet]
+        [Route("name/{name}")]
+        public IActionResult GetTeamByName(string name)
+        {
+            var team = _teamsUseCase.ExecuteGetByName(name);
+
+            if (team == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(team);
+        }
+
+        /// <summary>
         /// Get a list of teams by context
         /// </summary>
         /// <response code="200">Successful request and teams returned</response>
@@ -64,10 +86,6 @@ namespace SocialCareCaseViewerApi.V1.Controllers
 
             var teams = _teamsUseCase.ExecuteGet(request);
 
-            if (teams.Teams.Count == 0)
-            {
-                return NotFound("No team found");
-            }
             return Ok(teams);
         }
 

--- a/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
@@ -8,40 +8,40 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
 {
     public class SccvDbContext : ISccvDbContext
     {
-        // private MongoClient _mongoClient;
-        // private IMongoDatabase _mongoDatabase;
+        private MongoClient _mongoClient;
+        private IMongoDatabase _mongoDatabase;
         public IMongoCollection<BsonDocument> matProcessCollection { get; set; }
         public SccvDbContext()
         {
-            // string cAfile = Environment.GetEnvironmentVariable("RDS_CA_2019");
-            //
-            // // ADD CA certificate to local trust store
-            // // DO this once - Maybe when your service starts
-            // X509Store localTrustStore = new X509Store(StoreName.Root);
-            // //  string caContentString = System.IO.File.ReadAllText(cAfile);
-            //
-            // X509Certificate2 caCert = new X509Certificate2(Encoding.ASCII.GetBytes(cAfile));
-            //
-            // try
-            // {
-            //     localTrustStore.Open(OpenFlags.ReadWrite);
-            //     localTrustStore.Add(caCert);
-            // }
-            // catch (Exception ex)
-            // {
-            //     Console.WriteLine("Root certificate import failed: " + ex.Message);
-            //     throw;
-            // }
-            // finally
-            // {
-            //     localTrustStore.Close();
-            // }
-            //
-            // _mongoClient = new MongoClient(new MongoUrl(Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING")));
-            // //create a new blank database if database does not exist, otherwise get existing database
-            // _mongoDatabase = _mongoClient.GetDatabase(Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME"));
-            // //create collection to hold the documents if it does not exist, otherwise retrieve existing
-            // matProcessCollection = _mongoDatabase.GetCollection<BsonDocument>(Environment.GetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME"));
+            string cAfile = Environment.GetEnvironmentVariable("RDS_CA_2019");
+
+            // ADD CA certificate to local trust store
+            // DO this once - Maybe when your service starts
+            X509Store localTrustStore = new X509Store(StoreName.Root);
+            //  string caContentString = System.IO.File.ReadAllText(cAfile);
+
+            X509Certificate2 caCert = new X509Certificate2(Encoding.ASCII.GetBytes(cAfile));
+
+            try
+            {
+                localTrustStore.Open(OpenFlags.ReadWrite);
+                localTrustStore.Add(caCert);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Root certificate import failed: " + ex.Message);
+                throw;
+            }
+            finally
+            {
+                localTrustStore.Close();
+            }
+
+            _mongoClient = new MongoClient(new MongoUrl(Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING")));
+            //create a new blank database if database does not exist, otherwise get existing database
+            _mongoDatabase = _mongoClient.GetDatabase(Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME"));
+            //create collection to hold the documents if it does not exist, otherwise retrieve existing
+            matProcessCollection = _mongoDatabase.GetCollection<BsonDocument>(Environment.GetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME"));
         }
         public IMongoCollection<BsonDocument> getCollection()
         {

--- a/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
@@ -8,40 +8,40 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
 {
     public class SccvDbContext : ISccvDbContext
     {
-        private MongoClient _mongoClient;
-        private IMongoDatabase _mongoDatabase;
+        // private MongoClient _mongoClient;
+        // private IMongoDatabase _mongoDatabase;
         public IMongoCollection<BsonDocument> matProcessCollection { get; set; }
         public SccvDbContext()
         {
-            string cAfile = Environment.GetEnvironmentVariable("RDS_CA_2019");
-
-            // ADD CA certificate to local trust store
-            // DO this once - Maybe when your service starts
-            X509Store localTrustStore = new X509Store(StoreName.Root);
-            //  string caContentString = System.IO.File.ReadAllText(cAfile);
-
-            X509Certificate2 caCert = new X509Certificate2(Encoding.ASCII.GetBytes(cAfile));
-
-            try
-            {
-                localTrustStore.Open(OpenFlags.ReadWrite);
-                localTrustStore.Add(caCert);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Root certificate import failed: " + ex.Message);
-                throw;
-            }
-            finally
-            {
-                localTrustStore.Close();
-            }
-
-            _mongoClient = new MongoClient(new MongoUrl(Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING")));
-            //create a new blank database if database does not exist, otherwise get existing database
-            _mongoDatabase = _mongoClient.GetDatabase(Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME"));
-            //create collection to hold the documents if it does not exist, otherwise retrieve existing
-            matProcessCollection = _mongoDatabase.GetCollection<BsonDocument>(Environment.GetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME"));
+            // string cAfile = Environment.GetEnvironmentVariable("RDS_CA_2019");
+            //
+            // // ADD CA certificate to local trust store
+            // // DO this once - Maybe when your service starts
+            // X509Store localTrustStore = new X509Store(StoreName.Root);
+            // //  string caContentString = System.IO.File.ReadAllText(cAfile);
+            //
+            // X509Certificate2 caCert = new X509Certificate2(Encoding.ASCII.GetBytes(cAfile));
+            //
+            // try
+            // {
+            //     localTrustStore.Open(OpenFlags.ReadWrite);
+            //     localTrustStore.Add(caCert);
+            // }
+            // catch (Exception ex)
+            // {
+            //     Console.WriteLine("Root certificate import failed: " + ex.Message);
+            //     throw;
+            // }
+            // finally
+            // {
+            //     localTrustStore.Close();
+            // }
+            //
+            // _mongoClient = new MongoClient(new MongoUrl(Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING")));
+            // //create a new blank database if database does not exist, otherwise get existing database
+            // _mongoDatabase = _mongoClient.GetDatabase(Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME"));
+            // //create collection to hold the documents if it does not exist, otherwise retrieve existing
+            // matProcessCollection = _mongoDatabase.GetCollection<BsonDocument>(Environment.GetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME"));
         }
         public IMongoCollection<BsonDocument> getCollection()
         {

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
@@ -7,6 +7,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     {
         TeamResponse ExecuteGetById(int id);
 
+        TeamResponse ExecuteGetByName(string name);
+
         ListTeamsResponse ExecuteGet(GetTeamsRequest request);
 
         TeamResponse ExecutePost(CreateTeamRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ITeamsUseCase.cs
@@ -5,6 +5,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface ITeamsUseCase
     {
+        TeamResponse ExecuteGetById(int id);
+
         ListTeamsResponse ExecuteGet(GetTeamsRequest request);
 
         TeamResponse ExecutePost(CreateTeamRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -9,6 +8,7 @@ using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.UseCase
 {
     public class TeamsUseCase : ITeamsUseCase
@@ -20,34 +20,22 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
         }
 
-        public TeamResponse ExecuteGetById(int id)
+        public TeamResponse? ExecuteGetById(int id)
         {
             var team = _databaseGateway.GetTeamByTeamId(id);
             return team?.ToDomain().ToResponse();
         }
 
+        public TeamResponse? ExecuteGetByName(string name)
+        {
+            var team = _databaseGateway.GetTeamByTeamName(name);
+            return team?.ToDomain().ToResponse();
+        }
+
         public ListTeamsResponse ExecuteGet(GetTeamsRequest request)
         {
-            if (request.Name != null)
-            {
-                var teamFoundWithName = _databaseGateway.GetTeamByTeamName(request.Name);
-
-                if (teamFoundWithName == null)
-                {
-                    return new ListTeamsResponse() { Teams = new List<TeamResponse>() };
-                }
-
-                var teams = new List<Team> { teamFoundWithName };
-                return new ListTeamsResponse() { Teams = teams.Select(team => team.ToDomain().ToResponse()).ToList() };
-            }
-
-            if (request.ContextFlag != null)
-            {
-                var teams = _databaseGateway.GetTeamsByTeamContextFlag(request.ContextFlag);
-                return new ListTeamsResponse() { Teams = teams.Select(team => team.ToDomain().ToResponse()).ToList() };
-            }
-
-            return new ListTeamsResponse() { Teams = new List<TeamResponse>() };
+            var teams = _databaseGateway.GetTeamsByTeamContextFlag(request.ContextFlag);
+            return new ListTeamsResponse() { Teams = teams.Select(team => team.ToDomain().ToResponse()).ToList() };
         }
 
         public TeamResponse ExecutePost(CreateTeamRequest request)

--- a/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -19,21 +20,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
         }
 
+        public TeamResponse ExecuteGetById(int id)
+        {
+            Console.WriteLine(id);
+            var team = _databaseGateway.GetTeamByTeamId(id);
+            return team?.ToDomain().ToResponse();
+        }
+
         public ListTeamsResponse ExecuteGet(GetTeamsRequest request)
         {
-            if (request.Id != null)
-            {
-                var teamFoundWithId = _databaseGateway.GetTeamByTeamId(request.Id ?? 0);
-
-                if (teamFoundWithId == null)
-                {
-                    return new ListTeamsResponse() { Teams = new List<TeamResponse>() };
-                }
-
-                var teams = new List<Team> { teamFoundWithId };
-                return new ListTeamsResponse() { Teams = teams.Select(team => team.ToDomain().ToResponse()).ToList() };
-            }
-
             if (request.Name != null)
             {
                 var teamFoundWithName = _databaseGateway.GetTeamByTeamName(request.Name);

--- a/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/TeamsUseCase.cs
@@ -22,7 +22,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
         public TeamResponse ExecuteGetById(int id)
         {
-            Console.WriteLine(id);
             var team = _databaseGateway.GetTeamByTeamId(id);
             return team?.ToDomain().ToResponse();
         }


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-199)

## Describe this PR

### *What is the problem we're trying to solve*

We were incorrectly using query parameters to get teams by team name or id and returning a list of length 1 if team found.
This functionality has been moved into two separate API endpoints that both return a TeamResponse.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Look to deploy.
