### PR TITLE
feat(SCT-263): add database gateway methods for adding personal relationships

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
@@ -36,11 +36,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             _databaseGateway.CreatePersonalRelationship(request);
 
             var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
-            personalRelationship.PersonId.Should().Be(request.PersonId);
-            personalRelationship.OtherPersonId.Should().Be(request.OtherPersonId);
-            personalRelationship.TypeId.Should().Be(request.TypeId);
-            personalRelationship.IsMainCarer.Should().Be(request.IsMainCarer);
-            personalRelationship.IsInformalCarer.Should().Be(request.IsInformalCarer);
+            personalRelationship?.PersonId.Should().Be(request.PersonId);
+            personalRelationship?.OtherPersonId.Should().Be(request.OtherPersonId);
+            personalRelationship?.TypeId.Should().Be(request.TypeId);
+            personalRelationship?.IsMainCarer.Should().Be(request.IsMainCarer);
+            personalRelationship?.IsInformalCarer.Should().Be(request.IsInformalCarer);
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             _databaseGateway.CreatePersonalRelationship(request);
 
             var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
-            personalRelationship.StartDate.Should().Be(fakeTime);
+            personalRelationship?.StartDate.Should().Be(fakeTime);
         }
 
         [Test]
@@ -73,8 +73,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             var response = _databaseGateway.CreatePersonalRelationship(request);
 
             var details = DatabaseContext.PersonalRelationshipDetails.FirstOrDefault();
-            details.PersonalRelationshipId.Should().Be(response.Id);
-            details.Details.Should().Be(request.Details);
+            details?.PersonalRelationshipId.Should().Be(response.Id);
+            details?.Details.Should().Be(request.Details);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
+{
+    [TestFixture]
+    public class CreatePersonalRelationshipTests : DatabaseTests
+    {
+        private DatabaseGateway _databaseGateway;
+        private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+        private Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
+
+        [SetUp]
+        public void Setup()
+        {
+            _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object, _mockSystemTime.Object);
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
+
+        [Test]
+        public void CreatesAPersonalRelationship()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+
+            _databaseGateway.CreatePersonalRelationship(request);
+
+            var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
+            personalRelationship.PersonId.Should().Be(request.PersonId);
+            personalRelationship.OtherPersonId.Should().Be(request.OtherPersonId);
+            personalRelationship.TypeId.Should().Be(request.TypeId);
+            personalRelationship.IsMainCarer.Should().Be(request.IsMainCarer);
+            personalRelationship.IsInformalCarer.Should().Be(request.IsInformalCarer);
+        }
+
+        [Test]
+        public void SetsStartDateToNow()
+        {
+            var fakeTime = new DateTime(2000, 1, 1, 15, 30, 0);
+            _mockSystemTime.Setup(time => time.Now).Returns(fakeTime);
+
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+
+            _databaseGateway.CreatePersonalRelationship(request);
+
+            var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
+            personalRelationship.StartDate.Should().Be(fakeTime);
+        }
+
+        [Test]
+        public void CreatesAPersonalRelationshipDetails()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+
+            var response = _databaseGateway.CreatePersonalRelationship(request);
+
+            var details = DatabaseContext.PersonalRelationshipDetails.FirstOrDefault();
+            details.PersonalRelationshipId.Should().Be(response.Id);
+            details.Details.Should().Be(request.Details);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
@@ -14,8 +14,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
     public class CreatePersonalRelationshipTests : DatabaseTests
     {
         private DatabaseGateway _databaseGateway;
-        private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
-        private Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
+        private readonly Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+        private readonly Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
 
         [SetUp]
         public void Setup()

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
@@ -42,5 +42,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             response.Description.Should().Be(description);
             response.InverseTypeId.Should().NotBe(null);
         }
+
+        [Test]
+        [TestCase("parentofunbornchild", "parentOfUnbornChild")]
+        [TestCase("parentOfUnbornChild", "parentOfUnbornChild")]
+        [TestCase("auntuncle", "auntUncle")]
+        [TestCase("auntUncle", "auntUncle")]
+        public void WhenDescriptionIsADifferentCaseReturnsPersonalRelationshipType(string description, string expectedDescription)
+        {
+            var response = _databaseGateway.GetPersonalRelationshipTypeByDescription(description);
+
+            response.Id.Should().NotBe(null);
+            response.Description.Should().Be(expectedDescription);
+            response.InverseTypeId.Should().NotBe(null);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Helpers;
 using Microsoft.EntityFrameworkCore;
-using System;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 {

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.Helpers;
+using Microsoft.EntityFrameworkCore;
+using System;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
+{
+    [TestFixture]
+    public class GetPersonalRelationshipTypeByDescriptionTests : DatabaseTests
+    {
+        private DatabaseGateway _databaseGateway;
+        private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+        private Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
+
+        [SetUp]
+        public void Setup()
+        {
+            _databaseGateway = new DatabaseGateway(DatabaseContext, _mockProcessDataGateway.Object, _mockSystemTime.Object);
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
+
+        [Test]
+        public void WhenNoMatchingDescriptionReturnsNull()
+        {
+            var response = _databaseGateway.GetPersonalRelationshipTypeByDescription("foobar");
+
+            response.Should().BeNull();
+        }
+
+        [Test]
+        [TestCase("parent")]
+        [TestCase("child")]
+        [TestCase("friend")]
+        public void WhenMatchingDescriptionReturnsPersonalRelationshipType(string description)
+        {
+            var response = _databaseGateway.GetPersonalRelationshipTypeByDescription(description);
+
+            response.Id.Should().NotBe(null);
+            response.Description.Should().Be(description);
+            response.InverseTypeId.Should().NotBe(null);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetPersonalRelationshipTypeByDescriptionTests.cs
@@ -12,8 +12,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
     public class GetPersonalRelationshipTypeByDescriptionTests : DatabaseTests
     {
         private DatabaseGateway _databaseGateway;
-        private Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
-        private Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
+        private readonly Mock<IProcessDataGateway> _mockProcessDataGateway = new Mock<IProcessDataGateway>();
+        private readonly Mock<ISystemTime> _mockSystemTime = new Mock<ISystemTime>();
 
         [SetUp]
         public void Setup()

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -124,18 +124,35 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         }
 
         public static CreatePersonalRelationshipRequest CreatePersonalRelationshipRequest(
+            long? personId = null,
+            long? otherPersonId = null,
+            long? typeId = null,
+            string type = "parent",
             string? isMainCarer = null,
             string? isInformalCarer = null,
             string? details = null
         )
         {
             return new Faker<CreatePersonalRelationshipRequest>()
-                .RuleFor(pr => pr.PersonId, f => f.UniqueIndex + 1)
-                .RuleFor(pr => pr.OtherPersonId, f => f.UniqueIndex + 1)
-                .RuleFor(pr => pr.Type, f => "parent")
+                .RuleFor(pr => pr.PersonId, f => personId ?? f.UniqueIndex + 1)
+                .RuleFor(pr => pr.OtherPersonId, f => otherPersonId ?? f.UniqueIndex + 2)
+                .RuleFor(pr => pr.Type, type)
+                .RuleFor(pr => pr.TypeId, f => typeId ?? f.UniqueIndex)
                 .RuleFor(pr => pr.IsMainCarer, f => isMainCarer ?? f.Random.String2(1, "YNyn"))
                 .RuleFor(pr => pr.IsInformalCarer, f => isInformalCarer ?? f.Random.String2(1, "YNyn"))
-                .RuleFor(pr => pr.Details, f => details ?? f.Random.String(1000));
+                .RuleFor(pr => pr.Details, f => details ?? f.Random.String2(1000));
+        }
+
+        public static (Person, Person) SavePersonAndOtherPersonToDatabase(DatabaseContext databaseContext)
+        {
+            var person = TestHelpers.CreatePerson();
+            var otherPerson = TestHelpers.CreatePerson();
+
+            databaseContext.Persons.Add(person);
+            databaseContext.Persons.Add(otherPerson);
+            databaseContext.SaveChanges();
+
+            return (person, otherPerson);
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -16,6 +16,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("type")]
         public string Type { get; set; } = null!;
 
+        public long TypeId { get; set; }
+
         [JsonPropertyName("isMainCarer")]
         public string IsMainCarer { get; set; } = null!;
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -16,7 +16,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("type")]
         public string Type { get; set; } = null!;
 
-        public long TypeId { get; set; }
+        [JsonIgnore]
+        public long? TypeId { get; set; }
 
         [JsonPropertyName("isMainCarer")]
         public string IsMainCarer { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -911,6 +911,28 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .FirstOrDefault(prt => prt.Description == description);
         }
 
+        public Infrastructure.PersonalRelationship CreatePersonalRelationship(CreatePersonalRelationshipRequest request)
+        {
+            var personalRelationship = new Infrastructure.PersonalRelationship()
+            {
+                PersonId = request.PersonId,
+                OtherPersonId = request.OtherPersonId,
+                TypeId = request.TypeId,
+                IsMainCarer = request.IsMainCarer,
+                IsInformalCarer = request.IsInformalCarer,
+                StartDate = _systemTime.Now,
+                Details = new PersonalRelationshipDetail()
+                {
+                    Details = request.Details
+                }
+            };
+
+            _databaseContext.PersonalRelationships.Add(personalRelationship);
+            _databaseContext.SaveChanges();
+
+            return personalRelationship;
+        }
+
         private static AllocationSet SetDeallocationValues(AllocationSet allocation, DateTime dt, string modifiedBy)
         {
             //keep workerId and TeamId in the record so they can be easily exposed to front end

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -917,7 +917,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 PersonId = request.PersonId,
                 OtherPersonId = request.OtherPersonId,
-                TypeId = request.TypeId,
+                TypeId = (long) request.TypeId,
                 IsMainCarer = request.IsMainCarer,
                 IsInformalCarer = request.IsInformalCarer,
                 StartDate = _systemTime.Now,

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -905,6 +905,12 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return personWithRelationships;
         }
 
+        public PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description)
+        {
+            return _databaseContext.PersonalRelationshipTypes
+                .FirstOrDefault(prt => prt.Description == description);
+        }
+
         private static AllocationSet SetDeallocationValues(AllocationSet allocation, DateTime dt, string modifiedBy)
         {
             //keep workerId and TeamId in the record so they can be easily exposed to front end

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -908,7 +908,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description)
         {
             return _databaseContext.PersonalRelationshipTypes
-                .FirstOrDefault(prt => prt.Description == description);
+                .FirstOrDefault(prt => prt.Description.ToLower() == description.ToLower());
         }
 
         public Infrastructure.PersonalRelationship CreatePersonalRelationship(CreatePersonalRelationshipRequest request)

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -39,5 +39,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         Person GetPersonByMosaicId(long mosaicId);
         Person GetPersonWithPersonalRelationshipsByPersonId(long personId, bool includeEndedRelationships = false);
         PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description);
+        PersonalRelationship CreatePersonalRelationship(CreatePersonalRelationshipRequest request);
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -38,5 +38,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         List<Person> GetPersonsByListOfIds(List<long> ids);
         Person GetPersonByMosaicId(long mosaicId);
         Person GetPersonWithPersonalRelationshipsByPersonId(long personId, bool includeEndedRelationships = false);
+        PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description);
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-263

## Describe this PR

### *What is the problem we're trying to solve*

We want to be able to add a personal relationship. 

### *What changes have we introduced*

This PR adds two new `DatabaseGateway` methods:

- ` GetPersonalRelationshipTypeByDescription(string description)`
-  `CreatePersonalRelationship(CreatePersonalRelationshipRequest request)`

which will be used to support the new use case for creating a personal relationship that will handle:

- checking that the person and other person exist using _existing_ DB gateway method
- checking that the personal relationship type exists using _new_ DB gateway method
- checking that the personal relationship with the same type doesn't already exist using _existing_ DB gateway method
- creating the personal relationship using _new_ DB gateway method
- creating the inverse personal relationship using _new_ DB gateway method

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Create new use case for adding personal relationship.
