### PR TITLE
docs(SCT-585): remove ON DELETE CASCADE for personal relationship details table

### DIFF
--- a/database/manual-updates/2021-06-14_1-add-personal-relationships-tables.md
+++ b/database/manual-updates/2021-06-14_1-add-personal-relationships-tables.md
@@ -61,7 +61,6 @@ CREATE TABLE IF NOT EXISTS dbo.sccv_personal_relationship_detail (
     CONSTRAINT fk_personal_relationship
         FOREIGN KEY(fk_personal_relationship_id)
         REFERENCES dbo.sccv_personal_relationship(id)
-        ON DELETE CASCADE
 );
 ```
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -426,7 +426,6 @@ CREATE TABLE IF NOT EXISTS dbo.sccv_personal_relationship_detail (
     CONSTRAINT fk_personal_relationship
         FOREIGN KEY(fk_personal_relationship_id)
         REFERENCES dbo.sccv_personal_relationship(id)
-        ON DELETE CASCADE
 );
 
 -- add personal relationship types


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-585

## Describe this PR

### *What is the problem we're trying to solve*

We don't want `ON DELETE CASCADE` to be enable for the `dbo.sccv_personal_relationship_detail` table.

### *What changes have we introduced*

This PR removes it from the manual update and the `schema.sql` file.