### PR TITLE
feat(SCT-589): add duplicated get relationships API endpoint

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/RelationshipControllerTests.cs
@@ -29,7 +29,47 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void ListRelationshipsReturn200WhenPersonIsFound()
+        public void ListRelationshipsV1Returns200WhenPersonIsFound()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(new ListRelationshipsV1Response());
+
+            var response = _classUnderTest.ListRelationshipsV1(request) as ObjectResult;
+
+            response?.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void ListRelationshipsV1Returns404WithCorrectErrorMessageWhenPersonIsNotFound()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Throws(new GetRelationshipsException("Person not found"));
+
+            var response = _classUnderTest.ListRelationshipsV1(request) as NotFoundObjectResult;
+
+            response?.StatusCode.Should().Be(404);
+            response?.Value.Should().Be("Person not found");
+        }
+
+        [Test]
+        public void ListRelationshipsV1Returns200AndRelationshipsWhenSuccessful()
+        {
+            var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
+
+            var listRelationShipsResponse = _fixture.Create<ListRelationshipsV1Response>();
+
+            _mockRelationshipsUseCase.Setup(x => x.ExecuteGet(It.IsAny<ListRelationshipsV1Request>())).Returns(listRelationShipsResponse);
+
+            var response = _classUnderTest.ListRelationshipsV1(request) as ObjectResult;
+
+            response?.Value.Should().BeOfType<ListRelationshipsV1Response>();
+            response?.Value.Should().BeEquivalentTo(listRelationShipsResponse);
+        }
+
+        [Test]
+        public void ListRelationshipsReturns200WhenPersonIsFound()
         {
             var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 
@@ -41,7 +81,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void ListRelationshipsReturn404WithCorrectErrorMessageWhenPersonIsNotFound()
+        public void ListRelationshipsReturns404WithCorrectErrorMessageWhenPersonIsNotFound()
         {
             var request = new ListRelationshipsV1Request() { PersonId = _faker.Random.Long() };
 

--- a/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
@@ -29,6 +29,28 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="500">There was a problem getting the relationships</response>
         [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
         [HttpGet]
+        [Route("residents/{personId}/relationships-v1")]
+        public IActionResult ListRelationshipsV1([FromQuery] ListRelationshipsV1Request request)
+        {
+            try
+            {
+                return Ok(_relationshipsV1UseCase.ExecuteGet(request));
+            }
+            catch (GetRelationshipsException ex)
+            {
+                return NotFound(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Get a list of relationships by person id
+        /// </summary>
+        /// <param name="request"></param>
+        /// <response code="200">Successful request. Relationships returned</response>
+        /// <response code="404">Person not found</response>
+        /// <response code="500">There was a problem getting the relationships</response>
+        [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
+        [HttpGet]
         [Route("residents/{personId}/relationships")]
         public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)
         {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-589

## Describe this PR

### *What is the problem we're trying to solve*

We want to duplicate the current get relationships API endpoint (`residents/{personId}/relationships`) as we need to completely change the response without breaking current functionality.

Related PRs: #311, #310.

### *What changes have we introduced*

This PR duplicates the current get relationships API endpoint. It's a temporary addition. We'll update the frontend to use `residents/{personId}/relationships-v1` and then work on the `residents/{personId}/relationships` to make this the canonical API endpoint.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy to prod!