### PR TITLE
fix(SCT-381): get 500 error searching for some workers

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -236,7 +236,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             var worker = TestHelpers.CreateWorker();
             var workerTeam = TestHelpers.CreateWorkerTeam(workerId: worker.Id);
-            var team = TestHelpers.CreateTeam(teamId: workerTeam.TeamId);
+            var team = TestHelpers.CreateTeam();
             worker.WorkerTeams = new List<WorkerTeam> { workerTeam };
 
             DatabaseContext.Workers.Add(worker);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -117,7 +117,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? contextFlag = null,
             string? createdBy = null,
             DateTime? createdAt = null,
-            bool isActive = true)
+            bool isActive = true,
+            bool hasAllocations = true,
+            bool hasWorkerTeams = true)
         {
             DateTime? start = null;
             if (isActive)
@@ -143,7 +145,27 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.DateStart, start)
                 .RuleFor(w => w.DateEnd, end)
                 .RuleFor(w => w.IsActive, f => isActive)
+                .RuleFor(w => w.Allocations, hasAllocations ? new List<AllocationSet> {CreateAllocation(), CreateAllocation(), CreateAllocation()} : null)
+                .RuleFor(w => w.WorkerTeams, hasWorkerTeams ? new List<WorkerTeam> {CreateWorkerTeam(), CreateWorkerTeam(), CreateWorkerTeam()} : null)
                 .RuleFor(w => w.LastModifiedBy, f => createdBy ?? f.Person.Email);
+        }
+
+        private static AllocationSet CreateAllocation(int? id = null, int? personId = null, int? workerId = null, int? teamId = null)
+        {
+
+            var caseStatusChoices = new List<string> {"open", "closed"};
+
+            return new Faker<AllocationSet>()
+                .RuleFor(a => a.Id, f => id ?? f.UniqueIndex + 1)
+                .RuleFor(a => a.PersonId, f => personId ?? f.UniqueIndex + 1)
+                .RuleFor(a => a.WorkerId, f => workerId ?? f.UniqueIndex + 1)
+                .RuleFor(a => a.TeamId, f => teamId ?? f.UniqueIndex + 1)
+                .RuleFor(a => a.AllocationStartDate, f => f.Date.Past())
+                .RuleFor(a => a.AllocationEndDate, f => f.Date.Past())
+                .RuleFor(a => a.CaseStatus, f => f.PickRandom(caseStatusChoices))
+                .RuleFor(a => a.CaseClosureDate, f => f.Date.Past());
+
+
         }
 
         public static InfrastructurePerson CreatePerson(int? personId = null)
@@ -281,10 +303,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             int? workerId = null
         )
         {
+            var team = CreateTeam();
+
             return new Faker<WorkerTeam>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex)
                 .RuleFor(t => t.WorkerId, f => workerId ?? f.UniqueIndex)
-                .RuleFor(t => t.TeamId, f => f.UniqueIndex);
+                .RuleFor(t => t.TeamId, f => f.UniqueIndex)
+                .RuleFor(t => t.Team, team);
         }
 
         private static WorkerTeamRequest CreateWorkerRequestWorkerTeam(

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -145,15 +145,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.DateStart, start)
                 .RuleFor(w => w.DateEnd, end)
                 .RuleFor(w => w.IsActive, f => isActive)
-                .RuleFor(w => w.Allocations, hasAllocations ? new List<AllocationSet> {CreateAllocation(), CreateAllocation(), CreateAllocation()} : null)
-                .RuleFor(w => w.WorkerTeams, hasWorkerTeams ? new List<WorkerTeam> {CreateWorkerTeam(), CreateWorkerTeam(), CreateWorkerTeam()} : null)
+                .RuleFor(w => w.Allocations, hasAllocations ? new List<AllocationSet> { CreateAllocation(), CreateAllocation(), CreateAllocation() } : null)
+                .RuleFor(w => w.WorkerTeams, hasWorkerTeams ? new List<WorkerTeam> { CreateWorkerTeam(), CreateWorkerTeam(), CreateWorkerTeam() } : null)
                 .RuleFor(w => w.LastModifiedBy, f => createdBy ?? f.Person.Email);
         }
 
         private static AllocationSet CreateAllocation(int? id = null, int? personId = null, int? workerId = null, int? teamId = null)
         {
 
-            var caseStatusChoices = new List<string> {"open", "closed"};
+            var caseStatusChoices = new List<string> { "open", "closed" };
 
             return new Faker<AllocationSet>()
                 .RuleFor(a => a.Id, f => id ?? f.UniqueIndex + 1)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -152,7 +152,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
         private static AllocationSet CreateAllocation(int? id = null, int? personId = null, int? workerId = null, int? teamId = null)
         {
-
             var caseStatusChoices = new List<string> { "open", "closed" };
 
             return new Faker<AllocationSet>()
@@ -160,10 +159,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(a => a.PersonId, f => personId ?? f.UniqueIndex + 1)
                 .RuleFor(a => a.WorkerId, f => workerId ?? f.UniqueIndex + 1)
                 .RuleFor(a => a.TeamId, f => teamId ?? f.UniqueIndex + 1)
-                .RuleFor(a => a.AllocationStartDate, f => f.Date.Past())
-                .RuleFor(a => a.AllocationEndDate, f => f.Date.Past())
+                .RuleFor(a => a.AllocationStartDate, f => f.Date.Past().ToUniversalTime())
+                .RuleFor(a => a.AllocationEndDate, f => f.Date.Past().ToUniversalTime())
                 .RuleFor(a => a.CaseStatus, f => f.PickRandom(caseStatusChoices))
-                .RuleFor(a => a.CaseClosureDate, f => f.Date.Past());
+                .RuleFor(a => a.CaseClosureDate, f => f.Date.Past().ToUniversalTime());
 
 
         }
@@ -306,8 +305,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             var team = CreateTeam();
 
             return new Faker<WorkerTeam>()
-                .RuleFor(t => t.Id, f => f.UniqueIndex)
-                .RuleFor(t => t.WorkerId, f => workerId ?? f.UniqueIndex)
+                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
+                .RuleFor(t => t.WorkerId, f => workerId ?? f.UniqueIndex + 1)
                 .RuleFor(t => t.TeamId, f => f.UniqueIndex)
                 .RuleFor(t => t.Team, team);
         }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -74,8 +74,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 ContextFlag = worker.ContextFlag,
                 CreatedBy = worker.CreatedBy,
                 DateStart = worker.DateStart,
-                AllocationCount = worker?.Allocations == null ? 0 : worker.Allocations.Where(x => x.CaseStatus.ToUpper() == "OPEN").Count(),
-                Teams = includeTeamData ? worker.WorkerTeams?.Select(x => new Team() { Id = x.Team.Id, Name = x.Team.Name, Context = x.Team.Context }).ToList() : null,
+                AllocationCount = worker.Allocations?.Where(x => x.CaseStatus.ToUpper() == "OPEN").Count() ?? 0,
+                Teams = (includeTeamData ? worker.WorkerTeams?.Select(x => new Team() { Id = x.Team.Id, Name = x.Team.Name, Context = x.Team.Context }).ToList() : null) ?? new List<Team>()
             };
         }
 
@@ -170,7 +170,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         {
             return new dbPhoneNumber
             {
-                Number = number.Number.ToString(),
+                Number = number.Number,
                 Type = number.Type,
                 PersonId = personId,
                 CreatedBy = createdBy

--- a/SocialCareCaseViewerApi/V1/Infrastructure/Worker.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/Worker.cs
@@ -54,9 +54,9 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [Column("last_modified_at")] public DateTime? LastModifiedAt { get; set; }
 
         //nav props
-        public ICollection<WorkerTeam> WorkerTeams { get; set; } = null!;
+        public ICollection<WorkerTeam>? WorkerTeams { get; set; }
 
-        public ICollection<AllocationSet> Allocations { get; set; } = null!;
+        public ICollection<AllocationSet>? Allocations { get; set; }
 
         public Worker ShallowCopy()
         {


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-381)

## Describe this PR

### *What is the problem we're trying to solve*

Trying to get the details of certain workers is failing, this is probably due to poor null handling in the case of WorkerTeams or Allocations.

### *What changes have we introduced*

We have introduced better null handling checks and tested the conversion of a Infrastructure Worker object to a Domain Worker object when the teams or allocations are null.

The changes that fix the bug are in the EntityFactory.cs where we now handle null better. 
Change to Worker.cs is to signal that WorkerTeams and Allocations may be null.
Other changes are to tidy up our tests.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Confirm the changes don't also require us to update the schema.sql file and do a manual update of the database too!
We just need to confirm this in staging environment before deploying anything, if we can create and get a worker it is fine basically.
