### PR TITLE
Bugfix: add loop to remove circular reference for allocation worker

### DIFF
--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -59,7 +59,12 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 name.Person = null;
             }
 
-
+             for (var index = 0; index < resident.Allocations?.Count; index++)
+            {
+                var allocation = resident.Allocations[index];
+                allocation.Person = null;
+            }
+            
             var dateTimeNow = DateTime.Now;
 
             var caseSubmission = new CaseSubmission

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -59,12 +59,12 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 name.Person = null;
             }
 
-             for (var index = 0; index < resident.Allocations?.Count; index++)
+            for (var index = 0; index < resident.Allocations?.Count; index++)
             {
                 var allocation = resident.Allocations[index];
                 allocation.Person = null;
             }
-            
+
             var dateTimeNow = DateTime.Now;
 
             var caseSubmission = new CaseSubmission


### PR DESCRIPTION
## Link to JIRA ticket

None

## Describe this PR

### *What is the problem we're trying to solve*

To try and solve the bug related to the mongoDB circular reference issue when trying to post a new submission, A for loop has been added which makes the person associated with an allocation null so that it does not loop around and keep referencing itself

### *What changes have we introduced*

Add a for loop which makes the person attribute of a allocation null

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
