### PR TITLE
refactor(SCT-588): rename relationships classes

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/ListRelationshipsV1RequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/ListRelationshipsV1RequestTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 {
     [TestFixture]
-    public class ListRelationshipsRequestTests
+    public class ListRelationshipsV1RequestTests
     {
         private Faker _faker;
 
@@ -21,7 +21,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         [Test]
         public void ValidationPassesWhenValidPersonIdIsProvided()
         {
-            var request = new ListRelationshipsRequest() { PersonId = _faker.Random.Long(1, long.MaxValue) };
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long(1, long.MaxValue) };
 
             var errors = ValidationHelper.ValidateModel(request);
 
@@ -31,7 +31,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         [Test]
         public void ValidationFailsWhenPersonIdIsNotProvided()
         {
-            var request = new ListRelationshipsRequest();
+            var request = new ListRelationshipsV1Request();
 
             var errors = ValidationHelper.ValidateModel(request);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -30,7 +30,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         private Mock<IWarningNoteUseCase> _mockWarningNoteUseCase;
         private Mock<IGetVisitByVisitIdUseCase> _mockGetVisitByVisitIdUseCase;
         private Mock<IPersonUseCase> _mockPersonUseCase;
-        private Mock<IRelationshipsUseCase> _mockRelationshipsUseCase;
+        private Mock<IRelationshipsV1UseCase> _mockRelationshipsUseCase;
 
         private Fixture _fixture;
         private Faker _faker;
@@ -46,7 +46,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             _mockWarningNoteUseCase = new Mock<IWarningNoteUseCase>();
             _mockGetVisitByVisitIdUseCase = new Mock<IGetVisitByVisitIdUseCase>();
             _mockPersonUseCase = new Mock<IPersonUseCase>();
-            _mockRelationshipsUseCase = new Mock<IRelationshipsUseCase>();
+            _mockRelationshipsUseCase = new Mock<IRelationshipsV1UseCase>();
 
             _classUnderTest = new SocialCareCaseViewerApiController(_mockGetAllUseCase.Object, _mockAddNewResidentUseCase.Object,
                     _mockAllocationsUseCase.Object, _mockCaseNotesUseCase.Object, _mockVisitsUseCase.Object,

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -666,9 +666,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void ListRelationshipsReturn200WhenPersonIsFound()
         {
-            var request = new ListRelationshipsRequest() { PersonId = _faker.Random.Long() };
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsRequest>())).Returns(new ListRelationshipsResponse());
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsResponse());
 
             var response = _classUnderTest.ListRelationships(request) as ObjectResult;
 
@@ -678,9 +678,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void ListRelationshipsReturn404WithCorrectErrorMessageWhenPersonIsNotFound()
         {
-            var request = new ListRelationshipsRequest() { PersonId = _faker.Random.Long() };
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsRequest>())).Throws(new GetRelationshipsException("Person not found"));
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Throws(new GetRelationshipsException("Person not found"));
 
             var response = _classUnderTest.ListRelationships(request) as NotFoundObjectResult;
 
@@ -691,11 +691,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         [Test]
         public void ListRelationshipsReturns200AndRelationshipsWhenSuccessful()
         {
-            var request = new ListRelationshipsRequest() { PersonId = _faker.Random.Long() };
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
             var listRelationShipsResponse = _fixture.Create<ListRelationshipsResponse>();
 
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsRequest>())).Returns(listRelationShipsResponse);
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(listRelationShipsResponse);
 
             var response = _classUnderTest.ListRelationships(request) as ObjectResult;
 

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -668,7 +668,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         {
             var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsResponse());
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsV1Response());
 
             var response = _classUnderTest.ListRelationships(request) as ObjectResult;
 
@@ -693,13 +693,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         {
             var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
-            var listRelationShipsResponse = _fixture.Create<ListRelationshipsResponse>();
+            var listRelationShipsResponse = _fixture.Create<ListRelationshipsV1Response>();
 
             _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(listRelationShipsResponse);
 
             var response = _classUnderTest.ListRelationships(request) as ObjectResult;
 
-            response?.Value.Should().BeOfType<ListRelationshipsResponse>();
+            response?.Value.Should().BeOfType<ListRelationshipsV1Response>();
             response?.Value.Should().BeEquivalentTo(listRelationShipsResponse);
         }
     }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -470,7 +470,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = person.Id,
-                PersonalRelationships = new PersonalRelationships<RelatedPerson>()
+                PersonalRelationships = new PersonalRelationshipsV1<RelatedPerson>()
                 {
                     Children = AddRelatedPerson(children),
                     Other = AddRelatedPerson(others),

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -446,7 +446,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var expectedResult = personList
                 .Where(p => relationshipIds.Contains(p.Id))
-                .Select(x => new RelatedPerson()
+                .Select(x => new RelatedPersonV1()
                 {
                     Id = x.Id,
                     FirstName = x.FirstName,
@@ -470,7 +470,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = person.Id,
-                PersonalRelationships = new PersonalRelationshipsV1<RelatedPerson>()
+                PersonalRelationships = new PersonalRelationshipsV1<RelatedPersonV1>()
                 {
                     Children = AddRelatedPerson(children),
                     Other = AddRelatedPerson(others),
@@ -514,9 +514,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             domainCaseSubmission.ToResponse().Should().BeEquivalentTo(responseCaseSubmission);
         }
 
-        private static List<RelatedPerson> AddRelatedPerson(List<Person> persons)
+        private static List<RelatedPersonV1> AddRelatedPerson(List<Person> persons)
         {
-            return persons.Select(x => new RelatedPerson()
+            return persons.Select(x => new RelatedPersonV1()
             {
                 Id = x.Id,
                 FirstName = x.FirstName,

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -463,7 +463,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             var person = TestHelpers.CreatePerson();
 
             List<Person> children, others, parents, siblings;
-            Relationships relationships;
+            RelationshipsV1 relationships;
 
             (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -467,7 +467,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
 
-            var expectedResult = new ListRelationshipsResponse()
+            var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = person.Id,
                 PersonalRelationships = new PersonalRelationships<RelatedPerson>()

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -465,7 +465,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             List<Person> children, others, parents, siblings;
             RelationshipsV1 relationships;
 
-            (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
+            (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationshipsV1(person.Id);
 
             var expectedResult = new ListRelationshipsV1Response()
             {

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
@@ -128,7 +128,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         {
             const long personId = 123;
 
-            var relationships = TestHelpers.CreateRelationships(personId);
+            var relationships = TestHelpers.CreateRelationshipsV1(personId);
 
             var httpClient = CreateHttpClient(relationships);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/SocialCarePlatformAPIGatewayTests.cs
@@ -118,7 +118,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             _socialCarePlatformAPIGateway = new SocialCarePlatformAPIGateway(httpClient);
 
-            var exception = Assert.Throws<SocialCarePlatformApiException>(delegate { _socialCarePlatformAPIGateway.GetRelationshipsByPersonId(personId); });
+            var exception = Assert.Throws<SocialCarePlatformApiException>(delegate { _socialCarePlatformAPIGateway.GetRelationshipsByPersonIdV1(personId); });
 
             exception.Message.Should().Be("404");
         }
@@ -134,7 +134,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             _socialCarePlatformAPIGateway = new SocialCarePlatformAPIGateway(httpClient);
 
-            var response = _socialCarePlatformAPIGateway.GetRelationshipsByPersonId(personId);
+            var response = _socialCarePlatformAPIGateway.GetRelationshipsByPersonIdV1(personId);
 
             response.Should().NotBeNull();
             response.PersonalRelationships.Should().NotBeNull();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -452,7 +452,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.ContextFlag, f => contextFlag ?? f.Random.String2(1, "ACac"));
         }
 
-        public static Relationships CreateRelationships(
+        public static RelationshipsV1 CreateRelationships(
             long personId,
             List<long>? childrenIds = null,
             List<long>? parentsIds = null,
@@ -460,7 +460,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             List<long>? othersIds = null
         )
         {
-            return new Relationships()
+            return new RelationshipsV1()
             {
                 PersonId = personId,
                 PersonalRelationships = new PersonalRelationships<long>()
@@ -473,14 +473,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             };
         }
 
-        public static (List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, Relationships) CreatePersonsWithRelationships(long personId)
+        public static (List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, RelationshipsV1) CreatePersonsWithRelationships(long personId)
         {
             List<InfrastructurePerson> children = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
             List<InfrastructurePerson> others = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
             List<InfrastructurePerson> parents = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
             List<InfrastructurePerson> siblings = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
 
-            Relationships relationships = CreateRelationships(
+            RelationshipsV1 relationships = CreateRelationships(
                     personId: personId,
                     childrenIds: children.Select(x => x.Id).ToList(),
                     othersIds: others.Select(x => x.Id).ToList(),

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -473,7 +473,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             };
         }
 
-        public static (List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, RelationshipsV1) CreatePersonsWithRelationships(long personId)
+        public static (List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, List<InfrastructurePerson>, RelationshipsV1) CreatePersonsWithRelationshipsV1(long personId)
         {
             List<InfrastructurePerson> children = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
             List<InfrastructurePerson> others = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -463,7 +463,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             return new RelationshipsV1()
             {
                 PersonId = personId,
-                PersonalRelationships = new PersonalRelationships<long>()
+                PersonalRelationships = new PersonalRelationshipsV1<long>()
                 {
                     Children = childrenIds ?? new List<long>() { 1, 2 },
                     Parents = parentsIds ?? new List<long>() { 3, 4 },

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -452,7 +452,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(t => t.ContextFlag, f => contextFlag ?? f.Random.String2(1, "ACac"));
         }
 
-        public static RelationshipsV1 CreateRelationships(
+        public static RelationshipsV1 CreateRelationshipsV1(
             long personId,
             List<long>? childrenIds = null,
             List<long>? parentsIds = null,
@@ -480,7 +480,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             List<InfrastructurePerson> parents = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
             List<InfrastructurePerson> siblings = new List<InfrastructurePerson>() { CreatePerson(), CreatePerson() };
 
-            RelationshipsV1 relationships = CreateRelationships(
+            RelationshipsV1 relationships = CreateRelationshipsV1(
                     personId: personId,
                     childrenIds: children.Select(x => x.Id).ToList(),
                     othersIds: others.Select(x => x.Id).ToList(),

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsUseCaseTests.cs
@@ -30,9 +30,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _relationshipsUseCase = new RelationshipsUseCase(_mockSocialCarePlatformAPIGateway.Object, _mockDatabaseGateway.Object);
         }
 
-        private static ListRelationshipsRequest GetValidRequest()
+        private static ListRelationshipsV1Request GetValidRequest()
         {
-            return new ListRelationshipsRequest() { PersonId = 555666777 };
+            return new ListRelationshipsV1Request() { PersonId = 555666777 };
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsUseCaseTests.cs
@@ -78,7 +78,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns((Relationships) null);
 
-            var expectedResult = new ListRelationshipsResponse() { PersonId = request.PersonId };
+            var expectedResult = new ListRelationshipsV1Response() { PersonId = request.PersonId };
 
             var result = _relationshipsUseCase.ExecuteGet(request);
 
@@ -111,7 +111,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             result.Should().NotBeNull();
 
-            result.Should().BeOfType<ListRelationshipsResponse>();
+            result.Should().BeOfType<ListRelationshipsV1Response>();
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockDatabaseGateway.Setup(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>())).Returns(personRecords);
 
-            var expectedResult = new ListRelationshipsResponse()
+            var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = request.PersonId,
                 PersonalRelationships = new PersonalRelationships<RelatedPerson>()

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -124,7 +124,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             List<Person> children, others, parents, siblings;
             RelationshipsV1 relationships;
 
-            (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
+            (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationshipsV1(person.Id);
 
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(relationships);
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(person);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -41,7 +41,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = GetValidRequest();
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
 
             _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
@@ -52,11 +52,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExcecuteGetCallsSocialCarePlatformAPIGateway()
         {
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
 
             _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
-            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonId(It.IsAny<long>()));
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>()));
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns((Relationships) null);
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns((Relationships) null);
 
             var expectedResult = new ListRelationshipsV1Response() { PersonId = request.PersonId };
 
@@ -91,11 +91,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = GetValidRequest();
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
 
             _relationshipsV1UseCase.ExecuteGet(request);
 
-            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonId(request.PersonId));
+            _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonIdV1(request.PersonId));
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
 
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(TestHelpers.CreateRelationships(request.PersonId));
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(TestHelpers.CreateRelationships(request.PersonId));
 
             var result = _relationshipsV1UseCase.ExecuteGet(request);
 
@@ -126,7 +126,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
 
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(relationships);
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(relationships);
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(person);
 
             var personIds = new List<long>();
@@ -177,7 +177,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
 
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new Relationships());
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
             var result = _relationshipsV1UseCase.ExecuteGet(request);
@@ -199,7 +199,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new Relationships());
 
             _relationshipsV1UseCase.ExecuteGet(request);
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()), Times.Never);
@@ -209,7 +209,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExecuteGetCallsDatabaseGatewaysGetPersonsByListOfIdsWhenSocialCarePlatformAPIGatewayReturnsRelationships()
         {
             var request = GetValidRequest();
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(TestHelpers.CreateRelationships(request.PersonId));
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(TestHelpers.CreateRelationships(request.PersonId));
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
             _relationshipsV1UseCase.ExecuteGet(request);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -105,7 +105,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
 
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(TestHelpers.CreateRelationships(request.PersonId));
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(TestHelpers.CreateRelationshipsV1(request.PersonId));
 
             var result = _relationshipsV1UseCase.ExecuteGet(request);
 
@@ -209,7 +209,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExecuteGetCallsDatabaseGatewaysGetPersonsByListOfIdsWhenSocialCarePlatformAPIGatewayReturnsRelationships()
         {
             var request = GetValidRequest();
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(TestHelpers.CreateRelationships(request.PersonId));
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(TestHelpers.CreateRelationshipsV1(request.PersonId));
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
             _relationshipsV1UseCase.ExecuteGet(request);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -147,7 +147,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = request.PersonId,
-                PersonalRelationships = new PersonalRelationships<RelatedPerson>()
+                PersonalRelationships = new PersonalRelationshipsV1<RelatedPerson>()
                 {
                     Children = AddRelatedPerson(children),
                     Other = AddRelatedPerson(others),

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -147,7 +147,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var expectedResult = new ListRelationshipsV1Response()
             {
                 PersonId = request.PersonId,
-                PersonalRelationships = new PersonalRelationshipsV1<RelatedPerson>()
+                PersonalRelationships = new PersonalRelationshipsV1<RelatedPersonV1>()
                 {
                     Children = AddRelatedPerson(children),
                     Other = AddRelatedPerson(others),
@@ -216,9 +216,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()), Times.Once);
         }
 
-        private static List<RelatedPerson> AddRelatedPerson(List<Person> persons)
+        private static List<RelatedPersonV1> AddRelatedPerson(List<Person> persons)
         {
-            return persons.Select(x => new RelatedPerson()
+            return persons.Select(x => new RelatedPersonV1()
             {
                 Id = x.Id,
                 FirstName = x.FirstName,

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -20,14 +20,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
     {
         private Mock<ISocialCarePlatformAPIGateway> _mockSocialCarePlatformAPIGateway;
         private Mock<IDatabaseGateway> _mockDatabaseGateway;
-        private RelationshipsV1UseCase _relationshipsUseCase;
+        private RelationshipsV1UseCase _relationshipsV1UseCase;
 
         [SetUp]
         public void SetUp()
         {
             _mockSocialCarePlatformAPIGateway = new Mock<ISocialCarePlatformAPIGateway>();
             _mockDatabaseGateway = new Mock<IDatabaseGateway>();
-            _relationshipsUseCase = new RelationshipsV1UseCase(_mockSocialCarePlatformAPIGateway.Object, _mockDatabaseGateway.Object);
+            _relationshipsV1UseCase = new RelationshipsV1UseCase(_mockSocialCarePlatformAPIGateway.Object, _mockDatabaseGateway.Object);
         }
 
         private static ListRelationshipsV1Request GetValidRequest()
@@ -43,7 +43,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
 
-            _relationshipsUseCase.ExecuteGet(GetValidRequest());
+            _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
             _mockDatabaseGateway.Verify(x => x.GetPersonByMosaicId(It.IsAny<long>()));
         }
@@ -54,7 +54,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
 
-            _relationshipsUseCase.ExecuteGet(GetValidRequest());
+            _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
             _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonId(It.IsAny<long>()));
         }
@@ -66,7 +66,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns((Person) null);
 
-            _relationshipsUseCase.Invoking(x => x.ExecuteGet(request))
+            _relationshipsV1UseCase.Invoking(x => x.ExecuteGet(request))
                 .Should().Throw<GetRelationshipsException>()
                 .WithMessage("Person not found");
         }
@@ -80,7 +80,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var expectedResult = new ListRelationshipsV1Response() { PersonId = request.PersonId };
 
-            var result = _relationshipsUseCase.ExecuteGet(request);
+            var result = _relationshipsV1UseCase.ExecuteGet(request);
 
             result.Should().BeEquivalentTo(expectedResult);
         }
@@ -93,7 +93,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(new Relationships());
 
-            _relationshipsUseCase.ExecuteGet(request);
+            _relationshipsV1UseCase.ExecuteGet(request);
 
             _mockSocialCarePlatformAPIGateway.Verify(x => x.GetRelationshipsByPersonId(request.PersonId));
         }
@@ -107,7 +107,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(It.IsAny<long>())).Returns(TestHelpers.CreateRelationships(request.PersonId));
 
-            var result = _relationshipsUseCase.ExecuteGet(request);
+            var result = _relationshipsV1UseCase.ExecuteGet(request);
 
             result.Should().NotBeNull();
 
@@ -156,7 +156,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
                 }
             };
 
-            var result = _relationshipsUseCase.ExecuteGet(request);
+            var result = _relationshipsV1UseCase.ExecuteGet(request);
 
             result.Should().NotBeNull();
             result.PersonalRelationships.Children.Count.Should().Be(2);
@@ -180,7 +180,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(new Relationships());
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
-            var result = _relationshipsUseCase.ExecuteGet(request);
+            var result = _relationshipsV1UseCase.ExecuteGet(request);
 
             result.Should().NotBeNull();
             result.PersonalRelationships.Should().NotBeNull();
@@ -201,7 +201,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(new Relationships());
 
-            _relationshipsUseCase.ExecuteGet(request);
+            _relationshipsV1UseCase.ExecuteGet(request);
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()), Times.Never);
         }
 
@@ -212,7 +212,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonId(request.PersonId)).Returns(TestHelpers.CreateRelationships(request.PersonId));
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
-            _relationshipsUseCase.ExecuteGet(request);
+            _relationshipsV1UseCase.ExecuteGet(request);
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()), Times.Once);
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -41,7 +41,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = GetValidRequest();
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new RelationshipsV1());
 
             _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
@@ -52,7 +52,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExcecuteGetCallsSocialCarePlatformAPIGateway()
         {
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new RelationshipsV1());
 
             _relationshipsV1UseCase.ExecuteGet(GetValidRequest());
 
@@ -76,7 +76,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns((Relationships) null);
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns((RelationshipsV1) null);
 
             var expectedResult = new ListRelationshipsV1Response() { PersonId = request.PersonId };
 
@@ -91,7 +91,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = GetValidRequest();
 
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(It.IsAny<long>())).Returns(new RelationshipsV1());
 
             _relationshipsV1UseCase.ExecuteGet(request);
 
@@ -122,7 +122,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             Person person = TestHelpers.CreatePerson();
 
             List<Person> children, others, parents, siblings;
-            Relationships relationships;
+            RelationshipsV1 relationships;
 
             (children, others, parents, siblings, relationships) = TestHelpers.CreatePersonsWithRelationships(person.Id);
 
@@ -177,7 +177,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
 
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new RelationshipsV1());
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(request.PersonId)).Returns(new Person());
 
             var result = _relationshipsV1UseCase.ExecuteGet(request);
@@ -199,7 +199,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             var request = GetValidRequest();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(It.IsAny<long>())).Returns(new Person());
-            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new Relationships());
+            _mockSocialCarePlatformAPIGateway.Setup(x => x.GetRelationshipsByPersonIdV1(request.PersonId)).Returns(new RelationshipsV1());
 
             _relationshipsV1UseCase.ExecuteGet(request);
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()), Times.Never);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/RelationshipsV1UseCaseTests.cs
@@ -16,18 +16,18 @@ using System.Linq;
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 {
     [TestFixture]
-    public class RelationshipsUseCaseTests
+    public class RelationshipsV1UseCaseTests
     {
         private Mock<ISocialCarePlatformAPIGateway> _mockSocialCarePlatformAPIGateway;
         private Mock<IDatabaseGateway> _mockDatabaseGateway;
-        private RelationshipsUseCase _relationshipsUseCase;
+        private RelationshipsV1UseCase _relationshipsUseCase;
 
         [SetUp]
         public void SetUp()
         {
             _mockSocialCarePlatformAPIGateway = new Mock<ISocialCarePlatformAPIGateway>();
             _mockDatabaseGateway = new Mock<IDatabaseGateway>();
-            _relationshipsUseCase = new RelationshipsUseCase(_mockSocialCarePlatformAPIGateway.Object, _mockDatabaseGateway.Object);
+            _relationshipsUseCase = new RelationshipsV1UseCase(_mockSocialCarePlatformAPIGateway.Object, _mockDatabaseGateway.Object);
         }
 
         private static ListRelationshipsV1Request GetValidRequest()

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -162,7 +162,7 @@ namespace SocialCareCaseViewerApi
             services.AddScoped<IGetVisitByVisitIdUseCase, GetVisitByVisitIdUseCase>();
             services.AddScoped<IWorkersUseCase, WorkersUseCase>();
             services.AddScoped<IPersonUseCase, PersonUseCase>();
-            services.AddScoped<IRelationshipsUseCase, RelationshipsUseCase>();
+            services.AddScoped<IRelationshipsUseCase, RelationshipsV1UseCase>();
             services.AddScoped<IFormSubmissionsUseCase, FormSubmissionsUseCase>();
         }
 

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -162,7 +162,7 @@ namespace SocialCareCaseViewerApi
             services.AddScoped<IGetVisitByVisitIdUseCase, GetVisitByVisitIdUseCase>();
             services.AddScoped<IWorkersUseCase, WorkersUseCase>();
             services.AddScoped<IPersonUseCase, PersonUseCase>();
-            services.AddScoped<IRelationshipsUseCase, RelationshipsV1UseCase>();
+            services.AddScoped<IRelationshipsV1UseCase, RelationshipsV1UseCase>();
             services.AddScoped<IFormSubmissionsUseCase, FormSubmissionsUseCase>();
         }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListRelationshipsV1Request.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListRelationshipsV1Request.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
-    public class ListRelationshipsRequest
+    public class ListRelationshipsV1Request
     {
         [Required]
         [Range(1, long.MaxValue, ErrorMessage = "Please enter a valid personId")]

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
@@ -6,6 +6,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
     {
         public long PersonId { get; set; }
 
-        public PersonalRelationshipsV1<RelatedPerson> PersonalRelationships { get; set; } = new PersonalRelationshipsV1<RelatedPerson>();
+        public PersonalRelationshipsV1<RelatedPersonV1> PersonalRelationships { get; set; } = new PersonalRelationshipsV1<RelatedPersonV1>();
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
@@ -2,7 +2,7 @@ using SocialCareCaseViewerApi.V1.Domain;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Response
 {
-    public class ListRelationshipsResponse
+    public class ListRelationshipsV1Response
     {
         public long PersonId { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/ListRelationshipsV1Response.cs
@@ -6,6 +6,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
     {
         public long PersonId { get; set; }
 
-        public PersonalRelationships<RelatedPerson> PersonalRelationships { get; set; } = new PersonalRelationships<RelatedPerson>();
+        public PersonalRelationshipsV1<RelatedPerson> PersonalRelationships { get; set; } = new PersonalRelationshipsV1<RelatedPerson>();
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -388,7 +388,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="200">Successful request. Relationships returned</response>
         /// <response code="404">Person not found</response>
         /// <response code="500">There was a problem getting the relationships</response>
-        [ProducesResponseType(typeof(ListRelationshipsResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("residents/{personId}/relationships")]
         public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -391,7 +391,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [ProducesResponseType(typeof(ListRelationshipsResponse), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("residents/{personId}/relationships")]
-        public IActionResult ListRelationships([FromQuery] ListRelationshipsRequest request)
+        public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)
         {
             try
             {

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -25,12 +25,12 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         private readonly IWarningNoteUseCase _warningNoteUseCase;
         private readonly IGetVisitByVisitIdUseCase _getVisitByVisitIdUseCase;
         private readonly IPersonUseCase _personUseCase;
-        private readonly IRelationshipsUseCase _relationshipsUseCase;
+        private readonly IRelationshipsV1UseCase _relationshipsV1UseCase;
 
         public SocialCareCaseViewerApiController(IGetAllUseCase getAllUseCase, IAddNewResidentUseCase addNewResidentUseCase,
             IAllocationsUseCase allocationUseCase, ICaseNotesUseCase caseNotesUseCase,
             IVisitsUseCase visitsUseCase, IWarningNoteUseCase warningNotesUseCase,
-            IGetVisitByVisitIdUseCase getVisitByVisitIdUseCase, IPersonUseCase personUseCase, IRelationshipsUseCase relationshipsUseCase)
+            IGetVisitByVisitIdUseCase getVisitByVisitIdUseCase, IPersonUseCase personUseCase, IRelationshipsV1UseCase relationshipsV1UseCase)
         {
             _getAllUseCase = getAllUseCase;
             _addNewResidentUseCase = addNewResidentUseCase;
@@ -40,7 +40,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             _warningNoteUseCase = warningNotesUseCase;
             _getVisitByVisitIdUseCase = getVisitByVisitIdUseCase;
             _personUseCase = personUseCase;
-            _relationshipsUseCase = relationshipsUseCase;
+            _relationshipsV1UseCase = relationshipsV1UseCase;
         }
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         {
             try
             {
-                return Ok(_relationshipsUseCase.ExecuteGet(request));
+                return Ok(_relationshipsV1UseCase.ExecuteGet(request));
             }
             catch (GetRelationshipsException ex)
             {

--- a/SocialCareCaseViewerApi/V1/Domain/PersonalRelationshipsV1.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/PersonalRelationshipsV1.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace SocialCareCaseViewerApi.V1.Domain
 {
-    public class PersonalRelationships<T>
+    public class PersonalRelationshipsV1<T>
     {
         public List<T> Parents { get; set; } = new List<T>();
 

--- a/SocialCareCaseViewerApi/V1/Domain/RelatedPersonV1.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/RelatedPersonV1.cs
@@ -1,6 +1,6 @@
 namespace SocialCareCaseViewerApi.V1.Domain
 {
-    public class RelatedPerson
+    public class RelatedPersonV1
     {
         public long Id { get; set; }
         public string FirstName { get; set; }

--- a/SocialCareCaseViewerApi/V1/Domain/RelationshipsV1.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/RelationshipsV1.cs
@@ -4,6 +4,6 @@ namespace SocialCareCaseViewerApi.V1.Domain
     {
         public long PersonId { get; set; }
 
-        public PersonalRelationships<long> PersonalRelationships { get; set; }
+        public PersonalRelationshipsV1<long> PersonalRelationships { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Domain/RelationshipsV1.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/RelationshipsV1.cs
@@ -1,6 +1,6 @@
 namespace SocialCareCaseViewerApi.V1.Domain
 {
-    public class Relationships
+    public class RelationshipsV1
     {
         public long PersonId { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -259,11 +259,11 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static List<RelatedPerson> PersonsToRelatedPersonsList(List<Person> personList, List<long> relationshipIds)
+        public static List<RelatedPersonV1> PersonsToRelatedPersonsList(List<Person> personList, List<long> relationshipIds)
         {
             return personList
                .Where(p => relationshipIds.Contains(p.Id))
-               .Select(x => new RelatedPerson()
+               .Select(x => new RelatedPersonV1()
                {
                    Id = x.Id,
                    FirstName = x.FirstName,

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -214,7 +214,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static ListRelationshipsV1Response ToResponse(List<Person> personRecords, Relationships relationships, List<long> personIds, long personId)
+        public static ListRelationshipsV1Response ToResponse(List<Person> personRecords, RelationshipsV1 relationships, List<long> personIds, long personId)
         {
             ListRelationshipsV1Response response = new ListRelationshipsV1Response() { PersonId = personId };
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -214,9 +214,9 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static ListRelationshipsResponse ToResponse(List<Person> personRecords, Relationships relationships, List<long> personIds, long personId)
+        public static ListRelationshipsV1Response ToResponse(List<Person> personRecords, Relationships relationships, List<long> personIds, long personId)
         {
-            ListRelationshipsResponse response = new ListRelationshipsResponse() { PersonId = personId };
+            ListRelationshipsV1Response response = new ListRelationshipsV1Response() { PersonId = personId };
 
             if (personIds.Count == 0 || relationships == null)
                 return response;

--- a/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
@@ -15,6 +15,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         Visit GetVisitByVisitId(long id);
 
-        Relationships GetRelationshipsByPersonId(long id);
+        Relationships GetRelationshipsByPersonIdV1(long id);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/ISocialCarePlatformAPIGateway.cs
@@ -15,6 +15,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         Visit GetVisitByVisitId(long id);
 
-        Relationships GetRelationshipsByPersonIdV1(long id);
+        RelationshipsV1 GetRelationshipsByPersonIdV1(long id);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
@@ -48,7 +48,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return GetDataFromSocialCarePlatformAPI<Visit>(path);
         }
 
-        public Relationships GetRelationshipsByPersonId(long id)
+        public Relationships GetRelationshipsByPersonIdV1(long id)
         {
             var path = $"residents/{id}/relationships";
             return GetDataFromSocialCarePlatformAPI<Relationships>(path);

--- a/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SocialCarePlatformAPIGateway.cs
@@ -48,10 +48,10 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return GetDataFromSocialCarePlatformAPI<Visit>(path);
         }
 
-        public Relationships GetRelationshipsByPersonIdV1(long id)
+        public RelationshipsV1 GetRelationshipsByPersonIdV1(long id)
         {
             var path = $"residents/{id}/relationships";
-            return GetDataFromSocialCarePlatformAPI<Relationships>(path);
+            return GetDataFromSocialCarePlatformAPI<RelationshipsV1>(path);
         }
 
         private T GetDataFromSocialCarePlatformAPI<T>(string path)

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsUseCase.cs
@@ -5,6 +5,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface IRelationshipsUseCase
     {
-        ListRelationshipsResponse ExecuteGet(ListRelationshipsRequest request);
+        ListRelationshipsResponse ExecuteGet(ListRelationshipsV1Request request);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsUseCase.cs
@@ -5,6 +5,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
     public interface IRelationshipsUseCase
     {
-        ListRelationshipsResponse ExecuteGet(ListRelationshipsV1Request request);
+        ListRelationshipsV1Response ExecuteGet(ListRelationshipsV1Request request);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsV1UseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IRelationshipsV1UseCase.cs
@@ -3,7 +3,7 @@ using SocialCareCaseViewerApi.V1.Boundary.Response;
 
 namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
 {
-    public interface IRelationshipsUseCase
+    public interface IRelationshipsV1UseCase
     {
         ListRelationshipsV1Response ExecuteGet(ListRelationshipsV1Request request);
     }

--- a/SocialCareCaseViewerApi/V1/UseCase/RelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/RelationshipsUseCase.cs
@@ -20,7 +20,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
         }
 
-        public ListRelationshipsResponse ExecuteGet(ListRelationshipsV1Request request)
+        public ListRelationshipsV1Response ExecuteGet(ListRelationshipsV1Request request)
         {
             var person = _databaseGateway.GetPersonByMosaicId(request.PersonId);
 

--- a/SocialCareCaseViewerApi/V1/UseCase/RelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/RelationshipsUseCase.cs
@@ -20,7 +20,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             _databaseGateway = databaseGateway;
         }
 
-        public ListRelationshipsResponse ExecuteGet(ListRelationshipsRequest request)
+        public ListRelationshipsResponse ExecuteGet(ListRelationshipsV1Request request)
         {
             var person = _databaseGateway.GetPersonByMosaicId(request.PersonId);
 

--- a/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
@@ -27,7 +27,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             if (person == null)
                 throw new GetRelationshipsException("Person not found");
 
-            var relationships = _socialCarePlatformAPIGateway.GetRelationshipsByPersonId(request.PersonId);
+            var relationships = _socialCarePlatformAPIGateway.GetRelationshipsByPersonIdV1(request.PersonId);
 
             List<long> personIds = new List<long>();
             List<Person> personRecords = new List<Person>();

--- a/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
@@ -9,12 +9,12 @@ using System.Collections.Generic;
 
 namespace SocialCareCaseViewerApi.V1.UseCase
 {
-    public class RelationshipsUseCase : IRelationshipsUseCase
+    public class RelationshipsV1UseCase : IRelationshipsUseCase
     {
         private ISocialCarePlatformAPIGateway _socialCarePlatformAPIGateway;
         private IDatabaseGateway _databaseGateway;
 
-        public RelationshipsUseCase(ISocialCarePlatformAPIGateway socialCarePlatformAPIGateway, IDatabaseGateway databaseGateway)
+        public RelationshipsV1UseCase(ISocialCarePlatformAPIGateway socialCarePlatformAPIGateway, IDatabaseGateway databaseGateway)
         {
             _socialCarePlatformAPIGateway = socialCarePlatformAPIGateway;
             _databaseGateway = databaseGateway;

--- a/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/RelationshipsV1UseCase.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SocialCareCaseViewerApi.V1.UseCase
 {
-    public class RelationshipsV1UseCase : IRelationshipsUseCase
+    public class RelationshipsV1UseCase : IRelationshipsV1UseCase
     {
         private ISocialCarePlatformAPIGateway _socialCarePlatformAPIGateway;
         private IDatabaseGateway _databaseGateway;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-588

## Describe this PR

### *What is the problem we're trying to solve*

We want to refactor the current `residents/{personId}/relationships` API endpoint to change the response with more granular relationship types. In order to do this, we've decided that the best way to go about this without breaking current functionality to:

1. Rename current relationships classes to have `V1` in it, i.e. gateway, use case, etc.
2. Deploy to prod
3. Duplicate the current relationship API endpoint and rename one to `residents/{personId}/relationships-v1`
4. Deploy to prod
5. Update frontend to use `residents/{personId}/relationships-v1`
6. Deploy to prod
7. Add API code for how we want to respond with new relationships types
8. Deploy to prod
9. Update frontend to switch over to use `residents/{personId}/relationships` i.e. endpoint with new response
10. Delete v1 relationships code

### *What changes have we introduced*

This PR does step 1 and renames relationships classes to have `V1` in it.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy to prod and then duplicate endpoint.
