### PR TITLE
Remove temp remove Lambda workflow in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,27 +98,6 @@ commands:
           name: Deploy lambda
           command: |
             sls deploy --stage <<parameters.stage>> --conceal
-  remove-lambda:
-    description: "Removes API and lambdas via Serverless"
-    parameters:
-      stage:
-        type: string
-    steps:
-      - *attach_workspace
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
-            apt-get update && apt-get install -y nodejs
-      - run:
-          name: Install serverless CLI
-          command: npm i -g serverless
-      - run:
-          name: Remove lambda
-          command: |
-            sls remove --stage <<parameters.stage>>
 
 jobs:
   check-code-formatting:
@@ -158,11 +137,6 @@ jobs:
     steps:
       - assume-role-and-persist-workspace-mosaic-production:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  assume-role-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_PRODUCTION
   # terraform-init-and-apply-to-development:
     # executor: docker-terraform
     # steps:
@@ -188,24 +162,8 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "mosaic-prod"
-  remove-lambda-in-production:
-    executor: docker-dotnet
-    steps:
-      - remove-lambda:
-          stage: "production"
 
 workflows:
-  remove-lambda-in-production:
-    jobs:
-      - assume-role-production:
-          context: api-assume-role-production-context
-          filters:
-            branches:
-              only:
-                - development
-      - remove-lambda-in-production:
-          requires:
-            - assume-role-production
   check-and-deploy-development:
     jobs:
       - check-code-formatting

--- a/serverless.yml
+++ b/serverless.yml
@@ -153,13 +153,6 @@ custom:
       subnetIds:
         - subnet-0c39cd286eeaff2b2
         - subnet-04c42d0aafb3738ad
-    production:
-      securityGroupIds:
-        - sg-00a35603faf7971ad
-      subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
   mongoDBImportBucket:
     staging: qlik-bucket-csv-to-postgres-staging
     mosaic-prod: social-care-case-viewer-api-qlik-bucket-prod
-    production: mosaic-social-care-csv-prod


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

When we switched over to use the service API in Mosaic-Production, we left behind resources in the ProductionAPIs account for service API which needs to be removed.

In #284, we added a temporary workflow to remove the Lambdas in ProductionAPIs. 

### *What changes have we introduced*

This PR removes the temporary workflow as we've now run it and it has done its job!

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-389
