### PR TITLE
Feature(SCT-459): supplement cases api return completed case submissions

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/CaseControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/CaseControllerTests.cs
@@ -66,7 +66,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var careCaseDataList = _fixture.Create<CareCaseDataList>();
             var listCasesRequest = new ListCasesRequest();
 
-            _mockProcessDataUseCase.Setup(x => x.Execute(listCasesRequest)).Returns(careCaseDataList);
+            _mockProcessDataUseCase.Setup(x => x.GetResidentCases(listCasesRequest)).Returns(careCaseDataList);
             var response = _caseController.GetCases(listCasesRequest) as OkObjectResult;
 
             response.Should().NotBeNull();
@@ -77,7 +77,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void ListCasesReturns404WhenNoCasesAreFound()
         {
-            _mockProcessDataUseCase.Setup(x => x.Execute(It.IsAny<ListCasesRequest>()))
+            _mockProcessDataUseCase.Setup(x => x.GetResidentCases(It.IsAny<ListCasesRequest>()))
                 .Throws(new DocumentNotFoundException("Document Not Found"));
 
             var response = _caseController.GetCases(new ListCasesRequest()) as ObjectResult;

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/CaseControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/CaseControllerTests.cs
@@ -50,14 +50,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void GetCaseByIdReturns404WhenNoCaseIsFound()
+        public void GetCaseByIdReturnsNotFoundWhenNullIsReturned()
         {
-            _mockProcessDataUseCase.Setup(x => x.Execute(It.IsAny<string>()))
-                .Throws(new DocumentNotFoundException("Document Not Found"));
+            _mockProcessDataUseCase.Setup(x => x.Execute(It.IsAny<string>()));
 
             var response = _caseController.GetCaseByRecordId("caseString") as ObjectResult;
 
-            response.Should().NotBeNull();
             response?.StatusCode.Should().Be(404);
             response?.Value.Should().Be("Document Not Found");
         }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MongoGatewayTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MongoGatewayTests.cs
@@ -124,11 +124,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
             _mongoGateway.InsertRecord("test-collection-name", new TestObjectForMongo { Property1 = _testObjectForMongo.Property1 });
 
-             var retrievedObject =
-                    _mongoGateway.LoadMultipleRecordsByProperty<TestObjectForMongo, string>(
-                        "test-collection-name", "Property1", _testObjectForMongo.Property1);
+            var retrievedObject =
+                   _mongoGateway.LoadMultipleRecordsByProperty<TestObjectForMongo, string>(
+                       "test-collection-name", "Property1", _testObjectForMongo.Property1);
 
-             retrievedObject?.Count.Should().Be(2);
+            retrievedObject?.Count.Should().Be(2);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MongoGatewayTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MongoGatewayTests.cs
@@ -3,6 +3,7 @@ using Bogus;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Gateways;
@@ -26,7 +27,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
     {
         private readonly IMongoGateway _mongoGateway = new MongoGateway();
         private readonly Faker _faker = new Faker();
-        private TestObjectForMongo? _testObjectForMongo;
+        private TestObjectForMongo _testObjectForMongo = null!;
 
         [SetUp]
         public void Setup()
@@ -64,13 +65,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void GettingANonExistentRecordReturnsNull()
         {
-            TestObjectForMongo? retrievedObject = null;
+            var retrievedObject =
+                _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
 
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
-                    _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
             retrievedObject.Should().BeNull();
         }
 
@@ -79,13 +76,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
 
-            TestObjectForMongo? retrievedObject = null;
+            var retrievedObject =
+                _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
 
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
-                    _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
             retrievedObject.Should().BeEquivalentTo(_testObjectForMongo);
         }
 
@@ -94,20 +87,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
 
-            List<TestObjectForMongo>? retrievedObject = null;
+            var retrievedObject = _mongoGateway.LoadRecords<TestObjectForMongo>("test-collection-name");
 
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject = _mongoGateway.LoadRecords<TestObjectForMongo>("test-collection-name");
-            }
             retrievedObject?.Count.Should().Be(1);
             retrievedObject?[0].Should().BeEquivalentTo(_testObjectForMongo);
 
             _mongoGateway.InsertRecord("test-collection-name", new TestObjectForMongo());
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject = _mongoGateway.LoadRecords<TestObjectForMongo>("test-collection-name");
-            }
+
+            retrievedObject = _mongoGateway.LoadRecords<TestObjectForMongo>("test-collection-name");
             retrievedObject?.Count.Should().Be(2);
         }
 
@@ -116,28 +103,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
 
-            TestObjectForMongo? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
-                    _mongoGateway.LoadRecordByProperty<TestObjectForMongo, string>(
+            var retrievedObject = _mongoGateway.LoadRecordByProperty<TestObjectForMongo, string>(
                         "test-collection-name", "Property1", _testObjectForMongo.Property1);
-            }
+
             retrievedObject.Should().BeEquivalentTo(_testObjectForMongo);
         }
 
         [Test]
         public void LoadRecordByCustomPropertyReturnsNullWhenNoMatchFound()
         {
-            TestObjectForMongo? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
-                    _mongoGateway.LoadRecordByProperty<TestObjectForMongo, string>(
+            var retrievedObject = _mongoGateway.LoadRecordByProperty<TestObjectForMongo, string>(
                         "test-collection-name", "Property1", _testObjectForMongo.Property1);
-            }
+
             retrievedObject.Should().BeNull();
         }
 
@@ -145,33 +122,22 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         public void CanLoadMultipleRecordsByACustomProperty()
         {
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
-            if (_testObjectForMongo != null)
-            {
-                _mongoGateway.InsertRecord("test-collection-name", new TestObjectForMongo { Property1 = _testObjectForMongo.Property1 });
-            }
+            _mongoGateway.InsertRecord("test-collection-name", new TestObjectForMongo { Property1 = _testObjectForMongo.Property1 });
 
-            List<TestObjectForMongo>? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
+             var retrievedObject =
                     _mongoGateway.LoadMultipleRecordsByProperty<TestObjectForMongo, string>(
                         "test-collection-name", "Property1", _testObjectForMongo.Property1);
-            }
-            retrievedObject?.Count.Should().Be(2);
+
+             retrievedObject?.Count.Should().Be(2);
         }
 
         [Test]
         public void LoadMultipleRecordsByCustomerPropertyWithNoMatchReturnsEmptyList()
         {
-            List<TestObjectForMongo>? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
+            var retrievedObject =
                     _mongoGateway.LoadMultipleRecordsByProperty<TestObjectForMongo, string>(
                             "test-collection-name", "Property1", _testObjectForMongo.Property1);
-            }
+
             retrievedObject?.Should().BeEmpty();
         }
 
@@ -180,65 +146,60 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
 
-            TestObjectForMongo? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
-                    _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
+            var retrievedObject = _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
             retrievedObject.Should().BeEquivalentTo(_testObjectForMongo);
 
-            if (_testObjectForMongo != null)
-            {
-                _mongoGateway.DeleteRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-                retrievedObject =
-                    _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
+            _mongoGateway.DeleteRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
+            retrievedObject = _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
             retrievedObject.Should().BeNull();
         }
 
         [Test]
         public void UpsertingARecordNotInTheDatabaseInserts()
         {
-            TestObjectForMongo? retrievedObject = null;
-
-            if (_testObjectForMongo != null)
-            {
-                _mongoGateway.UpsertRecord("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id), _testObjectForMongo);
-                retrievedObject =
+            _mongoGateway.UpsertRecord("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id), _testObjectForMongo);
+            var retrievedObject =
                     _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
             retrievedObject.Should().BeEquivalentTo(_testObjectForMongo);
         }
 
         [Test]
         public void UpsertingARecordInTheDatabaseUpdates()
         {
-            TestObjectForMongo? retrievedObject = null;
             _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
 
-            if (_testObjectForMongo != null)
-            {
-                retrievedObject =
+            var retrievedObject =
                     _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
             retrievedObject.Should().BeEquivalentTo(_testObjectForMongo);
 
-            if (_testObjectForMongo != null)
-            {
-                _testObjectForMongo.Property1 = "new-test-property";
-                _testObjectForMongo.Property2?.Add(new TestObjectForMongo());
-                _testObjectForMongo.Property3 = null;
 
-                _mongoGateway.UpsertRecord("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id), _testObjectForMongo);
-                retrievedObject =
-                    _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
-            }
+            _testObjectForMongo.Property1 = "new-test-property";
+            _testObjectForMongo.Property2?.Add(new TestObjectForMongo());
+            _testObjectForMongo.Property3 = null;
+
+            _mongoGateway.UpsertRecord("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id), _testObjectForMongo);
+            retrievedObject =
+                _mongoGateway.LoadRecordById<TestObjectForMongo>("test-collection-name", ObjectId.Parse(_testObjectForMongo.Id));
 
             retrievedObject?.Property1.Should().Be("new-test-property");
             retrievedObject?.Property2?.Count.Should().Be(2);
             retrievedObject?.Property3.Should().BeNull();
+        }
+
+        [Test]
+        public void CanLoadRecordsByFilter()
+        {
+            _mongoGateway.InsertRecord("test-collection-name", _testObjectForMongo);
+            var id = _testObjectForMongo.Property2?[0].Id;
+
+            var filter = Builders<TestObjectForMongo>
+                .Filter
+                .ElemMatch(x => x.Property2, y => y.Id == id);
+
+            var retrievedObject = _mongoGateway.LoadRecordsByFilter("test-collection-name", filter);
+
+            retrievedObject.Count.Should().Be(1);
+            retrievedObject[0].Should().BeEquivalentTo(_testObjectForMongo);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -515,11 +515,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             DateTime? dateTime = null,
             Worker? worker = null,
             InfrastructurePerson? resident = null,
+            int? residentId = null,
             string? id = null,
             string? formId = null)
         {
             worker ??= CreateWorker();
-            resident ??= CreatePerson();
+            resident ??= CreatePerson(residentId);
 
             var submissionStates = new List<SubmissionState> { SubmissionState.InProgress, SubmissionState.Submitted };
 
@@ -536,6 +537,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? f.PickRandom(submissionStates))
                 .RuleFor(s => s.FormAnswers, new Dictionary<string, string>());
+        }
+
+        public static ListCasesRequest CreateListCasesRequest(bool nullMosaicId = false)
+        {
+            return new Faker<ListCasesRequest>()
+                .RuleFor(r => r.MosaicId, f => nullMosaicId ? null : f.Random.Long(0, 100000).ToString());
         }
 
         public static FinishCaseSubmissionRequest FinishCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Driver;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Factories;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using SocialCareCaseViewerApi.V1.UseCase;
+
+#nullable enable
+namespace SocialCareCaseViewerApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class CaseRecordsUseCaseTests
+    {
+        private Mock<IProcessDataGateway> _mockProcessDataGateway = null!;
+        private Mock<IDatabaseGateway> _mockDatabaseGateWay = null!;
+        private Mock<IMongoGateway> _mockMongoGateway = null!;
+        private CaseRecordsUseCase _caseRecordsUseCase = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+            _mockDatabaseGateWay = new Mock<IDatabaseGateway>();
+            _mockMongoGateway = new Mock<IMongoGateway>();
+
+            _caseRecordsUseCase = new CaseRecordsUseCase(_mockProcessDataGateway.Object, _mockDatabaseGateWay.Object, _mockMongoGateway.Object);
+        }
+
+        [Test]
+        public void GetResidentCasesCallMongoGatewayAndReturnsResidentsSubmittedCases()
+        {
+            var request = TestHelpers.CreateListCasesRequest();
+
+            var expectedResponse = new List<CaseSubmission>
+            {
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
+                TestHelpers.CreateCaseSubmission(SubmissionState.InProgress, residentId: int.Parse(request.MosaicId ?? ""))
+            };
+
+            _mockDatabaseGateWay.Setup(x => x.GetNCReferenceByPersonId(request.MosaicId)).Returns(request.MosaicId ?? "");
+            _mockDatabaseGateWay.Setup(x => x.GetPersonIdByNCReference(request.MosaicId)).Returns(request.MosaicId ?? "");
+            _mockProcessDataGateway.Setup(x => x.GetProcessData(request, request.MosaicId)).Returns(
+                () => new Tuple<IEnumerable<CareCaseData>, int>(new List<CareCaseData>(), 0));
+            _mockMongoGateway
+                .Setup(x => x.LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
+                    It.IsAny<FilterDefinition<CaseSubmission>>()))
+                .Returns(expectedResponse);
+
+            var response = _caseRecordsUseCase.GetResidentCases(request);
+
+            response.Cases.Count.Should().Be(2);
+            response.Cases.Should().BeEquivalentTo(expectedResponse.Take(2).Select(x => x.ToCareCaseData(request)).ToList());
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -45,7 +45,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var (caseSubmissionResponse, caseSubmission) = _formSubmissionsUseCase.ExecutePost(request);
             var expectedResponse = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress,
-                caseSubmission.CreatedAt, worker, resident, caseSubmission.SubmissionId, request.FormId);
+                caseSubmission.CreatedAt, worker, resident, null, caseSubmission.SubmissionId, request.FormId);
             caseSubmissionResponse.SubmissionId = expectedResponse.SubmissionId ?? "0";
 
             caseSubmissionResponse.Should().BeEquivalentTo(expectedResponse.ToDomain().ToResponse());

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/ProcessDataUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/ProcessDataUseCaseTests.cs
@@ -12,15 +12,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
     {
         private Mock<IProcessDataGateway> _mockProcessDataGateway;
         private Mock<IDatabaseGateway> _mockDatabaseGateway;
+        private Mock<IMongoGateway> _mockMongoGateway;
         private CaseRecordsUseCase _classUnderTest;
-        private Fixture _fixture = new Fixture();
+        private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
         {
             _mockProcessDataGateway = new Mock<IProcessDataGateway>();
             _mockDatabaseGateway = new Mock<IDatabaseGateway>();
-            _classUnderTest = new CaseRecordsUseCase(_mockProcessDataGateway.Object, _mockDatabaseGateway.Object);
+            _mockMongoGateway = new Mock<IMongoGateway>();
+            _classUnderTest = new CaseRecordsUseCase(_mockProcessDataGateway.Object, _mockDatabaseGateway.Object, _mockMongoGateway.Object);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -37,9 +37,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public int Limit { get; set; } = 20;
 
         [FromQuery(Name = "sort_by")]
-        public string? SortBy { get; set; }
+        public string SortBy { get; set; } = null!;
 
         [FromQuery(Name = "order_by")]
-        public string? OrderBy { get; set; }
+        public string OrderBy { get; set; } = null!;
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -1,18 +1,15 @@
-using System;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class ListCasesRequest
     {
-        [FromQuery(Name = "record_id")]
-        public string RecordId { get; set; }
-
         [FromQuery(Name = "mosaic_id")]
         public string MosaicId { get; set; }
 
         [FromQuery(Name = "exact_name_match")]
-        public Boolean ExactNameMatch { get; set; } = false;
+        public bool ExactNameMatch { get; set; } = false;
+
         [FromQuery(Name = "first_name")]
         public string FirstName { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -1,32 +1,34 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class ListCasesRequest
     {
         [FromQuery(Name = "mosaic_id")]
-        public string MosaicId { get; set; }
+        public string? MosaicId { get; set; }
 
         [FromQuery(Name = "exact_name_match")]
         public bool ExactNameMatch { get; set; } = false;
 
         [FromQuery(Name = "first_name")]
-        public string FirstName { get; set; }
+        public string? FirstName { get; set; }
 
         [FromQuery(Name = "last_name")]
-        public string LastName { get; set; }
+        public string? LastName { get; set; }
 
         [FromQuery(Name = "worker_email")]
-        public string WorkerEmail { get; set; }
+        public string? WorkerEmail { get; set; }
 
         [FromQuery(Name = "form_name")]
-        public string FormName { get; set; }
+        public string? FormName { get; set; }
 
         [FromQuery(Name = "start_date")]
-        public string StartDate { get; set; }
+        public DateTime? StartDate { get; set; }
 
         [FromQuery(Name = "end_date")]
-        public string EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
 
         [FromQuery(Name = "cursor")]
         public int Cursor { get; set; } = 0;
@@ -35,9 +37,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public int Limit { get; set; } = 20;
 
         [FromQuery(Name = "sort_by")]
-        public string SortBy { get; set; }
+        public string? SortBy { get; set; }
 
         [FromQuery(Name = "order_by")]
-        public string OrderBy { get; set; }
+        public string? OrderBy { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseData.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseData.cs
@@ -1,5 +1,3 @@
-using System;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using SocialCareCaseViewerApi.V1.Infrastructure;
+using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
 
 #nullable enable
 namespace SocialCareCaseViewerApi.V1.Boundary.Response
@@ -11,6 +12,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public string FormId { get; set; } = null!;
         public WorkerResponse CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public WorkerResponse? SubmittedBy { get; set; }
+        public DateTime? SubmittedAt { get; set; }
         public List<Person> Residents { get; set; } = null!;
         public List<WorkerResponse> Workers { get; set; } = null!;
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -36,21 +34,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         {
             try
             {
-                string? dateValidationError = null;
-
-                if (!string.IsNullOrWhiteSpace(request?.StartDate) && !DateTime.TryParseExact(request.StartDate,
-                    "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime startDate))
-                {
-                    dateValidationError += "Invalid start date";
-                }
-
-                if (!string.IsNullOrWhiteSpace(request?.EndDate) && !DateTime.TryParseExact(request.EndDate,
-                    "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime endDate))
-                {
-                    dateValidationError += " Invalid end date";
-                }
-
-                return !string.IsNullOrEmpty(dateValidationError) ? StatusCode(400, dateValidationError) : Ok(_caseRecordsUseCase.Execute(request));
+                return Ok(_caseRecordsUseCase.Execute(request));
             }
             catch (DocumentNotFoundException e)
             {

--- a/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
@@ -34,7 +34,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         {
             try
             {
-                return Ok(_caseRecordsUseCase.Execute(request));
+                return Ok(_caseRecordsUseCase.GetResidentCases(request));
             }
             catch (DocumentNotFoundException e)
             {

--- a/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/CaseController.cs
@@ -52,14 +52,14 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("{caseId}")]
         public IActionResult GetCaseByRecordId(string caseId)
         {
-            try
+            var caseRecord = _caseRecordsUseCase.Execute(caseId);
+
+            if (caseRecord == null)
             {
-                return Ok(_caseRecordsUseCase.Execute(caseId));
+                return NotFound("Document Not Found");
             }
-            catch (DocumentNotFoundException e)
-            {
-                return NotFound(e.Message);
-            }
+
+            return Ok(caseRecord);
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -12,6 +12,8 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string FormId { get; set; } = null!;
         public Worker CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public Worker? SubmittedBy { get; set; }
+        public DateTime? SubmittedAt { get; set; }
         public List<Person> Residents { get; set; } = null!;
         public List<Worker> Workers { get; set; } = null!;
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -21,6 +21,7 @@ using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Factories
 {
     public static class EntityFactory
@@ -67,8 +68,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static Worker ToDomain(this DbWorker worker, bool includeTeamData)
         {
-            if (worker == null) return null;
-
             return new Worker
             {
                 Id = worker.Id,
@@ -104,7 +103,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             return teams.Select(t => t.ToDomain()).ToList();
         }
 
-        public static WarningNote ToDomain(this dbWarningNote dbWarningNote, List<WarningNoteReview> reviews = null)
+        public static WarningNote ToDomain(this dbWarningNote dbWarningNote, List<WarningNoteReview>? reviews = null)
         {
             return new WarningNote
             {
@@ -158,7 +157,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CreatedAt = caseSubmission.CreatedAt,
                 CreatedBy = caseSubmission.CreatedBy.ToDomain(false),
                 SubmittedAt = caseSubmission.SubmittedAt,
-                SubmittedBy = caseSubmission.SubmittedBy.ToDomain(false),
+                SubmittedBy = caseSubmission.SubmittedBy?.ToDomain(false),
                 EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
                 {
                     EditTime = e.EditTime,

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -66,6 +67,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static Worker ToDomain(this DbWorker worker, bool includeTeamData)
         {
+            if (worker == null) return null;
+
             return new Worker
             {
                 Id = worker.Id,
@@ -163,6 +166,26 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 }).ToList(),
                 SubmissionState = caseSubmission.SubmissionState,
                 FormAnswers = caseSubmission.FormAnswers
+            };
+        }
+
+        public static CareCaseData ToCareCaseData(this CaseSubmission caseSubmission, ListCasesRequest listCasesRequest)
+        {
+            var resident = caseSubmission.Residents
+                .First(x => x.Id == long.Parse(listCasesRequest.MosaicId ?? ""));
+
+            return new CareCaseData
+            {
+                RecordId = caseSubmission.SubmissionId,
+                PersonId = resident.Id,
+                FirstName = resident.FirstName,
+                LastName = resident.LastName,
+                OfficerEmail = caseSubmission.Workers[0].Email,
+                CaseFormTimestamp = caseSubmission.SubmittedAt?.ToString(CultureInfo.InvariantCulture) ?? new DateTime().ToString(CultureInfo.InvariantCulture),
+                FormName = caseSubmission.FormId,
+                DateOfBirth = resident.DateOfBirth.ToString(),
+                DateOfEvent = caseSubmission.CreatedAt.ToString(CultureInfo.InvariantCulture),
+                CaseFormUrl = caseSubmission.SubmissionId
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -154,6 +154,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Workers = caseSubmission.Workers.Select(w => w.ToDomain(false)).ToList(),
                 CreatedAt = caseSubmission.CreatedAt,
                 CreatedBy = caseSubmission.CreatedBy.ToDomain(false),
+                SubmittedAt = caseSubmission.SubmittedAt,
+                SubmittedBy = caseSubmission.SubmittedBy.ToDomain(false),
                 EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
                 {
                     EditTime = e.EditTime,

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -249,7 +249,9 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Workers = caseSubmission.Workers.Select(w => w.ToResponse()).ToList(),
                 CreatedAt = caseSubmission.CreatedAt,
                 CreatedBy = caseSubmission.CreatedBy.ToResponse(),
-                EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
+                SubmittedAt = caseSubmission.SubmittedAt,
+                SubmittedBy = caseSubmission.SubmittedBy.ToResponse(),
+                    EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToResponse()

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -252,7 +252,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CreatedBy = caseSubmission.CreatedBy.ToResponse(),
                 SubmittedAt = caseSubmission.SubmittedAt,
                 SubmittedBy = caseSubmission.SubmittedBy?.ToResponse(),
-                    EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
+                EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToResponse()

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -30,7 +30,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static List<CareCaseData> ToResponse(List<BsonDocument> submittedFormsData)
+        public static List<CareCaseData> ToResponse(this IEnumerable<BsonDocument> submittedFormsData)
         {
             return submittedFormsData.Select(x => x.ToResponse()).ToList();
         }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -112,6 +112,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static WorkerResponse ToResponse(this Domain.Worker worker)
         {
+            if (worker == null) return null;
+
             return new WorkerResponse
             {
                 Id = worker.Id,

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -13,6 +13,7 @@ using dbPhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
 using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Factories
 {
     public static class ResponseFactory
@@ -112,8 +113,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static WorkerResponse ToResponse(this Domain.Worker worker)
         {
-            if (worker == null) return null;
-
             return new WorkerResponse
             {
                 Id = worker.Id,
@@ -141,7 +140,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         public static GetPersonResponse ToResponse(Person person)
         {
             //get the current display address
-            dbAddress displayAddress = person?.Addresses?.FirstOrDefault(x => x.IsDisplayAddress?.ToUpper() == "Y");
+            var displayAddress = person.Addresses?.FirstOrDefault(x => x.IsDisplayAddress?.ToUpper() == "Y");
 
             return new GetPersonResponse()
             {
@@ -163,8 +162,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Restricted = person.Restricted,
                 Title = person.Title,
                 Address = displayAddress != null ? EntityFactory.DbAddressToAddressDomain(displayAddress) : null,
-                OtherNames = person.OtherNames?.Select(x => x.ToDomain())?.ToList(),
-                PhoneNumbers = person.PhoneNumbers?.Select(x => x.ToDomain())?.ToList()
+                OtherNames = person.OtherNames?.Select(x => x.ToDomain()).ToList(),
+                PhoneNumbers = person.PhoneNumbers?.Select(x => x.ToDomain()).ToList()
             };
         }
 
@@ -252,7 +251,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CreatedAt = caseSubmission.CreatedAt,
                 CreatedBy = caseSubmission.CreatedBy.ToResponse(),
                 SubmittedAt = caseSubmission.SubmittedAt,
-                SubmittedBy = caseSubmission.SubmittedBy.ToResponse(),
+                SubmittedBy = caseSubmission.SubmittedBy?.ToResponse(),
                     EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
                 {
                     EditTime = e.EditTime,

--- a/SocialCareCaseViewerApi/V1/Gateways/IMongoGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IMongoGateway.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using MongoDB.Bson;
+using MongoDB.Driver;
 
 namespace SocialCareCaseViewerApi.V1.Gateways
 {
@@ -14,5 +15,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public List<T1> LoadMultipleRecordsByProperty<T1, T2>(string collectionName, string propertyName,
             T2 propertyValue);
         public T1 LoadRecordByProperty<T1, T2>(string collectionName, string propertyName, T2 propertyValue);
+        public List<T1> LoadRecordsByFilter<T1>(string collectionName, FilterDefinition<T1> filter);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
@@ -12,7 +12,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
     {
         Tuple<IEnumerable<CareCaseData>, int> GetProcessData(ListCasesRequest request, string? ncId);
 
-        CareCaseData GetCaseById(string recordId);
+        CareCaseData? GetCaseById(string recordId);
 
         Task<string> InsertCaseNoteDocument(CaseNotesDocument caseNotesDoc);
         IOrderedEnumerable<CareCaseData> SortData(string sortBy, string orderBy, List<CareCaseData> response);

--- a/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
@@ -5,11 +5,12 @@ using System.Threading.Tasks;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Gateways
 {
     public interface IProcessDataGateway
     {
-        Tuple<IEnumerable<CareCaseData>, int> GetProcessData(ListCasesRequest request, string ncId);
+        Tuple<IEnumerable<CareCaseData>, int> GetProcessData(ListCasesRequest request, string? ncId);
 
         CareCaseData GetCaseById(string recordId);
 

--- a/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IProcessDataGateway.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -15,6 +14,5 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         CareCaseData? GetCaseById(string recordId);
 
         Task<string> InsertCaseNoteDocument(CaseNotesDocument caseNotesDoc);
-        IOrderedEnumerable<CareCaseData> SortData(string sortBy, string orderBy, List<CareCaseData> response);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
@@ -73,5 +73,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var filter = Builders<T1>.Filter.Eq(propertyName, propertyValue);
             return collection.Find(filter).FirstOrDefault();
         }
+
+        public List<T1> LoadRecordsByFilter<T1>(string collectionName, FilterDefinition<T1> filter)
+        {
+            var collection = _mongoDatabase.GetCollection<T1>(collectionName);
+            return collection.Find(filter).ToList();
+        }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
@@ -80,4 +80,18 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return collection.Find(filter).ToList();
         }
     }
+
+
+    public static class MongoConnectionStrings
+    {
+        public static readonly Dictionary<Collection, string> Map = new Dictionary<Collection, string>
+        {
+            {Collection.ResidentCaseSubmissions, "resident-case-submissions"}
+        };
+    }
+
+    public enum Collection
+    {
+        ResidentCaseSubmissions
+    }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -278,7 +278,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var query = collection.AsQueryable().Where(db => filter.Inject());
 
             var result = query.ToList();
-            if (result.FirstOrDefault() == null) throw new DocumentNotFoundException("Search did not return any results");
 
             var response = result.ToResponse().FirstOrDefault();
 

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -81,7 +81,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (request.StartDate != null)
             {
-                if (DateTime.TryParseExact(((DateTime)request.StartDate).ToString(CultureInfo.InvariantCulture), "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var startDate))
+                if (DateTime.TryParseExact(((DateTime) request.StartDate).ToString(CultureInfo.InvariantCulture), "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var startDate))
                 {
                     response = response
                         .Where(x =>

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -82,7 +82,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (request.StartDate != null)
             {
-                if (DateTime.TryParseExact(request.StartDate, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime startDate))
+                if (DateTime.TryParseExact(((DateTime)request.StartDate).ToString(CultureInfo.InvariantCulture), "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var startDate))
                 {
                     response = response
                         .Where(x =>
@@ -99,7 +99,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (request.EndDate != null)
             {
-                if (DateTime.TryParseExact(request.EndDate, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime endDate))
+                if (DateTime.TryParseExact(((DateTime) request.EndDate).ToString(CultureInfo.InvariantCulture), "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var endDate))
                 {
                     response = response
                         .Where(x =>

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -271,7 +271,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return doc["_id"].AsObjectId.ToString();
         }
 
-        public CareCaseData GetCaseById(string recordId)
+        public CareCaseData? GetCaseById(string recordId)
         {
             var collection = _sccvDbContext.getCollection();
             var filter = Builders<BsonDocument>.Filter.Eq("_id", ObjectId.Parse(recordId));
@@ -280,7 +280,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var result = query.ToList();
             if (result.FirstOrDefault() == null) throw new DocumentNotFoundException("Search did not return any results");
 
-            var response = ResponseFactory.ToResponse(result).FirstOrDefault();
+            var response = result.ToResponse().FirstOrDefault();
 
             return response;
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -77,8 +77,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 throw new DocumentNotFoundException("document not found");
             }
 
-            var response = ResponseFactory
-                .ToResponse(result);
+            var response = result.ToResponse();
 
             if (request.StartDate != null)
             {
@@ -203,63 +202,61 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public IOrderedEnumerable<CareCaseData> SortData(string sortBy, string orderBy, List<CareCaseData> response)
         {
-            switch (sortBy)
+            return sortBy switch
             {
-                case "firstName":
-                    return (orderBy == "asc") ?
-                        response.OrderBy(x => x.FirstName) :
-                        response.OrderByDescending(x => x.FirstName);
-                case "lastName":
-                    return (orderBy == "asc") ?
-                        response.OrderBy(x => x.LastName) :
-                        response.OrderByDescending(x => x.LastName);
-                case "caseFormUrl":
-                    return (orderBy == "asc") ?
-                        response.OrderBy(x => x.CaseFormUrl) :
-                        response.OrderByDescending(x => x.CaseFormUrl);
-                case "dateOfBirth":
-                    return (orderBy == "asc") ?
-                        response.OrderBy(x =>
-                        {
-                            _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dt);
-                            return dt;
-                        }) :
-                        response.OrderByDescending(x =>
-                        {
-                            _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dt);
-                            return dt;
-                        });
-                case "officerEmail":
-                    return (orderBy == "asc") ?
-                        response.OrderBy(x => x.OfficerEmail) :
-                        response.OrderByDescending(x => x.OfficerEmail);
-                default:
-                    return (orderBy == "asc") ? response.OrderBy(GetDateToSortBy) : response.OrderByDescending(GetDateToSortBy);
-            }
+                "firstName" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.FirstName)
+                    : response.OrderByDescending(x => x.FirstName),
+                "lastName" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.LastName)
+                    : response.OrderByDescending(x => x.LastName),
+                "caseFormUrl" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.CaseFormUrl)
+                    : response.OrderByDescending(x => x.CaseFormUrl),
+                "dateOfBirth" => (orderBy == "asc")
+                    ? response.OrderBy(x =>
+                    {
+                        _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var dt);
+                        return dt;
+                    })
+                    : response.OrderByDescending(x =>
+                    {
+                        _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var dt);
+                        return dt;
+                    }),
+                "officerEmail" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.OfficerEmail)
+                    : response.OrderByDescending(x => x.OfficerEmail),
+                _ => (orderBy == "asc")
+                    ? response.OrderBy(GetDateToSortBy)
+                    : response.OrderByDescending(GetDateToSortBy)
+            };
 
             static DateTime? GetDateToSortBy(CareCaseData x)
             {
                 if (string.IsNullOrEmpty(x.DateOfEvent))
                 {
-                    bool success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
+                    var success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
                     if (success) return timeStamp;
 
-                    bool successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dataImportTimestamp);
+                    var successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dataImportTimestamp);
                     if (successForDataImportTimestampFormat) return dataImportTimestamp;
 
-                    bool successForNonISO24hrTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime nonISO24hrTimestamp);
-                    if (successForNonISO24hrTimestampFormat) return nonISO24hrTimestamp;
+                    var successForNonIso24HrTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var nonIso24HrTimestamp);
+                    if (successForNonIso24HrTimestampFormat) return nonIso24HrTimestamp;
                 }
                 else
                 {
-                    bool success = DateTime.TryParseExact(x.DateOfEvent, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEvent);
+                    var success = DateTime.TryParseExact(x.DateOfEvent, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEvent);
                     if (success) return dateOfEvent;
 
-                    bool successForISODateTimeFormat = DateTime.TryParseExact(x.DateOfEvent, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEventISODateTimeFormat);
-                    if (successForISODateTimeFormat) return dateOfEventISODateTimeFormat;
+                    var successForIsoDateTimeFormat = DateTime.TryParseExact(x.DateOfEvent, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEventIsoDateTimeFormat);
+                    if (successForIsoDateTimeFormat) return dateOfEventIsoDateTimeFormat;
 
-                    bool successForISODateFormat = DateTime.TryParseExact(x.DateOfEvent, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateOfEventISODateFormat);
-                    if (successForISODateFormat) return dateOfEventISODateFormat;
+                    var successForIsoDateFormat = DateTime.TryParseExact(x.DateOfEvent, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEventIsoDateFormat);
+                    if (successForIsoDateFormat) return dateOfEventIsoDateFormat;
                 }
 
                 return null;

--- a/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ProcessDataGateway.cs
@@ -10,12 +10,11 @@ using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
-using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 
-
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Gateways
 {
     public class ProcessDataGateway : IProcessDataGateway
@@ -29,16 +28,16 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             _socialCarePlatformAPIGateway = socialCarePlatformAPIGateway;
         }
 
-        public Tuple<IEnumerable<CareCaseData>, int> GetProcessData(ListCasesRequest request, string ncId)
+        public Tuple<IEnumerable<CareCaseData>, int> GetProcessData(ListCasesRequest request, string? ncId)
         {
             var result = new List<BsonDocument>();
-            FilterDefinition<BsonDocument> firstNameFilter;
-            FilterDefinition<BsonDocument> lastNameFilter;
+            FilterDefinition<BsonDocument>? firstNameFilter;
+            FilterDefinition<BsonDocument>? lastNameFilter;
 
             if (!string.IsNullOrWhiteSpace(request.MosaicId))
             {
-                var historicRecords = GetHistoricRecordsByPersonId(request.MosaicId, ncId)?.ToList();
-                if (historicRecords?.Count > 0)
+                var historicRecords = GetHistoricRecordsByPersonId(request.MosaicId, ncId).ToList();
+                if (historicRecords.Count > 0)
                 {
                     result.AddRange(historicRecords);
                 }
@@ -125,7 +124,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return new Tuple<IEnumerable<CareCaseData>, int>(response, totalCount);
         }
 
-        private IEnumerable<BsonDocument> GetHistoricRecordsByPersonId(string personId, string ncId)
+        private IEnumerable<BsonDocument> GetHistoricRecordsByPersonId(string personId, string? ncId)
         {
             var mosaicIdQuery = _sccvDbContext.getCollection().AsQueryable();
             var mosaicIDFilter = Builders<BsonDocument>.Filter.Regex("mosaic_id", new BsonRegularExpression("^" + personId + "$", "i"));

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
@@ -15,10 +15,11 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]
         public string? SubmissionId { get; set; }
-
         public string FormId { get; set; } = null!;
         public Worker CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public Worker? SubmittedBy { get; set; }
+        public DateTime? SubmittedAt { get; set; }
         public List<Person> Residents { get; set; } = null!;
         public List<Worker> Workers { get; set; } = null!;
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -26,7 +26,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
             _mongoGateway = mongoGateway;
         }
-        public CareCaseDataList Execute(ListCasesRequest request)
+        public CareCaseDataList GetResidentCases(ListCasesRequest request)
         {
             string? ncId = null;
 

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -45,9 +47,10 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
 
-
-
-            var careCaseData = response.ToList();
+            var careCaseData = SortData(request.SortBy, request.OrderBy, response)
+                .Skip(request.Cursor)
+                .Take(request.Limit)
+                .ToList();
 
             int? nextCursor = request.Cursor + request.Limit;
 
@@ -71,6 +74,69 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             CaseNotesDocument doc = request.ToEntity();
 
             return _processDataGateway.InsertCaseNoteDocument(doc);
+        }
+
+        private static IEnumerable<CareCaseData> SortData(string sortBy, string orderBy, IEnumerable<CareCaseData> response)
+        {
+            return sortBy switch
+            {
+                "firstName" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.FirstName)
+                    : response.OrderByDescending(x => x.FirstName),
+                "lastName" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.LastName)
+                    : response.OrderByDescending(x => x.LastName),
+                "caseFormUrl" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.CaseFormUrl)
+                    : response.OrderByDescending(x => x.CaseFormUrl),
+                "dateOfBirth" => (orderBy == "asc")
+                    ? response.OrderBy(x =>
+                    {
+                        _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var dt);
+                        return dt;
+                    })
+                    : response.OrderByDescending(x =>
+                    {
+                        _ = DateTime.TryParseExact(x.DateOfBirth, "dd/MM/yyyy", CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var dt);
+                        return dt;
+                    }),
+                "officerEmail" => (orderBy == "asc")
+                    ? response.OrderBy(x => x.OfficerEmail)
+                    : response.OrderByDescending(x => x.OfficerEmail),
+                _ => (orderBy == "asc")
+                    ? response.OrderBy(GetDateToSortBy)
+                    : response.OrderByDescending(GetDateToSortBy)
+            };
+
+            static DateTime? GetDateToSortBy(CareCaseData x)
+            {
+                if (string.IsNullOrEmpty(x.DateOfEvent))
+                {
+                    var success = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy H:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timeStamp);
+                    if (success) return timeStamp;
+
+                    var successForDataImportTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy hh:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dataImportTimestamp);
+                    if (successForDataImportTimestampFormat) return dataImportTimestamp;
+
+                    var successForNonIso24HrTimestampFormat = DateTime.TryParseExact(x.CaseFormTimestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var nonIso24HrTimestamp);
+                    if (successForNonIso24HrTimestampFormat) return nonIso24HrTimestamp;
+                }
+                else
+                {
+                    var success = DateTime.TryParseExact(x.DateOfEvent, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEvent);
+                    if (success) return dateOfEvent;
+
+                    var successForIsoDateTimeFormat = DateTime.TryParseExact(x.DateOfEvent, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEventIsoDateTimeFormat);
+                    if (successForIsoDateTimeFormat) return dateOfEventIsoDateTimeFormat;
+
+                    var successForIsoDateFormat = DateTime.TryParseExact(x.DateOfEvent, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfEventIsoDateFormat);
+                    if (successForIsoDateFormat) return dateOfEventIsoDateFormat;
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -44,6 +44,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             }
 
             var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
+
+
+
             var careCaseData = response.ToList();
 
             int? nextCursor = request.Cursor + request.Limit;

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -19,12 +20,12 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _processDataGateway = processDataGateway;
             _databaseGateway = databaseGateway;
         }
-        public CareCaseDataList Execute(ListCasesRequest? request)
+        public CareCaseDataList Execute(ListCasesRequest request)
         {
             string? ncId = null;
 
             //grab both mosaic id and nc reference id
-            if (!string.IsNullOrWhiteSpace(request?.MosaicId))
+            if (!string.IsNullOrWhiteSpace(request.MosaicId))
             {
                 string ncIdTmp = _databaseGateway.GetNCReferenceByPersonId(request.MosaicId);
 
@@ -42,16 +43,17 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 }
             }
 
-            var result = _processDataGateway.GetProcessData(request, ncId);
+            var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
+            var careCaseData = response.ToList();
 
-            int? nextCursor = request?.Cursor + request?.Limit;
+            int? nextCursor = request.Cursor + request.Limit;
 
             //support page size 1
-            if (nextCursor == result.Item2 || result.Item1.Count() < request?.Limit) nextCursor = null;
+            if (nextCursor == totalCount || careCaseData.Count < request.Limit) nextCursor = null;
 
             return new CareCaseDataList
             {
-                Cases = result.Item1.ToList(),
+                Cases = careCaseData.ToList(),
                 NextCursor = nextCursor
             };
         }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -61,7 +61,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             };
         }
 
-        public CareCaseData Execute(string recordId)
+        public CareCaseData? Execute(string recordId)
         {
             return _processDataGateway.GetCaseById(recordId);
         }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -49,19 +49,16 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 }
             }
 
-            var response = new List<CareCaseData>();
-            var totalCount = 0;
-
-            // var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
+            var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
             var allCareCaseData = response.ToList();
 
             if (request.MosaicId != null)
             {
-                var allCaseSubmissions = _mongoGateway.LoadRecords<CaseSubmission>("resident-case-submissions");
+                var filter = Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents, r => r.Id == long.Parse(request.MosaicId));
 
-                var caseSubmissions = allCaseSubmissions
-                    .Where(c => c.Residents.Any(r => r.Id == long.Parse(request.MosaicId)))
-                    .Where(c => c.SubmissionState == SubmissionState.Submitted)
+                var caseSubmissions = _mongoGateway
+                    .LoadRecordsByFilter("resident-case-submissions", filter)
+                    .Where(x => x.SubmissionState == SubmissionState.Submitted)
                     .Select(x => x.ToCareCaseData(request))
                     .ToList();
 

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -57,7 +57,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 var filter = Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents, r => r.Id == long.Parse(request.MosaicId));
 
                 var caseSubmissions = _mongoGateway
-                    .LoadRecordsByFilter("resident-case-submissions", filter)
+                    .LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], filter)
                     .Where(x => x.SubmissionState == SubmissionState.Submitted)
                     .Select(x => x.ToCareCaseData(request))
                     .ToList();

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -16,7 +16,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
     {
         private readonly IDatabaseGateway _databaseGateway;
         private readonly IMongoGateway _mongoGateway;
-        private const string CollectionName = "resident-case-submissions";
+        private static readonly string _collectionName = MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions];
 
         public FormSubmissionsUseCase(IDatabaseGateway databaseGateway, IMongoGateway mongoGateway)
         {
@@ -54,14 +54,14 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 FormAnswers = new Dictionary<string, string>()
             };
 
-            _mongoGateway.InsertRecord(CollectionName, caseSubmission);
+            _mongoGateway.InsertRecord(_collectionName, caseSubmission);
 
             return (caseSubmission.ToDomain().ToResponse(), caseSubmission);
         }
 
         public CaseSubmissionResponse? ExecuteGetById(string submissionId)
         {
-            var foundSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(submissionId));
+            var foundSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
 
             return foundSubmission?.ToDomain().ToResponse();
         }
@@ -76,7 +76,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             worker.WorkerTeams = null;
             worker.Allocations = null;
 
-            var updateSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(submissionId));
+            var updateSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
             if (updateSubmission == null)
             {
                 throw new GetSubmissionException($"Submission with ID {submissionId} not found");
@@ -85,7 +85,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             updateSubmission.SubmissionState = SubmissionState.Submitted;
             updateSubmission.EditHistory.Add(new EditHistory<Worker> { Worker = worker, EditTime = DateTime.Now });
 
-            _mongoGateway.UpsertRecord(CollectionName, ObjectId.Parse(submissionId), updateSubmission);
+            _mongoGateway.UpsertRecord(_collectionName, ObjectId.Parse(submissionId), updateSubmission);
         }
 
 
@@ -99,7 +99,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             worker.WorkerTeams = null;
             worker.Allocations = null;
 
-            var submission = _mongoGateway.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(submissionId));
+            var submission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
             if (submission == null)
             {
                 throw new GetSubmissionException($"Submission with ID {submissionId} not found");
@@ -111,7 +111,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 Worker = worker,
                 EditTime = DateTime.Now
             });
-            _mongoGateway.UpsertRecord(CollectionName, ObjectId.Parse(submissionId), submission);
+            _mongoGateway.UpsertRecord(_collectionName, ObjectId.Parse(submissionId), submission);
             return submission.ToDomain().ToResponse();
         }
     }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
@@ -7,7 +7,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface ICaseRecordsUseCase
     {
-        CareCaseDataList Execute(ListCasesRequest request);
+        CareCaseDataList GetResidentCases(ListCasesRequest request);
 
         CareCaseData? Execute(string recordId);
         Task<string> Execute(CreateCaseNoteRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
@@ -9,7 +9,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
     {
         CareCaseDataList Execute(ListCasesRequest request);
 
-        CareCaseData Execute(string recordId);
+        CareCaseData? Execute(string recordId);
         Task<string> Execute(CreateCaseNoteRequest request);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/ICaseRecordsUseCase.cs
@@ -7,7 +7,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface ICaseRecordsUseCase
     {
-        CareCaseDataList Execute(ListCasesRequest? request);
+        CareCaseDataList Execute(ListCasesRequest request);
 
         CareCaseData Execute(string recordId);
         Task<string> Execute(CreateCaseNoteRequest request);


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-459)

## Describe this PR

### *What is the problem we're trying to solve*

We want when going to a resident's page to see any submitted CaseSubmissions returned as part of their "records".

### *What changes have we introduced*

Amended CaseRecordsUseCase to make a request to MongoGateway to retrieve all CaseSubmissions that belong to the resident if they are in the submitted state. Transform this data into "CareCaseData" object so it can be returned via the original API.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
