### PR TITLE
add Team null to submissions use case

### DIFF
--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -63,6 +63,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             {
                 var allocation = resident.Allocations[index];
                 allocation.Person = null;
+                allocation.Team = null;
             }
 
             var dateTimeNow = DateTime.Now;


### PR DESCRIPTION

**What is the problem we're trying to solve**

To try and solve the bug related to the mongoDB circular reference issue when trying to post a new submission, A for loop has been added which makes the person associated with an allocation null so that it does not loop around and keep referencing itself. We have also added a line for teams to be null to stop the circular reference.

**What changes have we introduced**

Add a for loop which makes the person attribute of a allocation null