### PR TITLE
feat(SCT-263): add manual update for adding is_main_carer to personal relationship

### DIFF
--- a/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationship.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationship.cs
@@ -37,6 +37,10 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [MaxLength(1)]
         public string IsInformalCarer { get; set; }
 
+        [Column("is_main_carer")]
+        [MaxLength(1)]
+        public string IsMainCarer { get; set; }
+
         [Column("parental_responsibility")]
         [MaxLength(1)]
         public string ParentalResponsibility { get; set; }

--- a/database/manual-updates/2021-06-28_1-add-is-main-carer-to-personal-relationship-table.md
+++ b/database/manual-updates/2021-06-28_1-add-is-main-carer-to-personal-relationship-table.md
@@ -1,0 +1,29 @@
+# Add `is_main_carer` to personal relationship table
+
+## The problem we're trying to solve
+
+We need to add an additional flag to the `dbo.sccv_personal_relationship` table.
+
+## Justification for doing a manual update
+
+We don't have database migrations set up.
+
+## The plan
+
+1. Run SQL statement on staging
+2. Run SQL statement on production
+
+## Link to Jira ticket
+
+[<!-- Add the link to the Jira ticket -->](https://hackney.atlassian.net/browse/SCT-263)
+
+## SQL statement(s)
+
+```sql
+ALTER TABLE dbo.sccv_personal_relationship
+  ADD COLUMN is_main_carer varchar(1);
+```
+
+## Useful resources
+
+N/A

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -497,3 +497,6 @@ update dbo.sccv_personal_relationship_type set inverse_type_id = (select id from
 update dbo.sccv_personal_relationship_type set inverse_type_id = (select id from dbo.sccv_personal_relationship_type where description = 'neighbour') where id = (select id from dbo.sccv_personal_relationship_type where description = 'neighbour');
 update dbo.sccv_personal_relationship_type set inverse_type_id = (select id from dbo.sccv_personal_relationship_type where description = 'inContactWith') where id = (select id from dbo.sccv_personal_relationship_type where description = 'inContactWith');
 update dbo.sccv_personal_relationship_type set inverse_type_id = (select id from dbo.sccv_personal_relationship_type where description = 'acquaintance') where id = (select id from dbo.sccv_personal_relationship_type where description = 'acquaintance');
+
+ALTER TABLE dbo.sccv_personal_relationship
+  ADD COLUMN is_main_carer varchar(1);


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-263

## Describe this PR

### *What is the problem we're trying to solve*

We've decided we want to add a new column to `dbo.sccv_personal_relationship` to capture if a relationship is a main carer. 

### *What changes have we introduced*

This PR updates `schema.sql` to add `is_main_carer` column to `dbo.sccv_personal_relationship` and adds a manual update entry for this update.

### *Follow up actions after merging PR*

Run the SQL statement on staging.
