### PR TITLE
Fix: Make worker allocations null when executing upon a submission endpoint

### DIFF
--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -30,7 +30,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             {
                 throw new WorkerNotFoundException($"Worker with email {request.CreatedBy} not found");
             }
-            worker.WorkerTeams = new List<WorkerTeam>();
+            worker.WorkerTeams = null;
+            worker.Allocations = null;
 
             var resident = _databaseGateway.GetPersonByMosaicId(request.ResidentId);
             if (resident == null)
@@ -73,6 +74,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 throw new WorkerNotFoundException($"Worker with email {request.CreatedBy} not found");
             }
             worker.WorkerTeams = null;
+            worker.Allocations = null;
 
             var updateSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, submissionId);
             if (updateSubmission == null)
@@ -94,7 +96,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             {
                 throw new WorkerNotFoundException($"Worker with email {request.EditedBy} not found");
             }
-            worker.WorkerTeams = new List<WorkerTeam>();
+            worker.WorkerTeams = null;
+            worker.Allocations = null;
 
             var submission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, submissionId);
             if (submission == null)


### PR DESCRIPTION
## Link to JIRA ticket


## Describe this PR

To avoid the circular reference exceptions some users with allocations receive when trying to create a new form submission, when a worker is retrieved from the database to be attached to the submission their allocations are set to null.
### *What changes have we introduced*
Both a workers `WorkerTeams` and `Allocations` properties are set to null before a submission is created/updated or finished

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
