### PR TITLE
Bug(SCT-730): Only allow changes to answers or residents when a form is in progress

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Bogus;
 using MongoDB.Bson;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -484,8 +483,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             worker ??= CreateWorker();
             resident ??= CreatePerson(residentId);
 
-            var submissionStates = new List<SubmissionState> { SubmissionState.InProgress, SubmissionState.Submitted };
-
             return new Faker<CaseSubmission>()
                 .RuleFor(s => s.SubmissionId, f => id ?? ObjectId.Parse(f.Random.String2(24, "0123456789abcdef")))
                 .RuleFor(s => s.FormId, f => formId ?? f.Random.String2(20))
@@ -497,7 +494,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 {
                     new EditHistory<Worker>{ Worker = worker,  EditTime = dateTime ?? f.Date.Recent() }
                 })
-                .RuleFor(s => s.SubmissionState, f => submissionState ?? f.PickRandom(submissionStates))
+                .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
                 .RuleFor(s => s.FormAnswers, new Dictionary<string, string>());
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -273,7 +273,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void UpdatingResidentsThrowsUpdateSubmissionExceptionWhenSubmissionIsNotInProgress(SubmissionState submissionState)
         {
             var resident = TestHelpers.CreatePerson();
-            var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long>{resident.Id});
+            var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long> { resident.Id });
             var createdSubmission = TestHelpers.CreateCaseSubmission(submissionState);
             var worker = TestHelpers.CreateWorker();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(resident.Id)).Returns(resident);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -269,6 +269,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             response.Should().BeEquivalentTo(createdSubmission.ToDomain().ToResponse());
         }
 
+        [TestCaseSource(nameof(_invalidSubmissionStateForUpdates))]
+        public void UpdatingResidentsThrowsUpdateSubmissionExceptionWhenSubmissionIsNotInProgress(SubmissionState submissionState)
+        {
+            var resident = TestHelpers.CreatePerson();
+            var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long>{resident.Id});
+            var createdSubmission = TestHelpers.CreateCaseSubmission(submissionState);
+            var worker = TestHelpers.CreateWorker();
+            _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(resident.Id)).Returns(resident);
+            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
+            _mockMongoGateway
+                .Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString())))
+                .Returns(createdSubmission);
+
+            Action act = () => _formSubmissionsUseCase.ExecuteUpdateSubmission(createdSubmission.SubmissionId.ToString(), request);
+
+            act.Should().Throw<UpdateSubmissionException>().WithMessage("Cannot update residents for submission, submission state not 'in progress'");
+        }
+
         [Test]
         public void ExecuteUpdateSubmissionDoesNotChangeResidentsIfNoListIsPassed()
         {
@@ -289,7 +307,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExecuteUpdateSubmissionThrowsPersonNotFoundExceptionWhenInvalidResidentsFound()
         {
             var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long> { 0L });
-            var createdSubmission = TestHelpers.CreateCaseSubmission();
+            var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
             var worker = TestHelpers.CreateWorker();
             _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(0L));
             _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
@@ -366,6 +384,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             }
         }
 
+
         [Test]
         public void UpdateAnswersSuccessfullyChangesSubmissionAnswers()
         {
@@ -387,6 +406,30 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockDatabaseGateway.Verify(x => x.GetWorkerByEmail(request.EditedBy), Times.Once);
             _mockMongoGateway.Verify(x => x.LoadRecordById<CaseSubmission>(CollectionName, createdSubmission.SubmissionId), Times.Once);
             _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, createdSubmission.SubmissionId, It.IsAny<CaseSubmission>()), Times.Once);
+        }
+
+        private static object[] _invalidSubmissionStateForUpdates =
+        {
+            SubmissionState.Discarded,
+            SubmissionState.Submitted,
+            SubmissionState.Approved
+        };
+
+        [TestCaseSource(nameof(_invalidSubmissionStateForUpdates))]
+        public void UpdateAnswersThrowsUpdateSubmissionExceptionWhenSubmissionIsNotInProgress(SubmissionState submissionState)
+        {
+            var request = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
+            var createdSubmission = TestHelpers.CreateCaseSubmission(submissionState);
+            var worker = TestHelpers.CreateWorker();
+            const string stepId = "1";
+            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
+            _mockMongoGateway
+                .Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString())))
+                .Returns(createdSubmission);
+
+            Action act = () => _formSubmissionsUseCase.UpdateAnswers(createdSubmission.SubmissionId.ToString(), stepId, request);
+
+            act.Should().Throw<UpdateSubmissionException>().WithMessage("Cannot update answers, submission state not 'in progress'");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -25,6 +25,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         private Faker _faker = null!;
         private const string CollectionName = "resident-case-submissions";
 
+        private static object[] _invalidSubmissionStateForUpdates =
+        {
+            SubmissionState.Discarded,
+            SubmissionState.Submitted,
+            SubmissionState.Approved
+        };
+
         [SetUp]
         public void SetUp()
         {
@@ -407,13 +414,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockMongoGateway.Verify(x => x.LoadRecordById<CaseSubmission>(CollectionName, createdSubmission.SubmissionId), Times.Once);
             _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, createdSubmission.SubmissionId, It.IsAny<CaseSubmission>()), Times.Once);
         }
-
-        private static object[] _invalidSubmissionStateForUpdates =
-        {
-            SubmissionState.Discarded,
-            SubmissionState.Submitted,
-            SubmissionState.Approved
-        };
 
         [TestCaseSource(nameof(_invalidSubmissionStateForUpdates))]
         public void UpdateAnswersThrowsUpdateSubmissionExceptionWhenSubmissionIsNotInProgress(SubmissionState submissionState)

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -96,6 +96,10 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             {
                 throw new GetSubmissionException($"Submission with ID {submissionId} not found");
             }
+            if (submission.SubmissionState != SubmissionState.InProgress)
+            {
+                throw new UpdateSubmissionException("Cannot update answers, submission state not 'in progress'");
+            }
 
             submission.FormAnswers[stepId] = request.StepAnswers;
             submission.EditHistory.Add(new EditHistory<Worker>
@@ -177,6 +181,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         private void UpdateResidents(CaseSubmission caseSubmission, UpdateCaseSubmissionRequest request)
         {
             if (request.Residents == null) return;
+
+            if (caseSubmission.SubmissionState != SubmissionState.InProgress)
+            {
+                throw new UpdateSubmissionException("Cannot update residents for submission, submission state not 'in progress'");
+            }
 
             var newResident = request.Residents.Select(residentId => GetSanitisedResident(residentId)).ToList();
 


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-730)

## Describe this PR

### *What is the problem we're trying to solve*

We only want submissions that are in progress to allow editing.

### *What changes have we introduced*

When updating a submissions answers or residents we now validate the submission is currently in progress, if not we throw an exception.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
