### PR TITLE
fix(SCT-412): fix not getting related entities to personal relationships

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Gateways;
+using Microsoft.EntityFrameworkCore;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 {
@@ -18,6 +19,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         public void Setup()
         {
             _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object);
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 
         [Test]
@@ -45,7 +47,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
 
-            response.PersonalRelationships.FirstOrDefault().Should().BeEquivalentTo(personalRelationship);
+            response.PersonalRelationships.FirstOrDefault().Id.Should().Be(personalRelationship.Id);
+            response.PersonalRelationships.FirstOrDefault().PersonId.Should().Be(personalRelationship.PersonId);
+            response.PersonalRelationships.FirstOrDefault().OtherPersonId.Should().Be(personalRelationship.OtherPersonId);
+            response.PersonalRelationships.FirstOrDefault().TypeId.Should().Be(personalRelationship.TypeId);
         }
 
         [Test]
@@ -56,7 +61,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
             var otherPersonInResponse = response.PersonalRelationships.FirstOrDefault().OtherPerson;
 
-            otherPersonInResponse.Should().BeEquivalentTo(otherPerson);
+            otherPersonInResponse.Id.Should().Be(otherPerson.Id);
+            otherPersonInResponse.FirstName.Should().Be(otherPerson.FirstName);
+            otherPersonInResponse.LastName.Should().Be(otherPerson.LastName);
+            otherPersonInResponse.Gender.Should().Be(otherPerson.Gender);
         }
 
         [Test]
@@ -97,7 +105,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var response = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(person.Id);
 
-            response.PersonalRelationships.FirstOrDefault().Details.Should().BeEquivalentTo(personalRelationshipDetail);
+            response.PersonalRelationships.FirstOrDefault().Details.Details.Should().BeEquivalentTo(personalRelationshipDetail.Details);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -885,6 +885,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var personWithRelationships = _databaseContext
                 .Persons
                 .Include(person => person.PersonalRelationships)
+                .ThenInclude(personalRelationship => personalRelationship.Type)
+                .Include(person => person.PersonalRelationships)
+                .ThenInclude(personalRelationship => personalRelationship.OtherPerson)
+                .Include(person => person.PersonalRelationships)
+                .ThenInclude(personalRelationship => personalRelationship.Details)
                 .FirstOrDefault(p => p.Id == personId);
 
             if (personWithRelationships == null) return null;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-412

## Describe this PR

### *What is the problem we're trying to solve*

In https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/324, we updated the get relationships API endpoint to return the new response. However, upon testing it failed on a null exception. Upon debugging, we realised that this was because the database gateway method was not returning all the related entities for a personal relationship.

We made an assumption that by just including `PersonalRelationships`, it would also include the related entities within a personal relationship like the `Type` and `OtherPerson` which seemed right as our tests passed.

However, when testing the API endpoint we realised this was incorrect and our tests only passed because EF Core was tracking the navigation properties because we had just seeded those entities. Therefore, by disabling tracking, our tests fail as expected.

### *What changes have we introduced*

This PR ensures we included all the relevant entities for a personal relationship and disables query tracking for the relationships tests as when this is enabled globally a number of tests fail which is beyond the scope of this.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test the frontend again with staging and then redeploy prod.
