### PR TITLE
feat(SCT-412): add DatabaseGateway#GetPersonWithPersonalRelationshipsByPersonId 

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -71,13 +71,23 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
-        public void WhenThereIsARelationshipHasAnEndDateReturnsEmptyListForPersonalRelationships()
+        public void WhenIncludeEndedRelationshipsIsFalseReturnsEmptyListForPersonalRelationships()
         {
             var (person, _, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, hasEnded: true);
 
-            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id, includeEndedRelationships: false);
 
             response.PersonalRelationships.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenIncludeEndedRelationshipsIsTrueReturnsPersonalRelationships()
+        {
+            var (person, _, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, hasEnded: true);
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id, includeEndedRelationships: true);
+
+            response.PersonalRelationships.Should().NotBeEmpty();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -21,6 +21,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
+        public void WhenNoMatchingPersonIdReturnsNull()
+        {
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(123456789);
+
+            response.Should().BeNull();
+        }
+
+        [Test]
         public void WhenThereAreNoRelationshipsReturnsEmptyListForPersonalRelationships()
         {
             var (person, _, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, withRelationship: false);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Driver;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Gateways;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
+{
+    [TestFixture]
+    public class GetPersonWithPersonalRelationshipsByPersonIdTests : DatabaseTests
+    {
+        private DatabaseGateway _databaseGateway;
+        private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+
+        [SetUp]
+        public void Setup()
+        {
+            _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object);
+        }
+
+        [Test]
+        public void WhenThereAreNoRelationshipsReturnsEmptyListForPersonalRelationships()
+        {
+            var (person, _, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, withRelationship: false);
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+
+            response.PersonalRelationships.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenThereIsARelationshipReturnsThePersonalRelationship()
+        {
+            var (person, _, personalRelationship, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+
+            response.PersonalRelationships.FirstOrDefault().Should().BeEquivalentTo(personalRelationship);
+        }
+
+        [Test]
+        public void WhenThereIsARelationshipReturnsTheDetailsOfTheOtherPerson()
+        {
+            var (person, otherPerson, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+            var otherPersonInResponse = response.PersonalRelationships.FirstOrDefault().OtherPerson;
+
+            otherPersonInResponse.Should().BeEquivalentTo(otherPerson);
+        }
+
+        [Test]
+        public void WhenThereIsARelationshipReturnsTheDescriptionOfThePersonalRelationshipType()
+        {
+            var (person, _, _, personalRelationshipType, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, relationshipType: "stepParent", otherRelationshipType: "stepChild");
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+            var personalRelationshipTypeInResponse = response.PersonalRelationships.FirstOrDefault().Type;
+
+            personalRelationshipTypeInResponse.Description.Should().Equals(personalRelationshipType.Description);
+        }
+
+        [Test]
+        public void WhenThereIsARelationshipHasAnEndDateReturnsEmptyListForPersonalRelationships()
+        {
+            var (person, _, _, _, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, hasEnded: true);
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+
+            response.PersonalRelationships.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenThereIsARelationshipWithDetailsReturnsTheDetails()
+        {
+            var (person, _, _, _, personalRelationshipDetail) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext, details: "Emergency contact");
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+
+            response.PersonalRelationships.FirstOrDefault().Details.Should().BeEquivalentTo(personalRelationshipDetail);
+        }
+
+        [Test]
+        public void WhenThereAreMultipleRelationshipsReturnsAllRelevantPersonalRelationships()
+        {
+            var (person, _, _, personalRelationshipType, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
+            var anotherPerson = TestHelpers.CreatePerson();
+            var anotherRelationship = PersonalRelationshipsHelper.CreatePersonalRelationship(person.Id, anotherPerson.Id, personalRelationshipType.Id, id: 1);
+            var andAnotherPerson = TestHelpers.CreatePerson();
+            var andAnotherRelationship = PersonalRelationshipsHelper.CreatePersonalRelationship(person.Id, andAnotherPerson.Id, personalRelationshipType.Id, hasEnded: true, id: 2);
+            DatabaseContext.Persons.Add(anotherPerson);
+            DatabaseContext.Persons.Add(andAnotherPerson);
+            DatabaseContext.PersonalRelationships.Add(anotherRelationship);
+            DatabaseContext.PersonalRelationships.Add(andAnotherRelationship);
+            DatabaseContext.SaveChanges();
+
+            var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
+
+            response.PersonalRelationships.Should().HaveCount(2);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -480,6 +480,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             DatabaseContext.PersonOtherNames.RemoveRange(DatabaseContext.PersonOtherNames);
             DatabaseContext.Addresses.RemoveRange(DatabaseContext.Addresses);
             DatabaseContext.PhoneNumbers.RemoveRange(DatabaseContext.PhoneNumbers);
+            DatabaseContext.PersonalRelationships.RemoveRange(DatabaseContext.PersonalRelationships);
 
             const string title = "Mr";
             var firstName = _faker.Name.FirstName();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -42,11 +42,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             long personId,
             long otherPersonId,
             long typeId,
-            Boolean hasEnded = false
+            Boolean hasEnded = false,
+            long? id = null
         )
         {
             return new Faker<PersonalRelationship>()
-                .RuleFor(pr => pr.Id, f => f.UniqueIndex)
+                .RuleFor(pr => pr.Id, f => id ?? f.UniqueIndex)
                 .RuleFor(pr => pr.PersonId, personId)
                 .RuleFor(pr => pr.OtherPersonId, otherPersonId)
                 .RuleFor(pr => pr.TypeId, typeId)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -1,0 +1,83 @@
+using System;
+using Bogus;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using Person = SocialCareCaseViewerApi.V1.Infrastructure.Person;
+
+#nullable enable
+namespace SocialCareCaseViewerApi.Tests.V1.Helpers
+{
+    public static class PersonalRelationshipsHelper
+    {
+        public static (Person, Person, PersonalRelationship?, PersonalRelationshipType?, PersonalRelationshipDetail?) SavePersonWithPersonalRelationshipToDatabase(
+            DatabaseContext databaseContext,
+            Boolean withRelationship = true,
+            string relationshipType = "parent",
+            string otherRelationshipType = "child",
+            Boolean hasEnded = false,
+            string? details = null
+        )
+        {
+            var person = TestHelpers.CreatePerson();
+            var otherPerson = TestHelpers.CreatePerson();
+
+            databaseContext.Persons.Add(person);
+            databaseContext.Persons.Add(otherPerson);
+            databaseContext.SaveChanges();
+
+            if (withRelationship == false) return (person, otherPerson, null, null, null);
+
+            var (personalRelationshipType, _) = CreatePersonalRelationshipTypes(relationshipType, otherRelationshipType);
+            var personalRelationship = CreatePersonalRelationship(person.Id, otherPerson.Id, personalRelationshipType.Id, hasEnded);
+            var personalRelationshipDetail = CreatePersonalRelationshipDetail(personalRelationship.Id, details);
+
+            databaseContext.PersonalRelationshipTypes.Add(personalRelationshipType);
+            databaseContext.PersonalRelationships.Add(personalRelationship);
+            databaseContext.PersonalRelationshipDetails.Add(personalRelationshipDetail);
+            databaseContext.SaveChanges();
+
+            return (person, otherPerson, personalRelationship, personalRelationshipType, personalRelationshipDetail);
+        }
+
+        public static PersonalRelationship CreatePersonalRelationship(
+            long personId,
+            long otherPersonId,
+            long typeId,
+            Boolean hasEnded = false
+        )
+        {
+            return new Faker<PersonalRelationship>()
+                .RuleFor(pr => pr.Id, f => f.UniqueIndex)
+                .RuleFor(pr => pr.PersonId, personId)
+                .RuleFor(pr => pr.OtherPersonId, otherPersonId)
+                .RuleFor(pr => pr.TypeId, typeId)
+                .RuleFor(pr => pr.StartDate, f => f.Date.Past())
+                .RuleFor(pr => pr.EndDate, f => hasEnded ? f.Date.Future() : (DateTime?) null)
+                .RuleFor(pr => pr.IsInformalCarer, f => f.Random.String2(1, "YN"))
+                .RuleFor(pr => pr.ParentalResponsibility, f => f.Random.String2(1, "YN"));
+        }
+
+        public static PersonalRelationshipDetail CreatePersonalRelationshipDetail(long personalRelationshipId, string? details = null)
+        {
+            return new Faker<PersonalRelationshipDetail>()
+                .RuleFor(prd => prd.Id, f => f.UniqueIndex)
+                .RuleFor(prd => prd.PersonalRelationshipId, personalRelationshipId)
+                .RuleFor(prd => prd.Details, f => details ?? f.Random.String2(1000));
+        }
+
+        public static (PersonalRelationshipType, PersonalRelationshipType) CreatePersonalRelationshipTypes(string? description = null, string? inverseDescription = null)
+        {
+            PersonalRelationshipType personalRelationshipType = new Faker<PersonalRelationshipType>()
+                .RuleFor(prt => prt.Id, f => f.UniqueIndex)
+                .RuleFor(prt => prt.Description, f => description ?? f.Random.String2(20));
+
+            PersonalRelationshipType inversePersonalRelationshipType = new Faker<PersonalRelationshipType>()
+                .RuleFor(prt => prt.Id, f => f.UniqueIndex)
+                .RuleFor(prt => prt.Description, f => inverseDescription ?? f.Random.String2(20));
+
+            personalRelationshipType.InverseTypeId = inversePersonalRelationshipType.Id;
+            inversePersonalRelationshipType.InverseTypeId = personalRelationshipType.Id;
+
+            return (personalRelationshipType, inversePersonalRelationshipType);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -887,6 +887,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .Include(person => person.PersonalRelationships)
                 .FirstOrDefault(p => p.Id == personId);
 
+            if (personWithRelationships == null) return null;
+
             personWithRelationships.PersonalRelationships = personWithRelationships.PersonalRelationships.Where(pr => pr.EndDate == null).ToList();
 
             return personWithRelationships;

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -880,7 +880,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return _databaseContext.Persons.Where(x => ids.Contains(x.Id)).ToList();
         }
 
-        public Person GetPersonWithPersonalRelationshipsByPersonId(long personId)
+        public Person GetPersonWithPersonalRelationshipsByPersonId(long personId, Boolean includeEndedRelationships = false)
         {
             var personWithRelationships = _databaseContext
                 .Persons
@@ -889,7 +889,10 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (personWithRelationships == null) return null;
 
-            personWithRelationships.PersonalRelationships = personWithRelationships.PersonalRelationships.Where(pr => pr.EndDate == null).ToList();
+            if (includeEndedRelationships == false)
+            {
+                personWithRelationships.PersonalRelationships = personWithRelationships.PersonalRelationships.Where(pr => pr.EndDate == null).ToList();
+            }
 
             return personWithRelationships;
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -880,6 +880,18 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return _databaseContext.Persons.Where(x => ids.Contains(x.Id)).ToList();
         }
 
+        public Person GetPersonWithPersonalRelationshipsByPersonId(long personId)
+        {
+            var personWithRelationships = _databaseContext
+                .Persons
+                .Include(person => person.PersonalRelationships)
+                .FirstOrDefault(p => p.Id == personId);
+
+            personWithRelationships.PersonalRelationships = personWithRelationships.PersonalRelationships.Where(pr => pr.EndDate == null).ToList();
+
+            return personWithRelationships;
+        }
+
         private static AllocationSet SetDeallocationValues(AllocationSet allocation, DateTime dt, string modifiedBy)
         {
             //keep workerId and TeamId in the record so they can be easily exposed to front end

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -36,5 +36,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         void UpdatePerson(UpdatePersonRequest request);
         List<Person> GetPersonsByListOfIds(List<long> ids);
         Person GetPersonByMosaicId(long mosaicId);
+        Person GetPersonWithPersonalRelationshipsByPersonId(long personId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -36,6 +37,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         void UpdatePerson(UpdatePersonRequest request);
         List<Person> GetPersonsByListOfIds(List<long> ids);
         Person GetPersonByMosaicId(long mosaicId);
-        Person GetPersonWithPersonalRelationshipsByPersonId(long personId);
+        Person GetPersonWithPersonalRelationshipsByPersonId(long personId, Boolean includeEndedRelationships);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/Person.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/Person.cs
@@ -14,6 +14,12 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public List<AllocationSet> Allocations { get; set; }
         public List<WarningNote> WarningNotes { get; set; }
 
+        [InverseProperty("Person")]
+        public List<PersonalRelationship> PersonalRelationships { get; set; }
+
+        [InverseProperty("OtherPerson")]
+        public List<PersonalRelationship> InversePersonalRelationships { get; set; }
+
         [Column("person_id")]
         [MaxLength(16)]
         [Key]

--- a/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationship.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationship.cs
@@ -15,14 +15,17 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [Column("fk_person_id")]
         [MaxLength(16)]
         public long PersonId { get; set; }
+        public Person Person { get; set; }
 
         [Column("fk_other_person_id")]
         [MaxLength(16)]
         public long OtherPersonId { get; set; }
+        public Person OtherPerson { get; set; }
 
         [Column("fk_personal_relationship_type_id")]
         [MaxLength(16)]
-        public long PersonalRelationshipTypeId { get; set; }
+        public long TypeId { get; set; }
+        public PersonalRelationshipType Type { get; set; }
 
         [Column("start_date")]
         public DateTime StartDate { get; set; }
@@ -50,5 +53,8 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
 
         [Column("sccv_last_modified_by")]
         public string LastModifiedBy { get; set; }
+
+        [InverseProperty("PersonalRelationship")]
+        public PersonalRelationshipDetail Details { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationshipDetail.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationshipDetail.cs
@@ -15,6 +15,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [Column("fk_personal_relationship_id")]
         [MaxLength(16)]
         public long PersonalRelationshipId { get; set; }
+        public PersonalRelationship PersonalRelationship { get; set; }
 
         [Column("details")]
         [MaxLength(100)]


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-412

## Describe this PR

### *What is the problem we're trying to solve*

We've set everything up to allow us to change the response for getting relationships, now it's time to write the code to do dis!

### *What changes have we introduced*

This PR adds a new method in the `DatabaseGateway` to get a person with their personal relationships. For each personal relationship, it will also retrieve the details of the other person, the description of the relationship type and its details
e.g. "Emergency contact".

Some noticeable things:

- A completely new and separate test file is added even though it's part of `DatabaseGateway` as `DatabaseGateway.Tests.cs` is BIG -> `SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs` 
- A completely new and separate test helper is added that is just for personal relationships as `TestHelpers` is BIG -> `SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs`

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Create the use case to map the response from the gateway.