### PR TITLE
Refactor(): Make SubmissionState API response more (human) readable

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -282,7 +282,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
                 }).ToList(),
-                SubmissionState = "in-progress",
+                SubmissionState = "In progress",
                 FormAnswers = databaseCaseSubmission1.FormAnswers
             };
 
@@ -300,7 +300,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
                 }).ToList(),
-                SubmissionState = "submitted",
+                SubmissionState = "Submitted",
                 FormAnswers = databaseCaseSubmission2.FormAnswers
             };
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -268,26 +268,44 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void CanMapCaseSubmissionFromDatabaseObjectToDomainObject()
         {
-            var databaseCaseSubmission = TestHelpers.CreateCaseSubmission();
-
-            var domainCaseSubmission = new DomainCaseSubmission()
+            var databaseCaseSubmission1 = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
+            var domainCaseSubmission1 = new DomainCaseSubmission()
             {
-                SubmissionId = databaseCaseSubmission.SubmissionId,
-                FormId = databaseCaseSubmission.FormId,
-                Residents = databaseCaseSubmission.Residents,
-                Workers = databaseCaseSubmission.Workers.Select(w => w.ToDomain(false)).ToList(),
-                CreatedAt = databaseCaseSubmission.CreatedAt,
-                CreatedBy = databaseCaseSubmission.CreatedBy.ToDomain(false),
-                EditHistory = databaseCaseSubmission.EditHistory.Select(e => new EditHistory<Worker>
+                SubmissionId = databaseCaseSubmission1.SubmissionId,
+                FormId = databaseCaseSubmission1.FormId,
+                Residents = databaseCaseSubmission1.Residents,
+                Workers = databaseCaseSubmission1.Workers.Select(w => w.ToDomain(false)).ToList(),
+                CreatedAt = databaseCaseSubmission1.CreatedAt,
+                CreatedBy = databaseCaseSubmission1.CreatedBy.ToDomain(false),
+                EditHistory = databaseCaseSubmission1.EditHistory.Select(e => new EditHistory<Worker>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
                 }).ToList(),
-                SubmissionState = databaseCaseSubmission.SubmissionState,
-                FormAnswers = databaseCaseSubmission.FormAnswers,
+                SubmissionState = "in-progress",
+                FormAnswers = databaseCaseSubmission1.FormAnswers
             };
 
-            databaseCaseSubmission.ToDomain().Should().BeEquivalentTo(domainCaseSubmission);
+            var databaseCaseSubmission2 = TestHelpers.CreateCaseSubmission(SubmissionState.Submitted);
+            var domainCaseSubmission2 = new DomainCaseSubmission()
+            {
+                SubmissionId = databaseCaseSubmission2.SubmissionId,
+                FormId = databaseCaseSubmission2.FormId,
+                Residents = databaseCaseSubmission2.Residents,
+                Workers = databaseCaseSubmission2.Workers.Select(w => w.ToDomain(false)).ToList(),
+                CreatedAt = databaseCaseSubmission2.CreatedAt,
+                CreatedBy = databaseCaseSubmission2.CreatedBy.ToDomain(false),
+                EditHistory = databaseCaseSubmission2.EditHistory.Select(e => new EditHistory<Worker>
+                {
+                    EditTime = e.EditTime,
+                    Worker = e.Worker.ToDomain(false)
+                }).ToList(),
+                SubmissionState = "submitted",
+                FormAnswers = databaseCaseSubmission2.FormAnswers
+            };
+
+            databaseCaseSubmission1.ToDomain().Should().BeEquivalentTo(domainCaseSubmission1);
+            databaseCaseSubmission2.ToDomain().Should().BeEquivalentTo(domainCaseSubmission2);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -14,7 +14,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<Person> Residents { get; set; } = null!;
         public List<WorkerResponse> Workers { get; set; } = null!;
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
-        public SubmissionState SubmissionState { get; set; }
+        public string SubmissionState { get; set; } = null!;
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -15,7 +15,7 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<Person> Residents { get; set; } = null!;
         public List<Worker> Workers { get; set; } = null!;
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
-        public SubmissionState SubmissionState { get; set; }
+        public string SubmissionState { get; set; } = null!;
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -146,6 +146,11 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission)
         {
+            var mapSubmissionStateToString = new Dictionary<SubmissionState, string> {
+                { SubmissionState.InProgress, "in-progress" },
+                { SubmissionState.Submitted, "submitted" }
+            };
+
             return new Domain.CaseSubmission
             {
                 SubmissionId = caseSubmission.SubmissionId,
@@ -159,7 +164,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
                 }).ToList(),
-                SubmissionState = caseSubmission.SubmissionState,
+                SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
                 FormAnswers = caseSubmission.FormAnswers
             };
         }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -147,8 +147,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
         public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission)
         {
             var mapSubmissionStateToString = new Dictionary<SubmissionState, string> {
-                { SubmissionState.InProgress, "in-progress" },
-                { SubmissionState.Submitted, "submitted" }
+                { SubmissionState.InProgress, "In progress" },
+                { SubmissionState.Submitted, "Submitted" }
             };
 
             return new Domain.CaseSubmission


### PR DESCRIPTION
## Link to JIRA ticket

No ticket required, small change to make response nicer from API.

## Describe this PR

### *What is the problem we're trying to solve*

We store SubmissionState of a CaseSubmission in an enum which is logical, however we want a nicer human readable output instead of ints. Simply map enum value to appropriate string.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
