### PR TITLE
Bug(SCT-601): Saving form submission to mongo corrupts data

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -500,15 +500,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.CreatedBy, f => createdBy ?? f.Person.Email);
         }
 
-        public static UpdateFormSubmissionAnswersRequest CreateUpdateFormSubmissionAnswersRequest(string? editedBy = null, Dictionary<string, object>? stepAnswers = null)
+        public static UpdateFormSubmissionAnswersRequest CreateUpdateFormSubmissionAnswersRequest(string? editedBy = null, string? stepAnswers = null)
         {
-            stepAnswers ??= new Dictionary<string, object>
-            {
-                {"1", "Value One"},
-                {"2", new List<string>{"Value Two"}},
-                {"3", new List<Dictionary<string, string>> {new Dictionary<string, string> {{"3.1", "Value Three"}}}},
-                {"4", new List<Dictionary<string, List<string>>> {new Dictionary<string, List<string>> {{"4.1", new List<string>{"Value Four"}}}}}
-            };
+            stepAnswers ??= "{\"1\":\"one\"}";
 
             return new Faker<UpdateFormSubmissionAnswersRequest>()
                 .RuleFor(u => u.EditedBy, f => editedBy ?? f.Person.Email)
@@ -539,7 +533,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                     new EditHistory<Worker>{ Worker = worker,  EditTime = dateTime ?? f.Date.Recent() }
                 })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? f.PickRandom(submissionStates))
-                .RuleFor(s => s.FormAnswers, new Dictionary<string, Dictionary<string, object>>());
+                .RuleFor(s => s.FormAnswers, new Dictionary<string, string>());
         }
 
         public static FinishCaseSubmissionRequest FinishCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -15,7 +15,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromBody]
         [JsonPropertyName("stepAnswers")]
-        public Dictionary<string, object>
+        public string
         StepAnswers
         { get; set; } = null!;
     }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -16,9 +16,10 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset int represents step id for form, inner hashset int represents questionId
-        // object represents answer as either string, string[] or List<Dictionary<string,string>>
-        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
+        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
+        // either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, string> FormAnswers { get; set; } = null!;
 
         public override int GetHashCode()
         {

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -16,7 +16,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
         // either string, string[] or List<Dictionary<string,string>>
         public Dictionary<string, string> FormAnswers { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -17,9 +17,10 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset int represents step id for form, inner hashset int represents questionId
-        // object represents answer as either string, string[] or List<Dictionary<string,string>>
-        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
+        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
+        // either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, string> FormAnswers { get; set; } = null!;
     }
 }
 

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -17,7 +17,7 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
         // either string, string[] or List<Dictionary<string,string>>
         public Dictionary<string, string> FormAnswers { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
@@ -24,9 +24,10 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset int represents step id for form, inner hashset int represents questionId
-        // object represents answer as either string, string[] or List<Dictionary<string,string>>
-        public Dictionary<string, Dictionary<string, object>> FormAnswers { get; set; } = null!;
+        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
+        // either string, string[] or List<Dictionary<string,string>>
+        public Dictionary<string, string> FormAnswers { get; set; } = null!;
     }
 
     public enum SubmissionState

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
@@ -24,7 +24,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
 
-        // outer hashset string represents step id for form, inner hashset int represents questionId
+        // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
         // either string, string[] or List<Dictionary<string,string>>
         public Dictionary<string, string> FormAnswers { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -51,7 +51,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 CreatedBy = worker,
                 SubmissionState = SubmissionState.InProgress,
                 EditHistory = new List<EditHistory<Worker>> { new EditHistory<Worker> { Worker = worker, EditTime = dateTimeNow } },
-                FormAnswers = new Dictionary<string, Dictionary<string, object>>()
+                FormAnswers = new Dictionary<string, string>()
             };
 
             _mongoGateway.InsertRecord(CollectionName, caseSubmission);


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-601)

## Describe this PR

### *What is the problem we're trying to solve*

Ability to patch FormAnswers and then retrieve the form after.

### *What changes have we introduced*

Store question and answers for a whole step as string (json string)

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Amend frontend as it now needs to parse the JSON response type.
