### PR TITLE
Fix(SCT-680, SCT-728): Fix date bug when ending a warning note

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
@@ -160,7 +160,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             };
 
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewNotes, request)
-                .WithErrorMessage("Review notes be less than 1000 characters");
+                .WithErrorMessage("Review notes should be 1000 characters or less");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
@@ -189,6 +189,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 .WithErrorMessage("Discussed with manager date must be in the past");
         }
 
+        [Test]
+        public void GivenARequestWithEndedDateSetForLaterTodayValidationPasses()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                EndedDate = DateTime.Now.AddHours(1),
+                Status = "open"
+            };
 
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.EndedDate, request);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
@@ -1,0 +1,194 @@
+using System;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
+{
+    [TestFixture]
+    public class PatchWarningNoteRequestTests
+    {
+        private PatchWarningNoteRequestValidator _classUnderTest;
+
+
+        [SetUp]
+        public void SetUp()
+        {
+            _classUnderTest = new PatchWarningNoteRequestValidator();
+        }
+
+        [Test]
+        public void GivenARequestWithInvalidWarningNoteIdValidationFails()
+        {
+            var request = new PatchWarningNoteRequest { Status = "open" };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.WarningNoteId, request)
+                .WithErrorMessage("Warning Note Id must be greater than 1");
+        }
+
+        [Test]
+        public void GivenARequestWithNoReviewDateValidationFails()
+        {
+            var request = new PatchWarningNoteRequest { Status = "open" };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewDate, request)
+                .WithErrorMessage("Review date required");
+        }
+
+        [Test]
+        public void GivenARequestWithFutureReviewDateValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ReviewDate = DateTime.Now.AddYears(2),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewDate, request)
+                .WithErrorMessage("Review date must be in the past");
+        }
+
+        [Test]
+        public void GivenARequestWithNoReviewedByEmailValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewedBy, request)
+                .WithErrorMessage("Reviewer email required");
+        }
+
+        [Test]
+        public void GivenARequestWithInvalidReviewedByEmailAddressValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ReviewedBy = "hello",
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewedBy, request)
+                .WithErrorMessage("Provide a valid email address");
+        }
+
+        [Test]
+        public void GivenARequestWithNextReviewDateSetInThePastValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                NextReviewDate = new DateTime(2000, 1, 1),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.NextReviewDate, request)
+                .WithErrorMessage("Next review date must be in the future");
+        }
+
+        [Test]
+        public void GivenARequestWithInvalidStatusValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                Status = "hello"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.Status, request)
+                .WithErrorMessage("Provide a valid status");
+        }
+
+        [Test]
+        public void GivenARequestWithEndedDateSetInTheFutureValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                EndedDate = DateTime.Now.AddYears(2),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.EndedDate, request)
+                .WithErrorMessage("Ended date must be in the past");
+        }
+
+        [Test]
+        public void GivenARequestWithInvalidEndedByEmailAddressValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                EndedBy = "hello",
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.EndedBy, request)
+                .WithErrorMessage("Provide a valid email address");
+        }
+
+        [Test]
+        public void GivenARequestWithNoReviewNotesValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ReviewNotes = null,
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewNotes, request)
+                .WithErrorMessage("Review notes required");
+        }
+
+        [Test]
+        public void GivenARequestWithReviewNotesLessThanMinimumLengthValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ReviewNotes = "",
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewNotes, request)
+                .WithErrorMessage("Review notes required");
+        }
+
+        [Test]
+        public void GivenARequestWithReviewNotesMoreThanMaximumLengthValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ReviewNotes = new string('a', 1100),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ReviewNotes, request)
+                .WithErrorMessage("Review notes be less than 1000 characters");
+        }
+
+        [Test]
+        public void GivenARequestWithManagerNameMoreThanMaximumLengthValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                ManagerName = new string('a', 110),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.ManagerName, request)
+                .WithErrorMessage("Manager name must be less than 100 characters");
+        }
+
+        [Test]
+        public void GivenARequestWithDiscussedWithManagerDateSetInTheFutureValidationFails()
+        {
+            var request = new PatchWarningNoteRequest
+            {
+                DiscussedWithManagerDate = DateTime.Now.AddYears(2),
+                Status = "open"
+            };
+
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.DiscussedWithManagerDate, request)
+                .WithErrorMessage("Discussed with manager date must be in the past");
+        }
+
+
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/PatchWarningNoteRequestTests.cs
@@ -99,19 +99,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
-        public void GivenARequestWithEndedDateSetInTheFutureValidationFails()
-        {
-            var request = new PatchWarningNoteRequest
-            {
-                EndedDate = DateTime.Now.AddYears(2),
-                Status = "open"
-            };
-
-            _classUnderTest.ShouldHaveValidationErrorFor(x => x.EndedDate, request)
-                .WithErrorMessage("Ended date must be in the past");
-        }
-
-        [Test]
         public void GivenARequestWithInvalidEndedByEmailAddressValidationFails()
         {
             var request = new PatchWarningNoteRequest
@@ -187,18 +174,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.DiscussedWithManagerDate, request)
                 .WithErrorMessage("Discussed with manager date must be in the past");
-        }
-
-        [Test]
-        public void GivenARequestWithEndedDateSetForLaterTodayValidationPasses()
-        {
-            var request = new PatchWarningNoteRequest
-            {
-                EndedDate = DateTime.Now.AddHours(1),
-                Status = "open"
-            };
-
-            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.EndedDate, request);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/SocialCareCaseViewerApiControllerTests.cs
@@ -575,16 +575,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void PatchWarningNoteReturns400WhenInvalidEndedDate()
-        {
-            var request = TestHelpers.CreatePatchWarningNoteRequest(endedDate: DateTime.Now.AddDays(1)).Item1;
-
-            var response = _classUnderTest.PatchWarningNote(request) as ObjectResult;
-
-            response?.StatusCode.Should().Be(400);
-        }
-
-        [Test]
         public void PatchWarningNoteReturns400WhenInvalidReviewNotes()
         {
             var request = TestHelpers.CreatePatchWarningNoteRequest(reviewNotes: "").Item1;

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -14,11 +14,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
     {
         private DatabaseGateway _databaseGateway;
         private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+        private Mock<ISystemTime> _mockSystemTime;
 
         [SetUp]
         public void Setup()
         {
-            _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object);
+            _mockSystemTime = new Mock<ISystemTime>();
+            _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object, _mockSystemTime.Object);
             DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonWithPersonalRelationshipsByPersonIdTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Gateways;
 using Microsoft.EntityFrameworkCore;
+using SocialCareCaseViewerApi.V1.Helpers;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -15,6 +15,7 @@ using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using Allocation = SocialCareCaseViewerApi.V1.Infrastructure.AllocationSet;
 using dbAddress = SocialCareCaseViewerApi.V1.Infrastructure.Address;

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -37,17 +37,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         private Fixture _fixture;
         private ProcessDataGateway _processDataGateway;
         private Mock<ISocialCarePlatformAPIGateway> _mockSocialCarePlatformAPIGateway;
+        private Mock<ISystemTime> _mockSystemTime;
 
         [SetUp]
         public void Setup()
         {
             _mockProcessDataGateway = new Mock<IProcessDataGateway>();
-            _classUnderTest = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object);
+            _mockSystemTime = new Mock<ISystemTime>();
+            _classUnderTest = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object, _mockSystemTime.Object);
             _faker = new Faker();
             _fixture = new Fixture();
             _mockSocialCarePlatformAPIGateway = new Mock<ISocialCarePlatformAPIGateway>();
             _processDataGateway = new ProcessDataGateway(MongoDbTestContext, _mockSocialCarePlatformAPIGateway.Object);
-            _classUnderTestWithProcessDataGateway = new DatabaseGateway(DatabaseContext, _processDataGateway);
+            _classUnderTestWithProcessDataGateway = new DatabaseGateway(DatabaseContext, _processDataGateway, _mockSystemTime.Object);
         }
 
         [Test]
@@ -809,6 +811,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void PatchWarningNoteUpdatesAnExistingRecordInTheDatabase()
         {
+            var fakeTime = new DateTime(2000, 1, 1);
+            _mockSystemTime.Setup(time => time.Now).Returns(fakeTime);
+
             var (request, person, worker, warningNote) =
                 TestHelpers.CreatePatchWarningNoteRequest(requestStatus: "closed");
 
@@ -824,7 +829,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             var query = DatabaseContext.WarningNotes;
             var updatedRecord = query.First(x => x.Id == request.WarningNoteId);
 
-            updatedRecord.EndDate.Should().Be(request.EndedDate);
+            updatedRecord.EndDate.Should().Be(fakeTime);
             updatedRecord.LastReviewDate.Should().Be(request.ReviewDate);
             updatedRecord.NextReviewDate.Should().BeNull();
             updatedRecord.Status.Should().Be("closed");
@@ -873,6 +878,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void PatchWarningNoteClosesTheWarningNoteIfRequestStatusIsClosed()
         {
+            var fakeTime = new DateTime(2000, 1, 1);
+
+            _mockSystemTime.Setup(time => time.Now).Returns(fakeTime);
+
             var (request, person, worker, warningNote) =
                 TestHelpers.CreatePatchWarningNoteRequest(requestStatus: "closed");
 
@@ -886,7 +895,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             var updatedRecord = query.First(x => x.Id == request.WarningNoteId);
 
             updatedRecord.Status.Should().Be("closed");
-            updatedRecord.EndDate.Should().Be(request.EndedDate);
+            updatedRecord.EndDate.Should().Be(fakeTime);
             updatedRecord.NextReviewDate.Should().BeNull();
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -362,7 +362,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             DateTime? nextReviewDate = null,
             string? startingStatus = "open",
             string? requestStatus = "open",
-            DateTime? endedDate = null,
             string? endedBy = null,
             string? reviewNotes = null,
             string? managerName = null,
@@ -381,7 +380,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(p => p.NextReviewDate, f => nextReviewDate ?? f.Date.Future())
                 .RuleFor(p => p.DisclosedWithIndividual, f => disclosedWithIndividual)
                 .RuleFor(p => p.Status, f => requestStatus)
-                .RuleFor(p => p.EndedDate, f => endedDate ?? f.Date.Recent())
                 .RuleFor(p => p.EndedBy, f => endedBy ?? worker.Email)
                 .RuleFor(p => p.ReviewNotes, f => reviewNotes ?? f.Random.String2(1, 1000))
                 .RuleFor(p => p.ManagerName, f => managerName ?? f.Random.String2(1, 100))

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -128,6 +128,8 @@ namespace SocialCareCaseViewerApi
             services.AddTransient<IValidator<FinishCaseSubmissionRequest>, FinishCaseSubmissionRequestValidator>();
             services
                 .AddTransient<IValidator<UpdateFormSubmissionAnswersRequest>, UpdateFormSubmissionAnswersValidator>();
+
+            services.AddScoped<ISystemTime, SystemTime>();
         }
 
         private static void ConfigureDbContext(IServiceCollection services)

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
@@ -38,7 +38,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                 .NotNull().WithMessage("Status must be provided")
                 .Must(x => x.Equals("open") || x.Equals("closed")).WithMessage("Provide a valid status");
             RuleFor(x => x.EndedDate)
-                .LessThan(DateTime.Now).WithMessage("Ended date must be in the past");
+                .LessThan(DateTime.Today.AddDays(1)).WithMessage("Ended date must be in the past");
             RuleFor(x => x.EndedBy)
                 .EmailAddress().WithMessage("Provide a valid email address");
             RuleFor(x => x.ReviewNotes)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
@@ -44,7 +44,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(x => x.ReviewNotes)
                 .NotNull().WithMessage("Review notes required")
                 .MinimumLength(1).WithMessage("Review notes required")
-                .MaximumLength(1000).WithMessage("Review notes be less than 1000 characters");
+                .MaximumLength(1000).WithMessage("Review notes should be 1000 characters or less");
             RuleFor(x => x.ManagerName)
                 .MaximumLength(100).WithMessage("Manager name must be less than 100 characters");
             RuleFor(x => x.DiscussedWithManagerDate)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PatchWarningNoteRequest.cs
@@ -11,7 +11,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public string ReviewedBy { get; set; }
         public DateTime? NextReviewDate { get; set; }
         public string Status { get; set; }
-        public DateTime? EndedDate { get; set; }
         public string EndedBy { get; set; }
         public string ReviewNotes { get; set; }
         public string ManagerName { get; set; }
@@ -37,8 +36,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(x => x.Status)
                 .NotNull().WithMessage("Status must be provided")
                 .Must(x => x.Equals("open") || x.Equals("closed")).WithMessage("Provide a valid status");
-            RuleFor(x => x.EndedDate)
-                .LessThan(DateTime.Today.AddDays(1)).WithMessage("Ended date must be in the past");
             RuleFor(x => x.EndedBy)
                 .EmailAddress().WithMessage("Provide a valid email address");
             RuleFor(x => x.ReviewNotes)

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -10,6 +10,7 @@ using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Domain;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
+using SocialCareCaseViewerApi.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using Address = SocialCareCaseViewerApi.V1.Infrastructure.Address;
 using dbPhoneNumber = SocialCareCaseViewerApi.V1.Infrastructure.PhoneNumber;
@@ -1010,14 +1011,5 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 CreatedBy = createdBy
             };
         }
-    }
-
-    public class SystemTime : ISystemTime
-    {
-        public DateTime Now => DateTime.Now;
-    }
-    public interface ISystemTime
-    {
-        DateTime Now { get; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -25,11 +25,13 @@ namespace SocialCareCaseViewerApi.V1.Gateways
     {
         private readonly DatabaseContext _databaseContext;
         private readonly IProcessDataGateway _processDataGateway;
+        private readonly ISystemTime _systemTime;
 
-        public DatabaseGateway(DatabaseContext databaseContext, IProcessDataGateway processDataGateway)
+        public DatabaseGateway(DatabaseContext databaseContext, IProcessDataGateway processDataGateway, ISystemTime systemTime)
         {
             _databaseContext = databaseContext;
             _processDataGateway = processDataGateway;
+            _systemTime = systemTime;
         }
 
         public List<Allocation> SelectAllocations(long mosaicId, long workerId)
@@ -815,7 +817,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             if (request.Status?.ToLower() == "closed")
             {
                 warningNote.Status = "closed";
-                warningNote.EndDate = request.EndedDate;
+                warningNote.EndDate = _systemTime.Now;
                 warningNote.NextReviewDate = null;
             }
 
@@ -1008,5 +1010,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 CreatedBy = createdBy
             };
         }
+    }
+
+    public class SystemTime : ISystemTime
+    {
+        public DateTime Now => DateTime.Now;
+    }
+    public interface ISystemTime
+    {
+        DateTime Now { get; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Helpers/ISystemTime.cs
+++ b/SocialCareCaseViewerApi/V1/Helpers/ISystemTime.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SocialCareCaseViewerApi.V1.Helpers
+{
+    public interface ISystemTime
+    {
+        DateTime Now { get; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Helpers/SystemTime.cs
+++ b/SocialCareCaseViewerApi/V1/Helpers/SystemTime.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SocialCareCaseViewerApi.V1.Helpers
+{
+    public class SystemTime : ISystemTime
+    {
+        public DateTime Now => DateTime.Now;
+    }
+}


### PR DESCRIPTION
There is a potential issue with the date being provided by the client app when ending a warning note. 

Ending a warning note currently relies on the device time being passed into the request, but there may be instances where this might be different to our server time. e.g. if the client device time is incorrect or possible timezone differences.

This checks for the `status` parameter in an incoming PATCH warning note request and saves the server's current time to a warning note's `end date` if the status is set as `closed`. Thus, ignoring any end date value passed in from the frontend.

A [future PR](https://hackney.atlassian.net/browse/SCT-727) would remove the `ended date` parameter from being passed in Frontend.