### PR TITLE
Remove deployment to ProductionAPIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,11 +132,6 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_STAGING
-  assume-role-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_PRODUCTION
   assume-role-mosaic-production:
     executor: docker-python
     steps:
@@ -152,11 +147,6 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "staging"
-  # terraform-init-and-apply-to-production:
-    # executor: docker-terraform
-    # steps:
-      # - terraform-init-then-apply:
-          # environment: "production"
   # deploy-to-development:
     # executor: docker-dotnet
     # steps:
@@ -167,11 +157,6 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "staging"
-  deploy-to-production:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: "production"
   deploy-to-mosaic-production:
     executor: docker-dotnet
     steps:
@@ -204,7 +189,7 @@ workflows:
           # filters:
             # branches:
               # only: development
-  check-and-deploy-staging-and-production:
+  check-and-deploy-staging-and-mosaic-production:
       jobs:
       - build-and-test:
           filters:
@@ -237,38 +222,10 @@ workflows:
               only:
                 - master
                 - development
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: master
-      - deploy-to-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: master
-  check-and-deploy-mosaic-production:
-      jobs:
-      - build-and-test:
-          filters:
-            branches:
-              only:
-                - master
-                - development
       - permit-mosaic-production-release:
           type: approval
           requires:
-            - build-and-test
+            - deploy-to-staging
           filters:
             branches:
               only: master

--- a/serverless.yml
+++ b/serverless.yml
@@ -146,12 +146,6 @@ custom:
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
-    production:
-      securityGroupIds:
-        - sg-00a35603faf7971ad
-      subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
     mosaic-prod:
       securityGroupIds:
         - sg-0d8739383f0960389
@@ -161,5 +155,4 @@ custom:
         - subnet-04c42d0aafb3738ad
   mongoDBImportBucket:
     staging: qlik-bucket-csv-to-postgres-staging
-    production: mosaic-social-care-csv-prod
     mosaic-prod: social-care-case-viewer-api-qlik-bucket-prod


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Now that we've switchover to use the service API in Mosaic-Production, we no longer need to deploy to ProductionAPIs.

### *What changes have we introduced*

This PR updates the CircleCI and Serverless config to remove deployment to ProductionAPIs. It means now we'll deploy to StagingAPIs -> Approval -> Mosaic-Production.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-36