### PR TITLE
Feat(SCT-630): Add list endpoint for incomplete submissions

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/FormSubmissionControllerTests.cs
@@ -1,11 +1,14 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Controllers
@@ -94,6 +97,32 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
             var response = _formSubmissionController.GetSubmissionById("1234") as NotFoundResult;
 
             response?.StatusCode.Should().Be(404);
+        }
+
+        [Test]
+        public void ListBySubmissionStatusReturns200WhenMatchesAreFound()
+        {
+            var submissionResponse = new List<CaseSubmissionResponse> { TestHelpers.CreateCaseSubmission(SubmissionState.InProgress).ToDomain().ToResponse() };
+
+            _submissionsUseCaseMock.Setup(x => x.ExecuteListBySubmissionStatus(SubmissionState.InProgress)).Returns(submissionResponse);
+
+            var response = _formSubmissionController.ListAllSubmissionsInProgress() as ObjectResult;
+
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(submissionResponse);
+        }
+
+        [Test]
+        public void ListBySubmissionStatusReturns200AndEmptyListWhenNoMatchesAreFound()
+        {
+            var submissionResponse = new List<CaseSubmissionResponse>();
+
+            _submissionsUseCaseMock.Setup(x => x.ExecuteListBySubmissionStatus(SubmissionState.InProgress)).Returns(submissionResponse);
+
+            var response = _formSubmissionController.ListAllSubmissionsInProgress() as ObjectResult;
+
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(submissionResponse);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bogus;
 using FluentAssertions;
@@ -120,6 +121,26 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             _mockMongoGateway.Verify(x => x.LoadRecordById<CaseSubmission>(It.IsAny<string>(), ObjectId.Parse(objectId)), Times.Once);
             response.Should().BeNull();
+        }
+
+        [Test]
+        public void ExecuteListBySubmissionStatusSuccessfully()
+        {
+            var firstSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
+            var secondSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
+
+            var submissionResponse = new List<CaseSubmission> { firstSubmission, secondSubmission };
+
+            _mockMongoGateway
+                .Setup(x => x.LoadMultipleRecordsByProperty<CaseSubmission, SubmissionState>(It.IsAny<string>(), "SubmissionState", SubmissionState.InProgress))
+                .Returns(submissionResponse);
+
+            var response = _formSubmissionsUseCase.ExecuteListBySubmissionStatus(SubmissionState.InProgress);
+
+            _mockMongoGateway
+                .Verify(x => x.LoadMultipleRecordsByProperty<CaseSubmission, SubmissionState>(It.IsAny<string>(), "SubmissionState", SubmissionState.InProgress), Times.Once);
+
+            response.Should().BeEquivalentTo(submissionResponse.Select(x => x.ToDomain().ToResponse()));
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -144,6 +144,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ExecuteListBySubmissionStatusShouldReturnAnEmptyListIfNoMatchesWereFound()
+        {
+            var response = _formSubmissionsUseCase.ExecuteListBySubmissionStatus(SubmissionState.Submitted);
+
+            _mockMongoGateway
+                .Verify(x => x.LoadMultipleRecordsByProperty<CaseSubmission, SubmissionState>(It.IsAny<string>(), "SubmissionState", SubmissionState.Submitted), Times.Once);
+
+            response.Should().BeEmpty();
+        }
+
+        [Test]
         public void ExecuteFinishSubmissionSuccessfullyCompletesASubmission()
         {
             var request = TestHelpers.FinishCaseSubmissionRequest();

--- a/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
 namespace SocialCareCaseViewerApi.V1.Controllers
@@ -38,6 +40,20 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             }
 
             return Ok(submission);
+        }
+
+        /// <summary>
+        /// Lists all in-progress case submissions
+        /// </summary>
+        /// <response code="200">Success. Returns a list of any in progress case submissions</response>
+        [ProducesResponseType(typeof(List<CaseSubmissionResponse>), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("status/in-progress")]
+        public IActionResult ListAllSubmissionsInProgress()
+        {
+            var submissions = _formSubmissionsUseCase.ExecuteListBySubmissionStatus(SubmissionState.InProgress);
+
+            return Ok(submissions);
         }
 
         /// <summary>

--- a/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
@@ -48,7 +48,6 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="200">Success. Returns a list of any in progress case submissions</response>
         [ProducesResponseType(typeof(List<CaseSubmissionResponse>), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("status/in-progress")]
         public IActionResult ListAllSubmissionsInProgress()
         {
             var submissions = _formSubmissionsUseCase.ExecuteListBySubmissionStatus(SubmissionState.InProgress);

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MongoDB.Bson;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -83,6 +84,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             var foundSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
 
             return foundSubmission?.ToDomain().ToResponse();
+        }
+
+        public List<CaseSubmissionResponse> ExecuteListBySubmissionStatus(SubmissionState state)
+        {
+            var foundSubmissions = _mongoGateway
+                .LoadMultipleRecordsByProperty<CaseSubmission, SubmissionState>(_collectionName, "SubmissionState",
+                    state);
+
+            return foundSubmissions.Select(x => x.ToDomain().ToResponse()).ToList();
         }
 
         public void ExecuteFinishSubmission(string submissionId, FinishCaseSubmissionRequest request)

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -92,7 +92,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 .LoadMultipleRecordsByProperty<CaseSubmission, SubmissionState>(_collectionName, "SubmissionState",
                     state);
 
-            return foundSubmissions.Select(x => x.ToDomain().ToResponse()).ToList();
+            return foundSubmissions == null
+                ? new List<CaseSubmissionResponse>()
+                : foundSubmissions.Select(x => x.ToDomain().ToResponse()).ToList();
         }
 
         public void ExecuteFinishSubmission(string submissionId, FinishCaseSubmissionRequest request)

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IFormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IFormSubmissionsUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Infrastructure;
@@ -10,6 +11,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
         (CaseSubmissionResponse, CaseSubmission) ExecutePost(CreateCaseSubmissionRequest request);
 
         CaseSubmissionResponse ExecuteGetById(string submissionId);
+
+        List<CaseSubmissionResponse> ExecuteListBySubmissionStatus(SubmissionState state);
 
         void ExecuteFinishSubmission(string submissionId, FinishCaseSubmissionRequest request);
         CaseSubmissionResponse UpdateAnswers(string submissionId, string stepId,


### PR DESCRIPTION
The new form builder created for the application deals with completing a form by saving the current state of the submission as a status property in MongoDB.

This adds a `LIST` endpoint that, when called, would return a list of all **in-progress** submissions only.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary, e.g. to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [X] Added comments to the README or updated, relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *ACTIONS AFTER MERGING PR*

- Test the endpoint in staging