### PR TITLE
feat(SCT-412): update get relationships endpoint to use new use case

### DIFF
--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -164,6 +164,7 @@ namespace SocialCareCaseViewerApi
             services.AddScoped<IPersonUseCase, PersonUseCase>();
             services.AddScoped<IRelationshipsV1UseCase, RelationshipsV1UseCase>();
             services.AddScoped<IFormSubmissionsUseCase, FormSubmissionsUseCase>();
+            services.AddScoped<IRelationshipsUseCase, RelationshipsUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
@@ -14,14 +14,16 @@ namespace SocialCareCaseViewerApi.V1.Controllers
     public class RelationshipController : BaseController
     {
         private readonly IRelationshipsV1UseCase _relationshipsV1UseCase;
+        private readonly IRelationshipsUseCase _relationshipsUseCase;
 
-        public RelationshipController(IRelationshipsV1UseCase relationshipsV1UseCase)
+        public RelationshipController(IRelationshipsV1UseCase relationshipsV1UseCase, IRelationshipsUseCase relationshipsUseCase)
         {
             _relationshipsV1UseCase = relationshipsV1UseCase;
+            _relationshipsUseCase = relationshipsUseCase;
         }
 
         /// <summary>
-        /// Get a list of relationships by person id
+        /// Get a list of relationships by person id (old)
         /// </summary>
         /// <param name="request"></param>
         /// <response code="200">Successful request. Relationships returned</response>
@@ -45,18 +47,17 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <summary>
         /// Get a list of relationships by person id
         /// </summary>
-        /// <param name="request"></param>
         /// <response code="200">Successful request. Relationships returned</response>
         /// <response code="404">Person not found</response>
         /// <response code="500">There was a problem getting the relationships</response>
-        [ProducesResponseType(typeof(ListRelationshipsV1Response), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ListRelationshipsResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("residents/{personId}/relationships")]
-        public IActionResult ListRelationships([FromQuery] ListRelationshipsV1Request request)
+        [Route("residents/{personId:long}/relationships")]
+        public IActionResult ListRelationships(long personId)
         {
             try
             {
-                return Ok(_relationshipsV1UseCase.ExecuteGet(request));
+                return Ok(_relationshipsUseCase.ExecuteGet(personId));
             }
             catch (GetRelationshipsException ex)
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-412

## Describe this PR

### *What is the problem we're trying to solve*

We've set everything up to allow us to change the response for getting relationships. In #317, we added the database gateway method to get the data need from the database and in #320 we added a new use case which responds with the new response.

### *What changes have we introduced*

This PR updates our canonical get relationships endpoint to use our new use case which response with the new structure.

```json
{
 "personId": 555666777,
  "personalRelationships": [
    {
      "type": "sibling",
      "persons": [
        {
          "id": 333444555,
          "firstName": "Firstone",
          "lastName": "Lastone",
          "gender": "M"
        },
        {
          "id": 333444555,
          "firstName": "Firstone",
          "lastName": "Lastone",
          "gender": "F"
        }
      ]
    }
  ]
}

```

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly