### PR TITLE
Bug(): Updating residents sets some important resident information to null

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -265,7 +265,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long> { resident.Id });
             var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
             var worker = TestHelpers.CreateWorker();
-            _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(resident.Id)).Returns(resident);
+            _mockDatabaseGateway.Setup(x => x.GetPersonDetailsById(resident.Id)).Returns(resident);
             _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
             _mockMongoGateway.Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()))).Returns(createdSubmission);
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -283,7 +283,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = TestHelpers.UpdateCaseSubmissionRequest(residents: new List<long> { resident.Id, resident.Id });
             var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
             var worker = TestHelpers.CreateWorker();
-            _mockDatabaseGateway.Setup(x => x.GetPersonByMosaicId(resident.Id)).Returns(resident);
+            _mockDatabaseGateway.Setup(x => x.GetPersonDetailsById(resident.Id)).Returns(resident);
             _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
             _mockMongoGateway.Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()))).Returns(createdSubmission);
 

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -28,7 +28,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         public (CaseSubmissionResponse, CaseSubmission) ExecutePost(CreateCaseSubmissionRequest request)
         {
             var worker = GetSanitisedWorker(request.CreatedBy);
-            var resident = GetSanitisedResident(request.ResidentId, true);
+            var resident = GetSanitisedResident(request.ResidentId);
 
             var dateTimeNow = DateTime.Now;
 
@@ -194,7 +194,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             var residentsWithoutDuplicates = new HashSet<long>(request.Residents);
 
-            var newResident = residentsWithoutDuplicates.Select(residentId => GetSanitisedResident(residentId)).ToList();
+            var newResident = residentsWithoutDuplicates.Select(GetSanitisedResident).ToList();
 
             caseSubmission.Residents = newResident;
         }
@@ -210,9 +210,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return worker;
         }
 
-        private Person GetSanitisedResident(long residentId, bool includeExtraDetails = false)
+        private Person GetSanitisedResident(long residentId)
         {
-            var resident = includeExtraDetails ? _databaseGateway.GetPersonDetailsById(residentId) : _databaseGateway.GetPersonByMosaicId(residentId);
+            var resident = _databaseGateway.GetPersonDetailsById(residentId);
             if (resident == null)
             {
                 throw new PersonNotFoundException($"Resident not found with ID {residentId}");


### PR DESCRIPTION
## Link to JIRA ticket

Too small, no ticket.

## Describe this PR

### *What is the problem we're trying to solve*

Had weird bug that when updating a residents for a case submission we would lose their address information, this fixes that.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
