### PR TITLE
feat(SCT-263): add new use case for adding a personal relationship

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -120,7 +120,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         {
             return new Faker<PersonalRelationshipType>()
                 .RuleFor(prt => prt.Id, f => f.UniqueIndex)
-                .RuleFor(prt => prt.Description, f => description ?? f.Random.String2(20));
+                .RuleFor(prt => prt.Description, f => description ?? f.Random.String2(20))
+                .RuleFor(prt => prt.InverseTypeId, f => f.UniqueIndex);
         }
 
         public static CreatePersonalRelationshipRequest CreatePersonalRelationshipRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using SocialCareCaseViewerApi.V1.UseCase;
+using System.Collections.Generic;
+using System;
+
+namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
+{
+    [TestFixture]
+    public class PersonalRelationshipsExecutePostUseCaseTests
+    {
+        private Mock<IDatabaseGateway> _mockDatabaseGateway;
+        private PersonalRelationshipsUseCase _personalRelationshipsUseCase;
+        private CreatePersonalRelationshipRequest _request;
+        private Person _person;
+        private Person _otherPerson;
+        private readonly PersonalRelationshipType _typeInRequest = PersonalRelationshipsHelper.CreatePersonalRelationshipType("friend");
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockDatabaseGateway = new Mock<IDatabaseGateway>();
+            _personalRelationshipsUseCase = new PersonalRelationshipsUseCase(_mockDatabaseGateway.Object);
+
+            _mockDatabaseGateway.Setup(x => x.GetPersonalRelationshipTypeByDescription(_typeInRequest.Description))
+                .Returns(_typeInRequest);
+
+            var typeInExistingRelationship = PersonalRelationshipsHelper.CreatePersonalRelationshipType("partner");
+            _mockDatabaseGateway.Setup(x => x.GetPersonalRelationshipTypeByDescription(typeInExistingRelationship.Description))
+                .Returns(typeInExistingRelationship);
+
+            _request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(type: _typeInRequest.Description);
+
+            _person = TestHelpers.CreatePerson((int) _request.PersonId);
+            _otherPerson = TestHelpers.CreatePerson((int) _request.OtherPersonId);
+
+            var personalRelationship = PersonalRelationshipsHelper.CreatePersonalRelationship(_person, _otherPerson, typeInExistingRelationship);
+            _person.PersonalRelationships = new List<PersonalRelationship>() { personalRelationship };
+
+            _mockDatabaseGateway.Setup(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()))
+                .Returns(new List<Person>() { _person, _otherPerson });
+
+            _mockDatabaseGateway.Setup(x => x.GetPersonWithPersonalRelationshipsByPersonId(It.IsAny<long>(), It.IsAny<bool>()))
+                .Returns(_person);
+
+            _mockDatabaseGateway.Setup(x => x.CreatePersonalRelationship(It.IsAny<CreatePersonalRelationshipRequest>()))
+                .Returns(personalRelationship);
+        }
+
+        [Test]
+        public void CallsDatabaseGatewayToCheckPersonAndOtherPersonExists()
+        {
+            _personalRelationshipsUseCase.ExecutePost(_request);
+
+            _mockDatabaseGateway.Verify(gateway => gateway.GetPersonsByListOfIds(new List<long>() { _request.PersonId, _request.OtherPersonId }));
+        }
+
+        [Test]
+        public void WhenPersonDoesNotExistThrowsPersonNotFoundException()
+        {
+            _mockDatabaseGateway.Setup(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()))
+                .Returns(new List<Person>() { new Person() { Id = _request.OtherPersonId } });
+
+            Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
+
+            act.Should().Throw<PersonNotFoundException>()
+                .WithMessage($"\"personId\" with \"{_request.PersonId}\" was not found.");
+        }
+
+        [Test]
+        public void WhenOtherPersonDoesNotExistThrowsPersonNotFoundException()
+        {
+            _mockDatabaseGateway.Setup(x => x.GetPersonsByListOfIds(It.IsAny<List<long>>()))
+                .Returns(new List<Person>() { new Person() { Id = _request.PersonId } });
+
+            Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
+
+            act.Should().Throw<PersonNotFoundException>()
+                .WithMessage($"\"otherPersonId\" with \"{_request.OtherPersonId}\" was not found.");
+        }
+
+        [Test]
+        public void CallsDatabaseGatewayToCheckTypeExists()
+        {
+            _personalRelationshipsUseCase.ExecutePost(_request);
+
+            _mockDatabaseGateway.Verify(gateway => gateway.GetPersonalRelationshipTypeByDescription(_request.Type));
+        }
+
+        [Test]
+        public void WhenTypeDoesNotExistThrowsPersonalRelationshipTypeNotFoundException()
+        {
+            _mockDatabaseGateway.Setup(x => x.GetPersonalRelationshipTypeByDescription(It.IsAny<string>()))
+                .Returns((PersonalRelationshipType) null);
+
+            Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
+
+            act.Should().Throw<PersonalRelationshipTypeNotFoundException>()
+                .WithMessage($"\"type\" with \"{_request.Type}\" was not found.");
+        }
+
+        [Test]
+        public void CallsDatabaseGatewayToCheckIfRelationshipWithTheSameTypeAlreadyExists()
+        {
+            _personalRelationshipsUseCase.ExecutePost(_request);
+
+            _mockDatabaseGateway.Verify(gateway => gateway.GetPersonWithPersonalRelationshipsByPersonId(_request.PersonId, It.IsAny<bool>()));
+        }
+
+        [Test]
+        public void WhenRelationshipWithTheSameTypeAlreadyExistsThrowsPersonalRelationshipAlreadyExistsException()
+        {
+            var sameTypeAsRequest = _typeInRequest;
+            _person.PersonalRelationships = new List<PersonalRelationship>() { PersonalRelationshipsHelper.CreatePersonalRelationship(_person, _otherPerson, sameTypeAsRequest) };
+            _mockDatabaseGateway.Setup(x => x.GetPersonWithPersonalRelationshipsByPersonId(It.IsAny<long>(), It.IsAny<bool>()))
+                .Returns(_person);
+
+            Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
+
+            act.Should().Throw<PersonalRelationshipAlreadyExistsException>()
+                .WithMessage($"Personal relationship with \"type\" of \"{_request.Type}\" already exists.");
+        }
+
+        [Test]
+        public void CallsDatabaseGatewayToCreatePersonalRelationshipForPerson()
+        {
+            _personalRelationshipsUseCase.ExecutePost(_request);
+
+            _mockDatabaseGateway.Verify(gateway => gateway.CreatePersonalRelationship(_request));
+        }
+
+        [Test]
+        public void CallsDatabaseGatewayToCreateInversePersonalRelationshipForOtherPerson()
+        {
+            _personalRelationshipsUseCase.ExecutePost(_request);
+
+            _mockDatabaseGateway.Verify(gateway => gateway.CreatePersonalRelationship(
+                It.Is<CreatePersonalRelationshipRequest>(
+                    request =>
+                        request.PersonId == _request.OtherPersonId &&
+                        request.OtherPersonId == _request.PersonId &&
+                        request.TypeId == _typeInRequest.InverseTypeId &&
+                        request.IsMainCarer == null &&
+                        request.IsInformalCarer == null &&
+                        request.Details == null
+                )
+            ));
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
@@ -132,7 +132,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
         {
             _personalRelationshipsUseCase.ExecutePost(_request);
 
-            _mockDatabaseGateway.Verify(gateway => gateway.CreatePersonalRelationship(_request));
+            _mockDatabaseGateway.Verify(gateway => gateway.CreatePersonalRelationship(
+                It.Is<CreatePersonalRelationshipRequest>(
+                    request =>
+                        request.PersonId == _request.PersonId &&
+                        request.OtherPersonId == _request.OtherPersonId &&
+                        request.TypeId == _typeInRequest.Id &&
+                        request.IsMainCarer == _request.IsMainCarer &&
+                        request.IsInformalCarer == request.IsInformalCarer &&
+                        request.Details == _request.Details
+                )
+            ));
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -20,13 +20,13 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public long? TypeId { get; set; }
 
         [JsonPropertyName("isMainCarer")]
-        public string IsMainCarer { get; set; } = null!;
+        public string? IsMainCarer { get; set; } = null!;
 
         [JsonPropertyName("isInformalCarer")]
-        public string IsInformalCarer { get; set; } = null!;
+        public string? IsInformalCarer { get; set; } = null!;
 
         [JsonPropertyName("details")]
-        public string Details { get; set; } = null!;
+        public string? Details { get; set; } = null!;
     }
 
     public class CreatePersonalRelationshipRequestValidator : AbstractValidator<CreatePersonalRelationshipRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -20,13 +20,13 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public long? TypeId { get; set; }
 
         [JsonPropertyName("isMainCarer")]
-        public string? IsMainCarer { get; set; } = null!;
+        public string? IsMainCarer { get; set; }
 
         [JsonPropertyName("isInformalCarer")]
-        public string? IsInformalCarer { get; set; } = null!;
+        public string? IsInformalCarer { get; set; }
 
         [JsonPropertyName("details")]
-        public string? Details { get; set; } = null!;
+        public string? Details { get; set; }
     }
 
     public class CreatePersonalRelationshipRequestValidator : AbstractValidator<CreatePersonalRelationshipRequest>

--- a/SocialCareCaseViewerApi/V1/Exceptions/CustomExceptions.cs
+++ b/SocialCareCaseViewerApi/V1/Exceptions/CustomExceptions.cs
@@ -97,4 +97,14 @@ namespace SocialCareCaseViewerApi.V1.Exceptions
     {
         public UpdateSubmissionException(string message) : base(message) { }
     }
+
+    public class PersonalRelationshipTypeNotFoundException : Exception
+    {
+        public PersonalRelationshipTypeNotFoundException(string message) : base(message) { }
+    }
+
+    public class PersonalRelationshipAlreadyExistsException : Exception
+    {
+        public PersonalRelationshipAlreadyExistsException(string message) : base(message) { }
+    }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IPersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/Interfaces/IPersonalRelationshipsUseCase.cs
@@ -1,0 +1,8 @@
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+namespace SocialCareCaseViewerApi.V1.UseCase.Interfaces
+{
+    public interface IPersonalRelationshipsUseCase
+    {
+        void ExecutePost(CreatePersonalRelationshipRequest request);
+    }
+}

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.Gateways;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+
+namespace SocialCareCaseViewerApi.V1.UseCase
+{
+    public class PersonalRelationshipsUseCase : IPersonalRelationshipsUseCase
+    {
+        private IDatabaseGateway _databaseGateway;
+
+        public PersonalRelationshipsUseCase(IDatabaseGateway databaseGateway)
+        {
+            _databaseGateway = databaseGateway;
+        }
+
+        public void ExecutePost(CreatePersonalRelationshipRequest request)
+        {
+            var persons = _databaseGateway.GetPersonsByListOfIds(new List<long>() { request.PersonId, request.OtherPersonId });
+
+            var personDoesNotExist = persons.Find(person => person.Id == request.PersonId) == null;
+            if (personDoesNotExist) throw new PersonNotFoundException($"\"personId\" with \"{request.PersonId}\" was not found.");
+
+            var otherPersonDoesNotExist = persons.Find(person => person.Id == request.OtherPersonId) == null;
+            if (otherPersonDoesNotExist) throw new PersonNotFoundException($"\"otherPersonId\" with \"{request.OtherPersonId}\" was not found.");
+
+            var type = _databaseGateway.GetPersonalRelationshipTypeByDescription(request.Type);
+
+            var typeDoesNotExist = type == null;
+            if (typeDoesNotExist) throw new PersonalRelationshipTypeNotFoundException($"\"type\" with \"{request.Type}\" was not found.");
+
+            var personWithPersonalRelationships = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(request.PersonId);
+
+            var personalRelationships = personWithPersonalRelationships.PersonalRelationships;
+            var personalRelationshipAlreadyExists = personalRelationships.Find(pr => pr.OtherPersonId == request.OtherPersonId && pr.Type.Description == request.Type) != null;
+            if (personalRelationshipAlreadyExists) throw new PersonalRelationshipAlreadyExistsException($"Personal relationship with \"type\" of \"{request.Type}\" already exists.");
+
+            _databaseGateway.CreatePersonalRelationship(request);
+
+            _databaseGateway.CreatePersonalRelationship(new CreatePersonalRelationshipRequest()
+            {
+                PersonId = request.OtherPersonId,
+                OtherPersonId = request.PersonId,
+                TypeId = type.InverseTypeId,
+                IsMainCarer = null,
+                IsInformalCarer = null,
+                Details = null
+            });
+        }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -36,6 +36,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             var personalRelationshipAlreadyExists = personalRelationships.Find(pr => pr.OtherPersonId == request.OtherPersonId && pr.Type.Description == request.Type) != null;
             if (personalRelationshipAlreadyExists) throw new PersonalRelationshipAlreadyExistsException($"Personal relationship with \"type\" of \"{request.Type}\" already exists.");
 
+            request.TypeId = type.Id;
+
             _databaseGateway.CreatePersonalRelationship(request);
 
             _databaseGateway.CreatePersonalRelationship(new CreatePersonalRelationshipRequest()

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -8,7 +8,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 {
     public class PersonalRelationshipsUseCase : IPersonalRelationshipsUseCase
     {
-        private IDatabaseGateway _databaseGateway;
+        private readonly IDatabaseGateway _databaseGateway;
 
         public PersonalRelationshipsUseCase(IDatabaseGateway databaseGateway)
         {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-263

## Describe this PR

### *What is the problem we're trying to solve*

We want to be able to add a personal relationship. In #345, we added methods in the `DatabaseGateway` to support this new use case.

### *What changes have we introduced*

This PR adds a new use case: `PersonalRelationship#ExecutePost` that will ensure that:

- the provided `personId` does exist
- the provided `otherPersonId` does exist
- the provided `description` of type does exist
- the provided relationship doesn't already exist for the same person with the same type

It will then create a new personal relationship for the provided person and create the inverse relationship.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Create the API endpoint: `api/v1/relationships/personal`.