### PR TITLE
feature(SCT-416): patch endpoint for editing answers

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateFormSubmissionAnswersRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateFormSubmissionAnswersRequestTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
+{
+    [TestFixture]
+    public class UpdateFormSubmissionAnswersRequestTests
+    {
+        [Test]
+        public void UpdateFormSubmissionAnswersRequestReturnsIsNotValidForInvalidRequest()
+        {
+            var badRequests = new List<(UpdateFormSubmissionAnswersRequest, string)>
+            {
+                (TestHelpers.CreateUpdateFormSubmissionAnswersRequest(editedBy: "invalid_email"), "Provide a valid email address for who edited the submission")
+            };
+
+            var validator = new UpdateFormSubmissionAnswersValidator();
+
+            foreach (var (request, errorMessage) in badRequests)
+            {
+                var validationResponse = validator.Validate(request);
+
+                if (validationResponse == null)
+                {
+                    throw new NullReferenceException();
+                }
+
+                validationResponse.Should().NotBeNull();
+                validationResponse.IsValid.Should().Be(false);
+                validationResponse.ToString().Should().Be(errorMessage);
+            }
+
+        }
+
+        [Test]
+        public void UpdateWorkerReturnsIsValidForValidRequest()
+        {
+            var request = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
+            var validator = new UpdateFormSubmissionAnswersValidator();
+
+            var validationResponse = validator.Validate(request);
+
+            validationResponse.Should().NotBeNull();
+            validationResponse.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateWorkerRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateWorkerRequestTests.cs
@@ -48,11 +48,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             {
                 var validationResponse = validator.Validate(request);
 
-                if (validationResponse == null)
-                {
-                    throw new NullReferenceException();
-                }
-
                 validationResponse.Should().NotBeNull();
                 validationResponse.IsValid.Should().Be(false);
                 validationResponse.ToString().Should().Be(errorMessage);
@@ -68,10 +63,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 
             var validationResponse = validator.Validate(request);
 
-            if (validationResponse == null)
-            {
-                throw new NullReferenceException();
-            }
             validationResponse.Should().NotBeNull();
             validationResponse.IsValid.Should().Be(true);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
@@ -104,5 +104,54 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             response.Should().NotBeNull();
             response?.StatusCode.Should().Be(404);
         }
+
+        [Test]
+        public void EditSubmissionAnswersReturns200AndUpdatedResponse()
+        {
+            var createdSubmission = TestHelpers.CreateCaseSubmission().ToDomain().ToResponse();
+            const string stepId = "1";
+            var updateFormSubmissionAnswersRequest = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
+            _submissionsUseCaseMock.Setup(x => x.UpdateAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest)).Returns(createdSubmission);
+
+            var response = _formSubmissionController.EditSubmissionAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(createdSubmission);
+        }
+
+        [Test]
+        public void EditSubmissionAnswersReturns422WhenGetSubmissionExceptionThrown()
+        {
+            var createdSubmission = TestHelpers.CreateCaseSubmission();
+            const string errorMessage = "Failed to find submission";
+            var updateFormSubmissionAnswersRequest = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
+            const string stepId = "1";
+            _submissionsUseCaseMock.Setup(x => x.UpdateAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest))
+                .Throws(new GetSubmissionException(errorMessage));
+
+            var response = _formSubmissionController.EditSubmissionAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response?.StatusCode.Should().Be(422);
+            response?.Value.Should().Be(errorMessage);
+        }
+
+        [Test]
+        public void EditSubmissionAnswersReturns422WhenGetWorkerNotFoundExceptionThrown()
+        {
+            var createdSubmission = TestHelpers.CreateCaseSubmission();
+            const string errorMessage = "Failed to find worker";
+            var updateFormSubmissionAnswersRequest = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
+            const string stepId = "1";
+            _submissionsUseCaseMock.Setup(x => x.UpdateAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest))
+                .Throws(new WorkerNotFoundException(errorMessage));
+
+            var response = _formSubmissionController.EditSubmissionAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response?.StatusCode.Should().Be(422);
+            response?.Value.Should().Be(errorMessage);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
@@ -121,6 +121,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
+        public void EditSubmissionAnswersReturns400WhenGivenInvalidRequest()
+        {
+            var createdSubmission = TestHelpers.CreateCaseSubmission().ToDomain().ToResponse();
+            const string stepId = "1";
+            var updateFormSubmissionAnswersRequest = TestHelpers.CreateUpdateFormSubmissionAnswersRequest(editedBy: "not_a_valid_email");
+            _submissionsUseCaseMock.Setup(x => x.UpdateAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest)).Returns(createdSubmission);
+
+            var response = _formSubmissionController.EditSubmissionAnswers(createdSubmission.SubmissionId, stepId, updateFormSubmissionAnswersRequest) as ObjectResult;
+
+            response.Should().NotBeNull();
+            response?.StatusCode.Should().Be(400);
+        }
+
+        [Test]
         public void EditSubmissionAnswersReturns422WhenGetSubmissionExceptionThrown()
         {
             var createdSubmission = TestHelpers.CreateCaseSubmission();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bogus;
-using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
@@ -10,7 +9,6 @@ using SocialCareCaseViewerApi.V1.Infrastructure;
 using Address = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using CaseSubmission = SocialCareCaseViewerApi.V1.Infrastructure.CaseSubmission;
 using InfrastructurePerson = SocialCareCaseViewerApi.V1.Infrastructure.Person;
-using Person = Bogus.Person;
 using PhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
 using Team = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
@@ -542,7 +540,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                     new EditHistory<Worker>{ Worker = worker,  EditTime = dateTime ?? f.Date.Recent() }
                 })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? f.PickRandom(submissionStates))
-                .RuleFor(s => s.FormAnswers, new Dictionary<string, Dictionary<string, string[]>>());
+                .RuleFor(s => s.FormAnswers, new Dictionary<string, Dictionary<string, object>>());
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -502,6 +502,21 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.CreatedBy, f => createdBy ?? f.Person.Email);
         }
 
+        public static UpdateFormSubmissionAnswersRequest CreateUpdateFormSubmissionAnswersRequest(string? editedBy = null, Dictionary<string, object>? stepAnswers = null)
+        {
+            stepAnswers ??= new Dictionary<string, object>
+            {
+                {"1", "Value One"},
+                {"2", new List<string>{"Value Two"}},
+                {"3", new List<Dictionary<string, string>> {new Dictionary<string, string> {{"3.1", "Value Three"}}}},
+                {"4", new List<Dictionary<string, List<string>>> {new Dictionary<string, List<string>> {{"4.1", new List<string>{"Value Four"}}}}}
+            };
+
+            return new Faker<UpdateFormSubmissionAnswersRequest>()
+                .RuleFor(u => u.EditedBy, f => editedBy ?? f.Person.Email)
+                .RuleFor(u => u.StepAnswers, stepAnswers);
+        }
+
         public static CaseSubmission CreateCaseSubmission(SubmissionState? submissionState = null,
             DateTime? dateTime = null,
             Worker? worker = null,

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -145,7 +145,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.CreatedAt, f => createdAt ?? f.Date.Soon())
                 .RuleFor(w => w.DateStart, start)
                 .RuleFor(w => w.DateEnd, end)
-                .RuleFor(w => w.IsActive, f => isActive)
+                .RuleFor(w => w.IsActive, isActive)
                 .RuleFor(w => w.Allocations, hasAllocations ? new List<AllocationSet> { CreateAllocation(), CreateAllocation(), CreateAllocation() } : null)
                 .RuleFor(w => w.WorkerTeams, hasWorkerTeams ? new List<WorkerTeam> { CreateWorkerTeam(), CreateWorkerTeam(), CreateWorkerTeam() } : null)
                 .RuleFor(w => w.LastModifiedBy, f => createdBy ?? f.Person.Email);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -120,7 +120,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockDatabaseGateway.Verify(x => x.GetWorkerByEmail(request.EditedBy), Times.Once);
             _mockMongoGateway.Verify(x => x.LoadRecordById<CaseSubmission>(CollectionName, createdSubmission.SubmissionId), Times.Once);
-            _mockMongoGateway.Verify(x => x.UpsertRecord<CaseSubmission>(CollectionName, createdSubmission.SubmissionId, It.IsAny<CaseSubmission>()), Times.Once);
+            _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, createdSubmission.SubmissionId, It.IsAny<CaseSubmission>()), Times.Once);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -124,7 +124,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void UpdateAnswersThrowsWorkerNotFoundExceptionWhenNoWorkerFoundFromRequest()
+        public void UpdateAnswersThrowsGetSubmissionExceptionWhenNoSubmissionFoundFromRequest()
         {
             var request = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
             var createdSubmission = TestHelpers.CreateCaseSubmission();
@@ -140,7 +140,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void UpdateAnswersThrowsGetSubmissionExceptionWhenNoSubmissionFoundFromRequest()
+        public void UpdateAnswersThrowsWorkerNotFoundExceptionWhenNoWorkerFoundFromRequest()
         {
             var request = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
             var createdSubmission = TestHelpers.CreateCaseSubmission();

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -125,6 +125,8 @@ namespace SocialCareCaseViewerApi
             services.AddTransient<IValidator<CreateTeamRequest>, CreateTeamRequestValidator>();
             services.AddTransient<IValidator<GetTeamsRequest>, GetTeamsRequestValidator>();
             services.AddTransient<IValidator<CreateCaseSubmissionRequest>, CreateCaseSubmissionRequestValidator>();
+            services
+                .AddTransient<IValidator<UpdateFormSubmissionAnswersRequest>, UpdateFormSubmissionAnswersValidator>();
         }
 
         private static void ConfigureDbContext(IServiceCollection services)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+
+#nullable enable
+namespace SocialCareCaseViewerApi.V1.Boundary.Requests
+{
+    public class UpdateFormSubmissionAnswersRequest
+    {
+        [FromBody]
+        [JsonPropertyName("editedBy")]
+        public string EditedBy { get; set; } = null!;
+
+        [FromBody]
+        [JsonPropertyName("stepAnswers")]
+        public object StepAnswers { get; set; } = null!;
+    }
+
+    public class UpdateFormSubmissionAnswersValidator : AbstractValidator<UpdateFormSubmissionAnswersRequest>
+    {
+        public UpdateFormSubmissionAnswersValidator()
+        {
+            RuleFor(u => u.EditedBy)
+                .NotNull().WithMessage("Provide who edited the submission")
+                .EmailAddress().WithMessage("Provide a valid email address for who edited the submission");
+            RuleFor(u => u.StepAnswers)
+                .NotNull().WithMessage("Provide form answers");
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +15,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromBody]
         [JsonPropertyName("stepAnswers")]
-        public object StepAnswers { get; set; } = null!;
+        public Dictionary<string, object>
+        StepAnswers { get; set; } = null!;
     }
 
     public class UpdateFormSubmissionAnswersValidator : AbstractValidator<UpdateFormSubmissionAnswersRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -16,8 +16,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [FromBody]
         [JsonPropertyName("stepAnswers")]
         public Dictionary<string, object>
-        StepAnswers
-        { get; set; } = null!;
+        StepAnswers { get; set; } = null!;
     }
 
     public class UpdateFormSubmissionAnswersValidator : AbstractValidator<UpdateFormSubmissionAnswersRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -16,7 +16,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [FromBody]
         [JsonPropertyName("stepAnswers")]
         public Dictionary<string, object>
-        StepAnswers { get; set; } = null!;
+        StepAnswers
+        { get; set; } = null!;
     }
 
     public class UpdateFormSubmissionAnswersValidator : AbstractValidator<UpdateFormSubmissionAnswersRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -16,8 +16,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset key represents step id for form, inner hashset key represents questionId, answer values stored as string[]
-        public Dictionary<string, Dictionary<string, string[]>> FormAnswers { get; set; } = null!;
+        // outer hashset int represents step id for form, inner hashset int represents questionId
+        // object represents answer as either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
 
         public override int GetHashCode()
         {

--- a/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
@@ -74,5 +74,37 @@ namespace SocialCareCaseViewerApi.V1.Controllers
                 return UnprocessableEntity(e.Message);
             }
         }
+
+        /// <summary>
+        /// Edit answers for a submission
+        /// </summary>
+        /// <param name="submissionId">Get the related submission by unique ID</param>
+        /// <param name="stepId">Get the correct step on the form answers to update</param>
+        /// <param name="request">Contains Edited By - email for worker doing the edit, StepAnswers - new answers to be saved for Form Submission</param>
+        /// <response code="201">Case submission created successfully</response>
+        /// <response code="400">Invalid CreateCaseSubmissionRequest received</response>
+        /// <response code="422">Could not process request</response>
+        [ProducesResponseType(typeof(CaseSubmissionResponse), StatusCodes.Status200OK)]
+        [HttpPatch]
+        [Route("{submissionId:Guid}/steps/{stepId}")]
+        public IActionResult EditSubmissionAnswers(Guid submissionId, string stepId, [FromBody] UpdateFormSubmissionAnswersRequest request)
+        {
+            var validator = new UpdateFormSubmissionAnswersValidator();
+            var validationResults = validator.Validate(request);
+
+            if (!validationResults.IsValid)
+            {
+                return BadRequest(validationResults.ToString());
+            }
+
+            try
+            {
+                return Ok(_formSubmissionsUseCase.UpdateAnswers(submissionId, stepId, request));
+            }
+            catch(GetSubmissionException)
+            {
+                return BadRequest();
+            }
+        }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
@@ -101,9 +101,13 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             {
                 return Ok(_formSubmissionsUseCase.UpdateAnswers(submissionId, stepId, request));
             }
-            catch(GetSubmissionException)
+            catch (GetSubmissionException e)
             {
-                return BadRequest();
+                return UnprocessableEntity(e.Message);
+            }
+            catch (WorkerNotFoundException e)
+            {
+                return UnprocessableEntity(e.Message);
             }
         }
     }

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -17,8 +17,9 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset key represents step id for form, inner hashset key represents questionId, answer values stored as string[]
-        public Dictionary<string, Dictionary<string, string[]>> FormAnswers { get; set; } = null!;
+        // outer hashset int represents step id for form, inner hashset int represents questionId
+        // object represents answer as either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
     }
 }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
@@ -12,7 +12,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public MongoGateway()
         {
-            string mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+            string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
+                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
                                            @"mongodb://localhost:1433/";
 
             string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
@@ -19,8 +19,9 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset int represents step id for form, inner hashset int represents questionId, answer values stored as string[]
-        public Dictionary<string, Dictionary<string, string[]>> FormAnswers { get; set; } = null!;
+        // outer hashset int represents step id for form, inner hashset int represents questionId
+        // object represents answer as either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
     }
 
     public enum SubmissionState

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -50,7 +50,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 CreatedBy = worker,
                 SubmissionState = SubmissionState.InProgress,
                 EditHistory = new List<EditHistory<Worker>> { new EditHistory<Worker> { Worker = worker, EditTime = dateTimeNow } },
-                FormAnswers = new Dictionary<string, Dictionary<string, string[]>>()
+                FormAnswers = new Dictionary<string, Dictionary<string, object>>()
             };
 
             _mongoGateway.InsertRecord(CollectionName, caseSubmission);

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -64,7 +64,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             return foundSubmission?.ToDomain().ToResponse();
         }
-    }
 
+        public CaseSubmissionResponse UpdateAnswers(Guid submissionId, string stepId, UpdateFormSubmissionAnswersRequest request)
+        {
+            throw new NotImplementedException();
+        }
+    }
 
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -67,7 +67,22 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
         public CaseSubmissionResponse UpdateAnswers(Guid submissionId, string stepId, UpdateFormSubmissionAnswersRequest request)
         {
-            throw new NotImplementedException();
+            var worker = _databaseGateway.GetWorkerByEmail(request.EditedBy);
+            if (worker == null)
+            {
+                throw new WorkerNotFoundException($"Worker with email {request.EditedBy} not found");
+            }
+            worker.WorkerTeams = new List<WorkerTeam>();
+
+            var submission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, submissionId);
+            if (submission == null)
+            {
+                throw new GetSubmissionException($"Submission with ID {submissionId.ToString()} not found");
+            }
+
+            submission.FormAnswers[stepId] = request.StepAnswers;
+            _mongoGateway.UpsertRecord(CollectionName, submissionId, submission);
+            return submission.ToDomain().ToResponse();
         }
     }
 

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -81,6 +81,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             }
 
             submission.FormAnswers[stepId] = request.StepAnswers;
+            submission.EditHistory.Add(new EditHistory<Worker>
+            {
+                Worker = worker,
+                EditTime = DateTime.Now
+            });
             _mongoGateway.UpsertRecord(CollectionName, submissionId, submission);
             return submission.ToDomain().ToResponse();
         }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IFormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IFormSubmissionsUseCase.cs
@@ -10,5 +10,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
         (CaseSubmissionResponse, CaseSubmission) ExecutePost(CreateCaseSubmissionRequest request);
 
         CaseSubmissionResponse ExecuteGetById(Guid submissionId);
+
+        CaseSubmissionResponse UpdateAnswers(Guid submissionId, string stepId,
+            UpdateFormSubmissionAnswersRequest request);
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-416)

## Describe this PR

### *What is the problem we're trying to solve*

We want the ability to save a submission which means updating some of the answers stored against a form and the ability to later retrieve the form from that saved state.

### *What changes have we introduced*

Created a new API endpoint FormSubmissionController#EditSubmissionAnswers, takes form submission id and step (step is which part of the form you're on) as path parameters. From the body takes worker email who is doing the edit and also the dictionary object which represents the questions and their associated values for that part of the form.

FormSubmissionsUseCase#UpdateAnswers which validates the worker given and form to be updated are real (if not throw error and controller return bad request). Then update the answers and also update the EditHistory. Save update to database and return updated form.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
