### PR TITLE
refactor(SCT-589): refactor get relationships endpoint into new RelationshipController

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
@@ -17,8 +17,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
     {
         private RelationshipController _classUnderTest;
         private Mock<IRelationshipsV1UseCase> _mockRelationshipsUseCase;
-        private Fixture _fixture;
-        private Faker _faker;
+        private readonly Fixture _fixture = new Fixture();
+        private readonly Faker _faker = new Faker();
 
         [SetUp]
         public void SetUp()
@@ -26,9 +26,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             _mockRelationshipsUseCase = new Mock<IRelationshipsV1UseCase>();
 
             _classUnderTest = new RelationshipController(_mockRelationshipsUseCase.Object);
-
-            _fixture = new Fixture();
-            _faker = new Faker();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
@@ -1,0 +1,74 @@
+using AutoFixture;
+using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Controllers;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class RelationshipControllerTests
+    {
+        private RelationshipController _classUnderTest;
+        private Mock<IRelationshipsV1UseCase> _mockRelationshipsUseCase;
+        private Fixture _fixture;
+        private Faker _faker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockRelationshipsUseCase = new Mock<IRelationshipsV1UseCase>();
+
+            _classUnderTest = new RelationshipController(_mockRelationshipsUseCase.Object);
+
+            _fixture = new Fixture();
+            _faker = new Faker();
+        }
+
+        [Test]
+        public void ListRelationshipsReturn200WhenPersonIsFound()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsV1Response());
+
+            var response = _classUnderTest.ListRelationships(request) as ObjectResult;
+
+            response?.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void ListRelationshipsReturn404WithCorrectErrorMessageWhenPersonIsNotFound()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Throws(new GetRelationshipsException("Person not found"));
+
+            var response = _classUnderTest.ListRelationships(request) as NotFoundObjectResult;
+
+            response?.StatusCode.Should().Be(404);
+            response?.Value.Should().Be("Person not found");
+        }
+
+        [Test]
+        public void ListRelationshipsReturns200AndRelationshipsWhenSuccessful()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            var listRelationShipsResponse = _fixture.Create<ListRelationshipsV1Response>();
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(listRelationShipsResponse);
+
+            var response = _classUnderTest.ListRelationships(request) as ObjectResult;
+
+            response?.Value.Should().BeOfType<ListRelationshipsV1Response>();
+            response?.Value.Should().BeEquivalentTo(listRelationShipsResponse);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -30,8 +30,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         private Mock<IWarningNoteUseCase> _mockWarningNoteUseCase;
         private Mock<IGetVisitByVisitIdUseCase> _mockGetVisitByVisitIdUseCase;
         private Mock<IPersonUseCase> _mockPersonUseCase;
-        private Mock<IRelationshipsV1UseCase> _mockRelationshipsUseCase;
-
         private Fixture _fixture;
         private Faker _faker;
 
@@ -46,11 +44,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             _mockWarningNoteUseCase = new Mock<IWarningNoteUseCase>();
             _mockGetVisitByVisitIdUseCase = new Mock<IGetVisitByVisitIdUseCase>();
             _mockPersonUseCase = new Mock<IPersonUseCase>();
-            _mockRelationshipsUseCase = new Mock<IRelationshipsV1UseCase>();
 
             _classUnderTest = new SocialCareCaseViewerApiController(_mockGetAllUseCase.Object, _mockAddNewResidentUseCase.Object,
                     _mockAllocationsUseCase.Object, _mockCaseNotesUseCase.Object, _mockVisitsUseCase.Object,
-            _mockWarningNoteUseCase.Object, _mockGetVisitByVisitIdUseCase.Object, _mockPersonUseCase.Object, _mockRelationshipsUseCase.Object);
+            _mockWarningNoteUseCase.Object, _mockGetVisitByVisitIdUseCase.Object, _mockPersonUseCase.Object);
 
             _fixture = new Fixture();
             _faker = new Faker();
@@ -661,46 +658,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
 
             response.Should().NotBeNull();
             response?.StatusCode.Should().Be(400);
-        }
-
-        [Test]
-        public void ListRelationshipsReturn200WhenPersonIsFound()
-        {
-            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
-
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsV1Response());
-
-            var response = _classUnderTest.ListRelationships(request) as ObjectResult;
-
-            response?.StatusCode.Should().Be(200);
-        }
-
-        [Test]
-        public void ListRelationshipsReturn404WithCorrectErrorMessageWhenPersonIsNotFound()
-        {
-            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
-
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Throws(new GetRelationshipsException("Person not found"));
-
-            var response = _classUnderTest.ListRelationships(request) as NotFoundObjectResult;
-
-            response?.StatusCode.Should().Be(404);
-            response?.Value.Should().Be("Person not found");
-        }
-
-        [Test]
-        public void ListRelationshipsReturns200AndRelationshipsWhenSuccessful()
-        {
-            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
-
-            var listRelationShipsResponse = _fixture.Create<ListRelationshipsV1Response>();
-
-            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(listRelationShipsResponse);
-
-            var response = _classUnderTest.ListRelationships(request) as ObjectResult;
-
-            response?.Value.Should().BeOfType<ListRelationshipsV1Response>();
-            response?.Value.Should().BeEquivalentTo(listRelationShipsResponse);
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+
+namespace SocialCareCaseViewerApi.V1.Controllers
+{
+    [ApiController]
+    [Route("api/v1")]
+    [Produces("application/json")]
+    [ApiVersion("1.0")]
+    public class RelationshipController : BaseController
+    {
+        private readonly IRelationshipsV1UseCase _relationshipsV1UseCase;
+
+        public RelationshipController(IRelationshipsV1UseCase relationshipsV1UseCase)
+        {
+            _relationshipsV1UseCase = relationshipsV1UseCase;
+        }
+
+        /// <summary>
+        /// Get a list of relationships by person id
+        /// </summary>
+        /// <param name="request"></param>
+        /// <response code="200">Successful request. Relationships returned</response>
+        /// <response code="404">Person not found</response>
+        /// <response code="500">There was a problem getting the relationships</response>
+        [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("residents/{personId}/relationships")]
+        public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)
+        {
+            try
+            {
+                return Ok(_relationshipsV1UseCase.ExecuteGet(request));
+            }
+            catch (GetRelationshipsException ex)
+            {
+                return NotFound(ex.Message);
+            }
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -25,12 +25,11 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         private readonly IWarningNoteUseCase _warningNoteUseCase;
         private readonly IGetVisitByVisitIdUseCase _getVisitByVisitIdUseCase;
         private readonly IPersonUseCase _personUseCase;
-        private readonly IRelationshipsV1UseCase _relationshipsV1UseCase;
 
         public SocialCareCaseViewerApiController(IGetAllUseCase getAllUseCase, IAddNewResidentUseCase addNewResidentUseCase,
             IAllocationsUseCase allocationUseCase, ICaseNotesUseCase caseNotesUseCase,
             IVisitsUseCase visitsUseCase, IWarningNoteUseCase warningNotesUseCase,
-            IGetVisitByVisitIdUseCase getVisitByVisitIdUseCase, IPersonUseCase personUseCase, IRelationshipsV1UseCase relationshipsV1UseCase)
+            IGetVisitByVisitIdUseCase getVisitByVisitIdUseCase, IPersonUseCase personUseCase)
         {
             _getAllUseCase = getAllUseCase;
             _addNewResidentUseCase = addNewResidentUseCase;
@@ -40,7 +39,6 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             _warningNoteUseCase = warningNotesUseCase;
             _getVisitByVisitIdUseCase = getVisitByVisitIdUseCase;
             _personUseCase = personUseCase;
-            _relationshipsV1UseCase = relationshipsV1UseCase;
         }
 
         /// <summary>
@@ -378,28 +376,6 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             catch (PatchWarningNoteException e)
             {
                 return BadRequest(e.Message);
-            }
-        }
-
-        /// <summary>
-        /// Get a list of relationships by person id
-        /// </summary>
-        /// <param name="request"></param>
-        /// <response code="200">Successful request. Relationships returned</response>
-        /// <response code="404">Person not found</response>
-        /// <response code="500">There was a problem getting the relationships</response>
-        [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
-        [HttpGet]
-        [Route("residents/{personId}/relationships")]
-        public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)
-        {
-            try
-            {
-                return Ok(_relationshipsV1UseCase.ExecuteGet(request));
-            }
-            catch (GetRelationshipsException ex)
-            {
-                return NotFound(ex.Message);
             }
         }
     }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-589

## Describe this PR

### *What is the problem we're trying to solve*

We want to duplicate the current get relationships API endpoint (`residents/{personId}/relationships`) as we need to completely change the response without breaking current functionality.

### *What changes have we introduced*

This PR adds a new controller called `RelationshipController` and then moves the current relationships endpoint into there. Decided to split this first bit off so it's easier to review and we can get this deployed alongside the renaming in #310.

### *Follow up actions after merging PR*

Duplicate the relationships endpoint but with different path (`residents/{personId}/relationships-v1`)
