### PR TITLE
fix(SCT-471): fix not auditing personal relationship and details

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
@@ -113,6 +113,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
+        public void WhenCreatedByIsNotAnEmailAddressReturnsErrorWithMessage()
+        {
+            var badRequest = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(createdBy: "foobar");
+
+            var response = createPersonalRelationshipRequestValidator.Validate(badRequest);
+
+            response.IsValid.Should().BeFalse();
+            response.Errors.Should().Contain(e => e.ErrorMessage == "'createdBy' must be an email address.");
+        }
+
+        [Test]
         public void WhenRequestIsValidReturnsItIsValid()
         {
             var validRequest = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/CreatePersonalRelationshipRequestTests.cs
@@ -28,10 +28,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             var response = createPersonalRelationshipRequestValidator.Validate(badRequest);
 
             response.IsValid.Should().BeFalse();
-            response.Errors.Should().HaveCount(3);
+            response.Errors.Should().HaveCount(4);
             response.Errors.Should().Contain(e => e.ErrorMessage == "'personId' must be provided.");
             response.Errors.Should().Contain(e => e.ErrorMessage == "'otherPersonId' must be provided.");
             response.Errors.Should().Contain(e => e.ErrorMessage == "'type' must be provided.");
+            response.Errors.Should().Contain(e => e.ErrorMessage == "'createdBy' must be provided.");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerCreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/Relationship/RelationshipControllerCreatePersonalRelationshipTests.cs
@@ -1,10 +1,8 @@
-using AutoFixture;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
-using SocialCareCaseViewerApi.V1.Boundary.Response;
 using SocialCareCaseViewerApi.V1.Controllers;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
@@ -72,6 +70,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers.Relationship
             var exceptionMessage = "error message";
             _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()))
                 .Throws(new PersonalRelationshipAlreadyExistsException(exceptionMessage));
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
+
+            var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(exceptionMessage);
+        }
+
+        [Test]
+        public void WhenWorkerNotFoundExceptionIsThrownReturns400WithMessage()
+        {
+            var exceptionMessage = "error message";
+            _mockPersonalRelationshipsUseCase.Setup(x => x.ExecutePost(It.IsAny<CreatePersonalRelationshipRequest>()))
+                .Throws(new WorkerNotFoundException(exceptionMessage));
             var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest();
 
             var response = _relationshipController.CreatePersonalRelationship(request) as BadRequestObjectResult;

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/CreatePersonalRelationshipTests.cs
@@ -136,5 +136,37 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             details?.PersonalRelationshipId.Should().Be(response.Id);
             details?.Details.Should().Be(request.Details);
         }
+
+        [Test]
+        public void AuditsThePersonalRelationship()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+
+            var response = _databaseGateway.CreatePersonalRelationship(request);
+
+            var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault();
+            personalRelationship?.CreatedAt.Should().NotBeNull();
+            personalRelationship?.CreatedBy.Should().Be(request.CreatedBy);
+        }
+
+        [Test]
+        public void AuditsThePersonalRelationshipDetails()
+        {
+            var (person, otherPerson) = PersonalRelationshipsHelper.SavePersonAndOtherPersonToDatabase(DatabaseContext);
+            var type = DatabaseContext.PersonalRelationshipTypes.FirstOrDefault(prt => prt.Description == "parent");
+            var request = PersonalRelationshipsHelper.CreatePersonalRelationshipRequest(
+                person.Id, otherPerson.Id, type.Id, type.Description
+            );
+
+            var response = _databaseGateway.CreatePersonalRelationship(request);
+
+            var details = DatabaseContext.PersonalRelationshipDetails.FirstOrDefault();
+            details?.CreatedAt.Should().NotBeNull();
+            details?.CreatedBy.Should().Be(request.CreatedBy);
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -146,7 +146,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string type = "parent",
             string? isMainCarer = null,
             string? isInformalCarer = null,
-            string? details = null
+            string? details = null,
+            string? createdBy = null
         )
         {
             return new Faker<CreatePersonalRelationshipRequest>()
@@ -157,7 +158,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(pr => pr.IsMainCarer, f => isMainCarer ?? f.Random.String2(1, "YNyn"))
                 .RuleFor(pr => pr.IsInformalCarer, f => isInformalCarer ?? f.Random.String2(1, "YNyn"))
                 .RuleFor(pr => pr.Details, f => details ?? f.Random.String2(1000))
-                .RuleFor(pr => pr.CreatedBy, f => f.Internet.Email());
+                .RuleFor(pr => pr.CreatedBy, f => createdBy ?? f.Internet.Email());
         }
 
         public static (Person, Person) SavePersonAndOtherPersonToDatabase(DatabaseContext databaseContext)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/PersonalRelationshipsHelper.cs
@@ -156,7 +156,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(pr => pr.TypeId, f => typeId ?? f.UniqueIndex)
                 .RuleFor(pr => pr.IsMainCarer, f => isMainCarer ?? f.Random.String2(1, "YNyn"))
                 .RuleFor(pr => pr.IsInformalCarer, f => isInformalCarer ?? f.Random.String2(1, "YNyn"))
-                .RuleFor(pr => pr.Details, f => details ?? f.Random.String2(1000));
+                .RuleFor(pr => pr.Details, f => details ?? f.Random.String2(1000))
+                .RuleFor(pr => pr.CreatedBy, f => f.Internet.Email());
         }
 
         public static (Person, Person) SavePersonAndOtherPersonToDatabase(DatabaseContext databaseContext)

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecutePostUseCaseTests.cs
@@ -51,6 +51,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
 
             _mockDatabaseGateway.Setup(x => x.CreatePersonalRelationship(It.IsAny<CreatePersonalRelationshipRequest>()))
                 .Returns(personalRelationship);
+
+            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(It.IsAny<string>()))
+                .Returns(TestHelpers.CreateWorker(email: _request.CreatedBy));
         }
 
         [Test]
@@ -140,7 +143,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
                         request.TypeId == _typeInRequest.Id &&
                         request.IsMainCarer == _request.IsMainCarer &&
                         request.IsInformalCarer == request.IsInformalCarer &&
-                        request.Details == _request.Details
+                        request.Details == _request.Details &&
+                        request.CreatedBy == _request.CreatedBy
                 )
             ));
         }
@@ -158,9 +162,22 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Relationships
                         request.TypeId == _typeInRequest.InverseTypeId &&
                         request.IsMainCarer == null &&
                         request.IsInformalCarer == null &&
-                        request.Details == null
+                        request.Details == null &&
+                        request.CreatedBy == _request.CreatedBy
                 )
             ));
+        }
+
+        [Test]
+        public void WhenCreatedByEmailDoesNotExistThrowsWorkerNotFoundException()
+        {
+            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(It.IsAny<string>()))
+                .Returns((Worker) null);
+
+            Action act = () => _personalRelationshipsUseCase.ExecutePost(_request);
+
+            act.Should().Throw<WorkerNotFoundException>()
+                .WithMessage($"'createdBy' with '{_request.CreatedBy}' was not found as a worker.");
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -49,7 +49,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(pr => pr.Details)
                 .MaximumLength(1000).WithMessage("'details' must be less than or equal to 1,000 characters.");
             RuleFor(pr => pr.CreatedBy)
-                .NotNull().WithMessage("'createdBy' must be provided.");
+                .NotNull().WithMessage("'createdBy' must be provided.")
+                .EmailAddress().WithMessage("'createdBy' must be an email address.");
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/CreatePersonalRelationshipRequest.cs
@@ -27,6 +27,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [JsonPropertyName("details")]
         public string? Details { get; set; }
+
+        [JsonPropertyName("createdBy")]
+        public string CreatedBy { get; set; } = null!;
     }
 
     public class CreatePersonalRelationshipRequestValidator : AbstractValidator<CreatePersonalRelationshipRequest>
@@ -45,6 +48,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                 .Matches("(?i:^Y|N)$").WithMessage("'isInformalCarer' must be 'Y' or 'N'.");
             RuleFor(pr => pr.Details)
                 .MaximumLength(1000).WithMessage("'details' must be less than or equal to 1,000 characters.");
+            RuleFor(pr => pr.CreatedBy)
+                .NotNull().WithMessage("'createdBy' must be provided.");
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/RelationshipController.cs
@@ -72,7 +72,8 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             catch (Exception e) when (
                 e is PersonNotFoundException ||
                 e is PersonalRelationshipTypeNotFoundException ||
-                e is PersonalRelationshipAlreadyExistsException
+                e is PersonalRelationshipAlreadyExistsException ||
+                e is WorkerNotFoundException
             )
             {
                 return BadRequest(e.Message);

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -937,9 +937,11 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 IsMainCarer = request.IsMainCarer?.ToUpper(),
                 IsInformalCarer = request.IsInformalCarer?.ToUpper(),
                 StartDate = _systemTime.Now,
+                CreatedBy = request.CreatedBy,
                 Details = new PersonalRelationshipDetail()
                 {
-                    Details = request.Details
+                    Details = request.Details,
+                    CreatedBy = request.CreatedBy
                 }
             };
 

--- a/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationshipDetail.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/PersonalRelationshipDetail.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace SocialCareCaseViewerApi.V1.Infrastructure
 {
     [Table("sccv_personal_relationship_detail", Schema = "dbo")]
-    public class PersonalRelationshipDetail
+    public class PersonalRelationshipDetail : IAuditEntity
     {
         [Column("id")]
         [MaxLength(16)]

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -30,6 +30,10 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             var typeDoesNotExist = type == null;
             if (typeDoesNotExist) throw new PersonalRelationshipTypeNotFoundException($"'type' with '{request.Type}' was not found.");
 
+            var worker = _databaseGateway.GetWorkerByEmail(request.CreatedBy);
+            var workerDoesNotExist = worker == null;
+            if (workerDoesNotExist) throw new WorkerNotFoundException($"'createdBy' with '{request.CreatedBy}' was not found as a worker.");
+
             var personWithPersonalRelationships = _databaseGateway.GetPersonWithPersonalRelationshipsByPersonId(request.PersonId);
 
             var personalRelationships = personWithPersonalRelationships.PersonalRelationships;
@@ -47,7 +51,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 TypeId = type.InverseTypeId,
                 IsMainCarer = null,
                 IsInformalCarer = null,
-                Details = null
+                Details = null,
+                CreatedBy = request.CreatedBy
             });
         }
     }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-471

## Describe this PR

### *What is the problem we're trying to solve*

We're not correctly auditing `PersonalRelationship` and `PersonalRelationshipDetails` because we're missing the `CreatedBy` attribute and `IAuditEntity` for `PersonalRelationshipDetails`.

The frontend has been updated to send the user's email as `createdBy` in the request, see https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/567.

### *What changes have we introduced*

This PR updates the `CreatePersonalRelationshipRequest` to take in `CreatedBy` and then ensures we save this for a `PersonalRelationship` and `PersonalRelationshipDetails`. It also adds the missing `IAuditEntity` for `PersonalRelationshipDetails`.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

