### PR TITLE
SCT-789 fix search by postcode

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
@@ -413,7 +413,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person.Id, postCode: postcode, isDisplayAddress: "Y");
+            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person.Id, postCode: postcode);
 
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
@@ -226,6 +226,43 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
+        public void GetAllResidentsWithPostCodeQueryParameterReturnsOnlyResidentsWithPostcodeInDisplayAddress()
+        {
+            var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity();
+            var person2 = DatabaseGatewayHelper.CreatePersonDatabaseEntity();
+            DatabaseContext.Persons.Add(person1);
+            DatabaseContext.Persons.Add(person2);
+            DatabaseContext.SaveChanges();
+
+            var address1 = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person1.Id, postCode: "E83 AS");
+            var address2 = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person2.Id, postCode: "E83 AS", isDisplayAddress: "N");
+
+            DatabaseContext.Addresses.Add(address1);
+            DatabaseContext.Addresses.Add(address2);
+            DatabaseContext.SaveChanges();
+
+            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS");
+
+            listOfPersons.Count.Should().Be(1);
+            listOfPersons.First().MosaicId.Should().Be(person1.Id.ToString());
+        }
+
+        [Test]
+        public void GetAllResidentsWithPostCodeQueryParameterReturnsEmptyListWhenNoMatchingResidentsWithPostcodeInDisplayAddressAreFound()
+        {
+            var person = DatabaseGatewayHelper.CreatePersonDatabaseEntity();
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.SaveChanges();
+
+            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person.Id, postCode: "E83 AS", isDisplayAddress: "N");
+
+            DatabaseContext.Addresses.Add(address);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS").Should().BeEmpty();
+        }
+
+        [Test]
         public void GetAllResidentsWithPostCodeQueryParameterReturnsMatchingResident()
         {
             var person = DatabaseGatewayHelper.CreatePersonDatabaseEntity();
@@ -376,7 +413,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person.Id, postCode: postcode);
+            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: person.Id, postCode: postcode, isDisplayAddress: "Y");
 
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
@@ -71,7 +71,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
         public static Address CreateAddressDatabaseEntity(
             long? personId = null,
-            string isDisplayAddress = null,
+            string isDisplayAddress = "Y",
             DateTime? endDate = null,
             string postCode = null,
             string address = null

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -161,7 +161,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return _databaseContext.Addresses
                 .Where(add => id == null || EF.Functions.ILike(add.PersonId.ToString(), id.ToString()))
                 .Where(add => string.IsNullOrEmpty(address) || EF.Functions.ILike(add.AddressLines.Replace(" ", ""), addressSearchPattern))
-                .Where(add => string.IsNullOrEmpty(postcode) || EF.Functions.ILike(add.PostCode.Replace(" ", ""), postcodeSearchPattern))
+                .Where(add => string.IsNullOrEmpty(postcode) || EF.Functions.ILike(add.PostCode.Replace(" ", ""), postcodeSearchPattern) && add.IsDisplayAddress == "Y")
                 .Where(add => string.IsNullOrEmpty(firstname) || EF.Functions.ILike(add.Person.FirstName.Replace(" ", ""), firstNameSearchPattern))
                 .Where(add => string.IsNullOrEmpty(lastname) || EF.Functions.ILike(add.Person.LastName, lastNameSearchPattern))
                 .Where(add => string.IsNullOrEmpty(contextflag) || EF.Functions.ILike(add.Person.AgeContext, contextFlagSearchPattern))


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-789

## Describe this PR

### *What is the problem we're trying to solve*

When post code is used as a filter in person search the current implementation includes records with historical (non display) addresses as well. This is confusing to users because the type, display vs non display, is not visible on the front end.

### *What changes have we introduced*

This updates the gateway to exclude non display matches from results so only current display addresses are returned. 

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly