### PR TITLE
feat(SCT-471): update isMainCarer and isInformalCarer to be nullable in API request

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
@@ -28,12 +28,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             var response = createPersonalRelationshipRequestValidator.Validate(badRequest);
 
             response.IsValid.Should().BeFalse();
+            response.Errors.Should().HaveCount(3);
             response.Errors.Should().Contain(e => e.ErrorMessage == "'personId' must be provided.");
             response.Errors.Should().Contain(e => e.ErrorMessage == "'otherPersonId' must be provided.");
             response.Errors.Should().Contain(e => e.ErrorMessage == "'type' must be provided.");
-            response.Errors.Should().Contain(e => e.ErrorMessage == "'isMainCarer' must be provided.");
-            response.Errors.Should().Contain(e => e.ErrorMessage == "'isInformalCarer' must be provided.");
-            response.Errors.Should().NotContain(e => e.ErrorMessage == "'details' must be less than or equal to 1,000 characters.");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -40,10 +40,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(pr => pr.Type)
                 .NotNull().WithMessage("'type' must be provided.");
             RuleFor(pr => pr.IsMainCarer)
-                .NotNull().WithMessage("'isMainCarer' must be provided.")
                 .Matches("(?i:^Y|N)$").WithMessage("'isMainCarer' must be 'Y' or 'N'.");
             RuleFor(pr => pr.IsInformalCarer)
-                .NotNull().WithMessage("'isInformalCarer' must be provided.")
                 .Matches("(?i:^Y|N)$").WithMessage("'isInformalCarer' must be 'Y' or 'N'.");
             RuleFor(pr => pr.Details)
                 .MaximumLength(1000).WithMessage("'details' must be less than or equal to 1,000 characters.");


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-471

## Describe this PR

### *What is the problem we're trying to solve*

We've restricted `isMainCarer` and `isInformalCarer` to be required but they are times when it's not relevant to have both or either e.g. unborn child etc.

### *What changes have we introduced*

This PR removes the validation check for `isMainCarer` is not null and `isInformalCarer` is not null.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
