### PR TITLE
feat(SCT-263): add create personal relationship API endpoint

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerCreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerCreatePersonalRelationshipTests.cs
@@ -1,0 +1,109 @@
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Controllers;
+using SocialCareCaseViewerApi.V1.Exceptions;
+using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Controllers.Relationship
+{
+    [TestFixture]
+    public class RelationshipControllerCreatePersonalRelationshipTests
+    {
+        private RelationshipController _relationshipController;
+        private Mock<IPersonalRelationshipsUseCase> _mockPersonalRelationshipsUseCase;
+        private readonly Mock<IRelationshipsUseCase> _mockRelationshipsUseCase = new Mock<IRelationshipsUseCase>();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockPersonalRelationshipsUseCase = new Mock<IPersonalRelationshipsUseCase>();
+
+            _relationshipController = new RelationshipController(_mockRelationshipsUseCase.Object, _mockPersonalRelationshipsUseCase.Object);
+        }
+
+        [Test]
+        public void CallsPersonalRelationshipsUseCaseToCreatePersonalRelationship()
+        {
+            _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()));
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;
+
+            _mockPersonalRelationshipsUseCase.Verify(x => x.ExecutePost(request));
+        }
+
+        [Test]
+        public void WhenPersonNotFoundExceptionIsThrownReturns400WithMessage()
+        {
+            var exceptionMessage = "error message";
+            _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()))
+                .Throws(new PersonNotFoundException(exceptionMessage));
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(exceptionMessage);
+        }
+
+        [Test]
+        public void WhenPersonalRelationshipTypeNotFoundExceptionIsThrownReturns400WithMessage()
+        {
+            var exceptionMessage = "error message";
+            _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()))
+                .Throws(new PersonalRelationshipTypeNotFoundException(exceptionMessage));
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(exceptionMessage);
+        }
+
+        [Test]
+        public void WhenPersonalRelationshipAlreadyExistsExceptionIsThrownReturns400WithMessage()
+        {
+            var exceptionMessage = "error message";
+            _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()))
+                .Throws(new PersonalRelationshipAlreadyExistsException(exceptionMessage));
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(exceptionMessage);
+        }
+
+        [Test]
+        public void WhenRequestIsValidReturnsSuccessfulResponse()
+        {
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request);
+
+            response.Should().BeOfType<CreatedAtActionResult>();
+            var createdAtAction = response as CreatedAtActionResult;
+            createdAtAction.StatusCode.Should().Be(201);
+            createdAtAction.Value.Should().Be("Successfully created personal relationship.");
+        }
+
+        [Test]
+        public void WhenRequestIsInValidReturnsBadRequest400WithMessage()
+        {
+            var badRequest = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(isMainCarer: "invalid");
+
+            var response = _relationshipController.CreatePersonalRelationship(badRequest);
+
+            response.Should().BeOfType<BadRequestObjectResult>();
+            var badRequestObject = response as BadRequestObjectResult;
+            badRequestObject.StatusCode.Should().Be(400);
+            badRequestObject.Value.Should().Be("'isMainCarer' must be 'Y' or 'N'.");
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerListRelationshipsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerListRelationshipsTests.cs
@@ -1,19 +1,17 @@
 using AutoFixture;
-using Bogus;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
-using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
-namespace SocialCareCaseViewerApi.Tests.V1.Controllers
+namespace SocialCareCaseViewerApi.Tests.V1.Controllers.Relationship
 {
     [TestFixture]
-    public class RelationshipControllerTests
+    public class RelationshipControllerListRelationshipsTests
     {
         private RelationshipController _classUnderTest;
         private Mock<IRelationshipsUseCase> _mockRelationshipsUseCase;

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerListRelationshipsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerListRelationshipsTests.cs
@@ -15,14 +15,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers.Relationship
     {
         private RelationshipController _classUnderTest;
         private Mock<IRelationshipsUseCase> _mockRelationshipsUseCase;
+        private Mock<IPersonalRelationshipsUseCase> _mockPersonalRelationshipsUseCase;
         private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
         {
             _mockRelationshipsUseCase = new Mock<IRelationshipsUseCase>();
+            _mockPersonalRelationshipsUseCase = new Mock<IPersonalRelationshipsUseCase>();
 
-            _classUnderTest = new RelationshipController(_mockRelationshipsUseCase.Object);
+            _classUnderTest = new RelationshipController(_mockRelationshipsUseCase.Object, _mockPersonalRelationshipsUseCase.Object);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
@@ -39,8 +39,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             personalRelationship?.PersonId.Should().Be(request.PersonId);
             personalRelationship?.OtherPersonId.Should().Be(request.OtherPersonId);
             personalRelationship?.TypeId.Should().Be(request.TypeId);
-            personalRelationship?.IsMainCarer.Should().Be(request.IsMainCarer);
-            personalRelationship?.IsInformalCarer.Should().Be(request.IsInformalCarer);
+            personalRelationship?.IsMainCarer.Should().Be(request.IsMainCarer.ToUpper());
+            personalRelationship?.IsInformalCarer.Should().Be(request.IsInformalCarer.ToUpper());
         }
 
         [Test]
@@ -59,6 +59,66 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
             personalRelationship?.StartDate.Should().Be(fakeTime);
+        }
+
+        [Test]
+        public void WhenIsMainCarerIsLowercaseConvertsItToUppercase()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description, isMainCarer: "y"
+            );
+
+            _databaseGateway.CreatePersonalRelationship(request);
+
+            var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
+            personalRelationship?.IsMainCarer.Should().Be("Y");
+        }
+
+        [Test]
+        public void WhenIsMainCarerIsNullItDoesNotThrowANullException()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+            request.IsMainCarer = null;
+
+            Action act = () => _databaseGateway.CreatePersonalRelationship(request);
+
+            act.Should().NotThrow<NullReferenceException>();
+        }
+
+        [Test]
+        public void WhenIsInformalCarerIsLowercaseConvertsItToUppercase()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description, isInformalCarer: "y"
+            );
+
+            _databaseGateway.CreatePersonalRelationship(request);
+
+            var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
+            personalRelationship?.IsInformalCarer.Should().Be("Y");
+        }
+
+        [Test]
+        public void WhenIsInformalCarerIsNullItDoesNotThrowANullException()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+            request.IsInformalCarer = null;
+
+            Action act = () => _databaseGateway.CreatePersonalRelationship(request);
+
+            act.Should().NotThrow<NullReferenceException>();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
@@ -70,7 +70,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
             Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
 
             act.Should().Throw<PersonNotFoundException>()
-                .WithMessage($"\"personId\" with \"{_request.PersonId}\" was not found.");
+                .WithMessage($"'personId' with '{_request.PersonId}' was not found.");
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
             Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
 
             act.Should().Throw<PersonNotFoundException>()
-                .WithMessage($"\"otherPersonId\" with \"{_request.OtherPersonId}\" was not found.");
+                .WithMessage($"'otherPersonId' with '{_request.OtherPersonId}' was not found.");
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
             Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
 
             act.Should().Throw<PersonalRelationshipTypeNotFoundException>()
-                .WithMessage($"\"type\" with \"{_request.Type}\" was not found.");
+                .WithMessage($"'type' with '{_request.Type}' was not found.");
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
             Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
 
             act.Should().Throw<PersonalRelationshipAlreadyExistsException>()
-                .WithMessage($"Personal relationship with \"type\" of \"{_request.Type}\" already exists.");
+                .WithMessage($"Personal relationship with 'type' of '{_request.Type}' already exists.");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/Startup.cs
+++ b/SocialCareCaseViewerApi/Startup.cs
@@ -129,6 +129,7 @@ namespace SocialCareCaseViewerApi
             services.AddTransient<IValidator<UpdateCaseSubmissionRequest>, UpdateCaseSubmissionRequestValidator>();
             services
                 .AddTransient<IValidator<UpdateFormSubmissionAnswersRequest>, UpdateFormSubmissionAnswersValidator>();
+            services.AddTransient<IValidator<CreatePersonalRelationshipRequest>, CreatePersonalRelationshipRequestValidator>();
 
             services.AddScoped<ISystemTime, SystemTime>();
         }
@@ -167,6 +168,7 @@ namespace SocialCareCaseViewerApi
             services.AddScoped<IPersonUseCase, PersonUseCase>();
             services.AddScoped<IFormSubmissionsUseCase, FormSubmissionsUseCase>();
             services.AddScoped<IRelationshipsUseCase, RelationshipsUseCase>();
+            services.AddScoped<IPersonalRelationshipsUseCase, PersonalRelationshipsUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -918,8 +918,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 PersonId = request.PersonId,
                 OtherPersonId = request.OtherPersonId,
                 TypeId = (long) request.TypeId,
-                IsMainCarer = request.IsMainCarer,
-                IsInformalCarer = request.IsInformalCarer,
+                IsMainCarer = request.IsMainCarer?.ToUpper(),
+                IsInformalCarer = request.IsInformalCarer?.ToUpper(),
                 StartDate = _systemTime.Now,
                 Details = new PersonalRelationshipDetail()
                 {

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -20,21 +20,21 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             var persons = _databaseGateway.GetPersonsByListOfIds(new List<long>() { request.PersonId, request.OtherPersonId });
 
             var personDoesNotExist = persons.Find(person => person.Id == request.PersonId) == null;
-            if (personDoesNotExist) throw new PersonNotFoundException($"\"personId\" with \"{request.PersonId}\" was not found.");
+            if (personDoesNotExist) throw new PersonNotFoundException($"'personId' with '{request.PersonId}' was not found.");
 
             var otherPersonDoesNotExist = persons.Find(person => person.Id == request.OtherPersonId) == null;
-            if (otherPersonDoesNotExist) throw new PersonNotFoundException($"\"otherPersonId\" with \"{request.OtherPersonId}\" was not found.");
+            if (otherPersonDoesNotExist) throw new PersonNotFoundException($"'otherPersonId' with '{request.OtherPersonId}' was not found.");
 
             var type = _databaseGateway.GetPersonalRelationshipTypeByDescription(request.Type);
 
             var typeDoesNotExist = type == null;
-            if (typeDoesNotExist) throw new PersonalRelationshipTypeNotFoundException($"\"type\" with \"{request.Type}\" was not found.");
+            if (typeDoesNotExist) throw new PersonalRelationshipTypeNotFoundException($"'type' with '{request.Type}' was not found.");
 
             var personWithPersonalRelationships = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(request.PersonId);
 
             var personalRelationships = personWithPersonalRelationships.PersonalRelationships;
             var personalRelationshipAlreadyExists = personalRelationships.Find(pr => pr.OtherPersonId == request.OtherPersonId && pr.Type.Description == request.Type) != null;
-            if (personalRelationshipAlreadyExists) throw new PersonalRelationshipAlreadyExistsException($"Personal relationship with \"type\" of \"{request.Type}\" already exists.");
+            if (personalRelationshipAlreadyExists) throw new PersonalRelationshipAlreadyExistsException($"Personal relationship with 'type' of '{request.Type}' already exists.");
 
             request.TypeId = type.Id;
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-263

## Describe this PR

### *What is the problem we're trying to solve*

We want to be able to add a personal relationship. In #345, we added methods in the `DatabaseGateway` to support this new use case which was created in #346.

### *What changes have we introduced*

This PR creates the API endpoint with the path `/api/v1/relationships/personal` which takes in a request that looks like:

```json
{
    "personId": 1,
    "otherPersonId": 5,
    "type": "child",
    "isMainCarer": "y",
    "isInformalCarer": "N",
    "details": "Lorem ipsum"
}
```

It also does some other small things like ensures we uppercase `IsMainCarer` and `IsInformalCarer` for the database - see commits.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Connect with frontend and test!