### PR TITLE
SCT-801 increase import lambda timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,7 @@ functions:
     name: social-care-case-viewer-mongodb-import-${self:provider.stage}
     handler: MongoDBImport::MongoDBImport.Handler::ImportFormData
     role: lambdaExecutionRole
-    timeout: 600
+    timeout: 900
     package:
       artifact: ./MongoDBImport/bin/release/netcoreapp3.1/mongodb-import.zip
     environment:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-801

## Describe this PR

### *What is the problem we're trying to solve*

DocumentDB data import Lambda has started hitting the 10 min timeout limit. This is causing the data import job to fail

### *What changes have we introduced*

Increase the timeout to 15  mins. This is the maximum available.

#### _Checklist_

- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

We have to start looking into changing the way the import works because we are likely to hit the maximum limit sometime in the not far distant future.
