### PR TITLE
CaseNote now added when warning note updated

### DIFF
--- a/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
+++ b/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
@@ -1,8 +1,8 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using SocialCareCaseViewerApi.V1.Infrastructure;
-using System;
-using System.Security.Cryptography.X509Certificates;
 
 namespace SocialCareCaseViewerApi.Tests
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetPersonRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/GetPersonRequestTests.cs
@@ -1,9 +1,9 @@
+using System.Linq;
 using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
-using System.Linq;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdatePersonRequestTests.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using Bogus;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Domain;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -1,14 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
+using AutoFixture;
 using Bogus;
 using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Infrastructure;
+using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using dbPhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
 using dbTeam = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 using dbWarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
@@ -17,11 +22,6 @@ using PhoneNumber = SocialCareCaseViewerApi.V1.Domain.PhoneNumber;
 using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
-using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
-using SocialCareCaseViewerApi.Tests.V1.Helpers;
-using AutoFixture;
-using Newtonsoft.Json.Linq;
-using System.Globalization;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Factories
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoFixture;
 using Bogus;
 using FluentAssertions;
@@ -13,10 +17,6 @@ using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Allocation = SocialCareCaseViewerApi.V1.Infrastructure.AllocationSet;
 using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using Person = SocialCareCaseViewerApi.V1.Infrastructure.Person;
@@ -1057,6 +1057,60 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             insertedRecord.DiscussedWithManagerDate.Should().Be(request.DiscussedWithManagerDate);
             insertedRecord.CreatedBy.Should().Be(request.ReviewedBy);
             insertedRecord.LastModifiedBy.Should().Be(request.ReviewedBy);
+        }
+
+        [Test]
+        public void PatchWarningNotesCreatesReviewedCaseHistoryNoteByCallingProcessDataGatewayWhenRequestStatusNotClosed()
+        {
+            var (request, person, worker, warningNote) = TestHelpers.CreatePatchWarningNoteRequest();
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.WarningNotes.Add(warningNote);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTestWithProcessDataGateway.PatchWarningNote(request);
+
+            var filter = Builders<BsonDocument>.Filter.Eq("mosaic_id", person.Id.ToString());
+
+            var result = MongoDbTestContext.getCollection().Find(filter).First();
+
+            string note = $"Warning note against this person reviewed";
+
+            result["first_name"].Should().Be(person.FirstName);
+            result["last_name"].Should().Be(person.LastName);
+            result["mosaic_id"].Should().Be(person.Id.ToString());
+            result["note"].ToString().Should().Contain(note);
+            result["form_name_overall"].Should().Be("API_WarningNote");
+            result["form_name"].Should().Be("Warning Note Reviewed");
+            result["worker_email"].Should().Be(request.ReviewedBy);
+
+        }
+
+        [Test]
+        public void PatchWarningNotesCreatesClosedCaseHistoryNoteByCallingProcessDataGatewayWhenRequestStatusIsClosed()
+        {
+            var (request, person, worker, warningNote) = TestHelpers.CreatePatchWarningNoteRequest(requestStatus: "closed");
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.WarningNotes.Add(warningNote);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTestWithProcessDataGateway.PatchWarningNote(request);
+
+            var filter = Builders<BsonDocument>.Filter.Eq("mosaic_id", person.Id.ToString());
+
+            var result = MongoDbTestContext.getCollection().Find(filter).First();
+
+            string note = $"Warning note against this person ended";
+
+            result["first_name"].Should().Be(person.FirstName);
+            result["last_name"].Should().Be(person.LastName);
+            result["mosaic_id"].Should().Be(person.Id.ToString());
+            result["note"].ToString().Should().Contain(note);
+            result["form_name_overall"].Should().Be("API_WarningNote");
+            result["form_name"].Should().Be("Warning Note Ended");
+            result["worker_email"].Should().Be(request.ReviewedBy);
+
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
@@ -1,7 +1,7 @@
-using Bogus;
-using SocialCareCaseViewerApi.V1.Infrastructure;
 using System;
 using System.Collections.Generic;
+using Bogus;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 using dbPerson = SocialCareCaseViewerApi.V1.Infrastructure.Person;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Helpers

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonUsecaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonUsecaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoFixture;
 using Bogus;
 using FluentAssertions;
@@ -8,7 +9,6 @@ using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.UseCase;
-using System;
 using dbPerson = SocialCareCaseViewerApi.V1.Infrastructure.Person;
 
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/GetPersonRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/GetPersonRequest.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdatePersonRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdatePersonRequest.cs
@@ -1,7 +1,7 @@
-using SocialCareCaseViewerApi.V1.Domain;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using SocialCareCaseViewerApi.V1.Domain;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/GetPersonResponse.cs
@@ -1,6 +1,6 @@
-using SocialCareCaseViewerApi.V1.Domain;
 using System;
 using System.Collections.Generic;
+using SocialCareCaseViewerApi.V1.Domain;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Response
 {

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -825,6 +825,28 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var review = PostWarningNoteReview(request);
             _databaseContext.WarningNoteReview.Add(review);
             _databaseContext.SaveChanges();
+
+            var dt = DateTime.Now;
+
+            var note = new WarningNoteCaseNote
+            {
+                FirstName = person.FirstName,
+                LastName = person.LastName,
+                MosaicId = person.Id.ToString(),
+                Timestamp = dt.ToString("dd/MM/yyyy H:mm:ss"),
+                Note = $"{dt.ToShortDateString()} | Warning Note | {((request.Status == "closed") ? "Warning note against this person ended" : "Warning note against this person reviewed")}",
+                FormNameOverall = "API_WarningNote",
+                FormName = (request.Status == "closed") ? "Warning Note Ended" : "Warning Note Reviewed",
+                WarningNoteId = warningNote.Id.ToString(),
+                WorkerEmail = request.ReviewedBy
+            };
+
+            var caseNotesDocument = new CaseNotesDocument
+            {
+                CaseFormData = JsonConvert.SerializeObject(note)
+            };
+
+            _ = _processDataGateway.InsertCaseNoteDocument(caseNotesDocument).Result;
         }
 
         private static WarningNoteReview PostWarningNoteReview(PatchWarningNoteRequest request)

--- a/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/SccvDbContext.cs
@@ -1,8 +1,8 @@
-using MongoDB.Bson;
-using MongoDB.Driver;
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using MongoDB.Bson;
+using MongoDB.Driver;
 
 namespace SocialCareCaseViewerApi.V1.Infrastructure
 {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-136

## Describe this PR

### *What is the problem we're trying to solve*

Reviewing or ending of a warning note does not appear in the record history at all. 

### *What changes have we introduced*

Case notes were not being added as part of the PatchWarningNotes method, the method has been updated to create and insert CaseNotes into the MongoDB database.

#### _Checklist_

- [x ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x ] Added tests to cover all new production code
- [ x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x ] Checked all code for possible refactoring
- [x ] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A