### PR TITLE
Fix(SCT-508): Save the decision to disclose a warning note review

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1083,8 +1083,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             var warningNote = TestHelpers.CreateWarningNote();
             var firstReview = TestHelpers.CreateWarningNoteReview(warningNote.Id);
-            var secondReview = TestHelpers.CreateWarningNoteReview(warningNote.Id);
-            var thirdReview = TestHelpers.CreateWarningNoteReview(warningNote.Id);
+            var secondReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, true);
+            var thirdReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, false);
 
             DatabaseContext.WarningNotes.Add(warningNote);
             DatabaseContext.WarningNoteReview.Add(firstReview);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1083,8 +1083,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             var warningNote = TestHelpers.CreateWarningNote();
             var firstReview = TestHelpers.CreateWarningNoteReview(warningNote.Id);
-            var secondReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, true);
-            var thirdReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, false);
+            var secondReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, disclosedWithIndividual: true);
+            var thirdReview = TestHelpers.CreateWarningNoteReview(warningNote.Id, disclosedWithIndividual: false);
 
             DatabaseContext.WarningNotes.Add(warningNote);
             DatabaseContext.WarningNoteReview.Add(firstReview);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -976,6 +976,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             insertedRecord?.WarningNoteId.Should().Be(request.WarningNoteId);
             insertedRecord?.ReviewDate.Should().Be(request.ReviewDate);
+            insertedRecord?.DisclosedWithIndividual.Should().Be(request.DisclosedWithIndividual);
             insertedRecord?.ReviewNotes.Should().Be(request.ReviewNotes);
             insertedRecord?.ManagerName.Should().Be(request.ManagerName);
             insertedRecord?.DiscussedWithManagerDate.Should().Be(request.DiscussedWithManagerDate);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -378,7 +378,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(p => p.ReviewDate, f => reviewDate ?? f.Date.Recent())
                 .RuleFor(p => p.ReviewedBy, f => reviewedBy ?? worker.Email)
                 .RuleFor(p => p.NextReviewDate, f => nextReviewDate ?? f.Date.Future())
-                .RuleFor(p => p.DisclosedWithIndividual, f => disclosedWithIndividual ?? f.Random.Bool())
+                .RuleFor(p => p.DisclosedWithIndividual, f => disclosedWithIndividual)
                 .RuleFor(p => p.Status, f => requestStatus)
                 .RuleFor(p => p.EndedDate, f => endedDate ?? f.Date.Recent())
                 .RuleFor(p => p.EndedBy, f => endedBy ?? worker.Email)
@@ -415,13 +415,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(w => w.DateStart, f => dateStart ?? f.Date.Recent());
         }
 
-        public static WarningNoteReview CreateWarningNoteReview(long warningNoteId)
+        public static WarningNoteReview CreateWarningNoteReview(long warningNoteId, bool? disclosedWithIndividual = null)
         {
             return new Faker<WarningNoteReview>()
                 .RuleFor(r => r.Id, f => f.UniqueIndex)
                 .RuleFor(r => r.WarningNoteId, f => warningNoteId)
                 .RuleFor(r => r.ReviewDate, f => f.Date.Future())
-                .RuleFor(r => r.DisclosedWithIndividual, f => f.Random.Bool())
+                .RuleFor(r => r.DisclosedWithIndividual, f => disclosedWithIndividual)
                 .RuleFor(r => r.ReviewNotes, f => f.Random.String2(1, 50))
                 .RuleFor(r => r.ManagerName, f => f.Person.FullName)
                 .RuleFor(r => r.DiscussedWithManagerDate, f => f.Date.Past())

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -365,7 +365,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? endedBy = null,
             string? reviewNotes = null,
             string? managerName = null,
-            DateTime? discussedWithManagerDate = null
+            DateTime? discussedWithManagerDate = null,
+            bool? disclosedWithIndividual = null
         )
         {
             var person = CreatePerson();
@@ -377,6 +378,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(p => p.ReviewDate, f => reviewDate ?? f.Date.Recent())
                 .RuleFor(p => p.ReviewedBy, f => reviewedBy ?? worker.Email)
                 .RuleFor(p => p.NextReviewDate, f => nextReviewDate ?? f.Date.Future())
+                .RuleFor(p => p.DisclosedWithIndividual, f => disclosedWithIndividual ?? f.Random.Bool())
                 .RuleFor(p => p.Status, f => requestStatus)
                 .RuleFor(p => p.EndedDate, f => endedDate ?? f.Date.Recent())
                 .RuleFor(p => p.EndedBy, f => endedBy ?? worker.Email)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
@@ -16,7 +16,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public string ReviewNotes { get; set; }
         public string ManagerName { get; set; }
         public DateTime? DiscussedWithManagerDate { get; set; }
-        public bool DisclosedWithIndividual { get; set; }
+        public bool? DisclosedWithIndividual { get; set; }
     }
 
     public class PatchWarningNoteRequestValidator : AbstractValidator<PatchWarningNoteRequest>
@@ -29,9 +29,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(x => x.ReviewDate)
                 .NotNull().WithMessage("Review date required")
                 .LessThan(DateTime.Now).WithMessage("Review date must be in the past");
-            RuleFor(x => x.DisclosedWithIndividual)
-                .NotNull().WithMessage("Disclosed with individual must be either true or false")
-                .Must(x => x.Equals(true) || x.Equals(false));
             RuleFor(x => x.ReviewedBy)
                 .NotNull().WithMessage("Reviewer email required")
                 .EmailAddress().WithMessage("Provide a valid email address");

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
@@ -16,6 +16,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public string ReviewNotes { get; set; }
         public string ManagerName { get; set; }
         public DateTime? DiscussedWithManagerDate { get; set; }
+        public bool DisclosedWithIndividual { get; set; }
     }
 
     public class PatchWarningNoteRequestValidator : AbstractValidator<PatchWarningNoteRequest>
@@ -28,6 +29,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(x => x.ReviewDate)
                 .NotNull().WithMessage("Review date required")
                 .LessThan(DateTime.Now).WithMessage("Review date must be in the past");
+            RuleFor(x => x.DisclosedWithIndividual)
+                .NotNull().WithMessage("Disclosed with individual must be either true or false")
+                .Must(x => x.Equals(true) || x.Equals(false));
             RuleFor(x => x.ReviewedBy)
                 .NotNull().WithMessage("Reviewer email required")
                 .EmailAddress().WithMessage("Provide a valid email address");

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/WarningNoteResponse.cs
@@ -29,7 +29,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public long Id { get; set; }
         public long WarningNoteId { get; set; }
         public string ReviewDate { get; set; }
-        public bool DisclosedWithIndividual { get; set; }
+        public bool? DisclosedWithIndividual { get; set; }
         public string ReviewNotes { get; set; }
         public string ManagerName { get; set; }
         public string DiscussedWithManagerDate { get; set; }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -855,6 +855,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 WarningNoteId = request.WarningNoteId,
                 ReviewDate = request.ReviewDate,
                 ReviewNotes = request.ReviewNotes,
+                DisclosedWithIndividual = request.DisclosedWithIndividual,
                 ManagerName = request.ManagerName,
                 DiscussedWithManagerDate = request.DiscussedWithManagerDate,
                 CreatedBy = request.ReviewedBy,

--- a/SocialCareCaseViewerApi/V1/Infrastructure/WarningNoteReview.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/WarningNoteReview.cs
@@ -19,7 +19,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public DateTime? ReviewDate { get; set; }
 
         [Column("individual_notified")]
-        public bool DisclosedWithIndividual { get; set; }
+        public bool? DisclosedWithIndividual { get; set; }
 
         [Column("notes")]
         [MaxLength(1000)]


### PR DESCRIPTION
Previously, we were not retrieving nor saving a value for `DisclosedWithIndividual` on a warning note review.

In the frontend, a form element was added that would ask a user reviewing an ADULT warning note only, if they had disclosed the review to the individual.

When this form is submitted, the frontend would be making a PATCH request that would include a `DisclosedWithIndividual` value.

This change updates the service API to receive this updated request and process it.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test PATCH endpoint works and integrates with the frontend in Staging 