### PR TITLE
feat(SCT-471): update get relationships endpoint to return added fields

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/Response/ResponseFactoryListRelationshipsResponseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/Response/ResponseFactoryListRelationshipsResponseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using FluentAssertions;
@@ -36,7 +37,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories.Response
         [Test]
         public void WhenThereArePersonalRelationshipsOfSameTypeReturnsAllPersonsForThatType()
         {
-            var (person, otherPersons, personalRelationships) = PersonalRelationshipsHelper.CreatePersonWithPersonalRelationshipsOfSameType();
+            var (person, otherPersons, personalRelationships, details) = PersonalRelationshipsHelper.CreatePersonWithPersonalRelationshipsOfSameType();
 
             var response = personalRelationships.ToResponse();
 
@@ -45,10 +46,29 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories.Response
             response.FirstOrDefault().Persons.Should().Contain(p => p.FirstName == otherPersons[0].FirstName);
             response.FirstOrDefault().Persons.Should().Contain(p => p.LastName == otherPersons[0].LastName);
             response.FirstOrDefault().Persons.Should().Contain(p => p.Gender == otherPersons[0].Gender);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.IsMainCarer == personalRelationships[0].IsMainCarer);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.IsInformalCarer == personalRelationships[0].IsInformalCarer);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.Details == details[0].Details);
             response.FirstOrDefault().Persons.Should().Contain(p => p.Id == otherPersons[1].Id);
             response.FirstOrDefault().Persons.Should().Contain(p => p.FirstName == otherPersons[1].FirstName);
             response.FirstOrDefault().Persons.Should().Contain(p => p.LastName == otherPersons[1].LastName);
             response.FirstOrDefault().Persons.Should().Contain(p => p.Gender == otherPersons[1].Gender);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.IsMainCarer == personalRelationships[1].IsMainCarer);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.IsInformalCarer == personalRelationships[1].IsInformalCarer);
+            response.FirstOrDefault().Persons.Should().Contain(p => p.Details == details[1].Details);
+        }
+
+        [Test]
+        public void WhenDetailsIsNullDoesNotThrowNullReferenceException()
+        {
+            var (person, otherPersons, personalRelationships) = PersonalRelationshipsHelper.CreatePersonWithPersonalRelationships();
+            person.PersonalRelationships[0].Details = null;
+            person.PersonalRelationships[1].Details = null;
+            person.PersonalRelationships[2].Details = null;
+
+            Action act = () => personalRelationships.ToResponse();
+
+            act.Should().NotThrow<NullReferenceException>();
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -62,10 +62,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
             person.PersonalRelationships = personalrelationships;
 
+            var details = CreatePersonalRelationshipDetail(personalrelationships[0].Id);
+
+            person.PersonalRelationships[0].Details = details;
+            person.PersonalRelationships[1].Details = details;
+            person.PersonalRelationships[2].Details = details;
+
             return (person, otherPersons, personalrelationships);
         }
 
-        public static (Person, List<Person>, List<PersonalRelationship>) CreatePersonWithPersonalRelationshipsOfSameType()
+        public static (Person, List<Person>, List<PersonalRelationship>, List<PersonalRelationshipDetail>) CreatePersonWithPersonalRelationshipsOfSameType()
         {
             var person = TestHelpers.CreatePerson();
             var otherPersons = new List<Person>()
@@ -84,7 +90,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
             person.PersonalRelationships = personalrelationships;
 
-            return (person, otherPersons, personalrelationships);
+            var details = new List<PersonalRelationshipDetail>()
+            {
+                CreatePersonalRelationshipDetail(personalrelationships[0].Id),
+                CreatePersonalRelationshipDetail(personalrelationships[1].Id),
+            };
+
+            person.PersonalRelationships[0].Details = details[0];
+            person.PersonalRelationships[1].Details = details[1];
+
+            return (person, otherPersons, personalrelationships, details);
         }
 
         public static PersonalRelationship CreatePersonalRelationship(

--- a/SocialCareCaseViewerApi/V1/Domain/RelatedPerson.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/RelatedPerson.cs
@@ -6,5 +6,8 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Gender { get; set; }
+        public string IsMainCarer { get; set; }
+        public string IsInformalCarer { get; set; }
+        public string Details { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -252,7 +252,10 @@ namespace SocialCareCaseViewerApi.V1.Factories
                         Id = relationship.OtherPerson.Id,
                         FirstName = relationship.OtherPerson.FirstName,
                         LastName = relationship.OtherPerson.LastName,
-                        Gender = relationship.OtherPerson.Gender
+                        Gender = relationship.OtherPerson.Gender,
+                        IsMainCarer = relationship.IsMainCarer,
+                        IsInformalCarer = relationship.IsInformalCarer,
+                        Details = relationship.Details?.Details
                     }
                     ).ToList()
                 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-471

## Describe this PR

### *What is the problem we're trying to solve*

We've added `IsMainCarer`, `IsInformalCarer` and `Details` fields when creating a personal relationship but we don't return these in the get relationships API endpoint.

### *What changes have we introduced*

This PR updates the get relationships API endpoint so it adds `IsMainCarer`, `IsInformalCarer` and `Details` to the response like:

```json
{
    "personId": 15,
    "personalRelationships": [
        {
            "type": "parent",
            "persons": [
                {
                    "id": 19,
                    "firstName": "Emma",
                    "lastName": "Geller-Green",
                    "gender": "F",
                    "isMainCarer":"Y",
                    "isInformalCarer": "N",
                    "details": null
                }
            ]
        }
    ]
}
```

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
