### PR TITLE
Bug(SCT-731): Harden API for adding/removing residents to case submission

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateCaseSubmissionRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateCaseSubmissionRequestTests.cs
@@ -13,7 +13,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         {
             var badUpdateCaseSubmissionRequest = new List<(UpdateCaseSubmissionRequest, string)>
             {
-                (TestHelpers.UpdateCaseSubmissionRequest(updatedBy: "invalid email"), "Provide a valid email address for who is updating the submission")
+                (TestHelpers.UpdateCaseSubmissionRequest(updatedBy: "invalid email"), "Provide a valid email address for who is updating the submission"),
+                (TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long>()), "Provide residents for who this submission applies too"),
             };
 
             var validator = new UpdateCaseSubmissionRequestValidator();

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -277,6 +277,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ExecuteUpdateSubmissionRemovesAnyDuplicateResidents()
+        {
+            var resident = TestHelpers.CreatePerson();
+            var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long> { resident.Id, resident.Id });
+            var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
+            var worker = TestHelpers.CreateWorker();
+            _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(resident.Id)).Returns(resident);
+            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
+            _mockMongoGateway.Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()))).Returns(createdSubmission);
+
+            var response = _formSubmissionsUseCase.ExecuteUpdateSubmission(createdSubmission.SubmissionId.ToString(), request);
+
+            _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()), createdSubmission), Times.Once);
+            createdSubmission.Residents.Should().BeEquivalentTo(new List<SocialCareCaseViewerApi.V1.Infrastructure.Person> { resident });
+            response.Should().BeEquivalentTo(createdSubmission.ToDomain().ToResponse());
+        }
+
+        [Test]
         public void ExecuteUpdateSubmissionThrowsUpdateSubmissionExceptionIfEmptyListOfResidentsProvided()
         {
             var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long>());

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseSubmissionRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseSubmissionRequest.cs
@@ -27,6 +27,12 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(s => s.EditedBy)
                 .NotNull().WithMessage("Provide who is updating the submission")
                 .EmailAddress().WithMessage("Provide a valid email address for who is updating the submission");
+            When(s => s.Residents != null, () =>
+            {
+                RuleFor(s => s.Residents!.Count).GreaterThan(0)
+                    .WithMessage("Provide residents for who this submission applies too");
+            });
+
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -182,6 +182,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             if (request.Residents == null) return;
 
+            if (request.Residents.Count == 0)
+            {
+                throw new UpdateSubmissionException("A submission must be against at least one resident");
+            }
+
             if (caseSubmission.SubmissionState != SubmissionState.InProgress)
             {
                 throw new UpdateSubmissionException("Cannot update residents for submission, submission state not 'in progress'");

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -192,7 +192,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 throw new UpdateSubmissionException("Cannot update residents for submission, submission state not 'in progress'");
             }
 
-            var newResident = request.Residents.Select(residentId => GetSanitisedResident(residentId)).ToList();
+            var residentsWithoutDuplicates = new HashSet<long>(request.Residents);
+
+            var newResident = residentsWithoutDuplicates.Select(residentId => GetSanitisedResident(residentId)).ToList();
 
             caseSubmission.Residents = newResident;
         }


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-731)

## Describe this PR

### *What is the problem we're trying to solve*

Want to make sure that a case submission can never have either duplicates of a resident assigned or no residents assigned.

Validation added to request to ensure if residents are supplied the list isn't empty.
Use case throws an exception if empty resident list supplied.
Use case utilises a hashset to remove any duplicate resident IDs from the request.

All tested.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
