### PR TITLE
SCT-811 soft delete recovery script

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates;
+using System.Linq;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Data
+{
+    public class SoftDeleteRecoveryTests : DatabaseTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
+
+        [Test]
+        public void SetsTheMarkedForDeletionFlagToFalseForPersonAndRelatedEntitiesAndRemovesTheRecordFromDeletedPersonRecordTable()
+        {
+            //person to be deleted, new master record and relationship
+            var (deletedPerson, newMasterPersonRecord, personalRelationship, personalRelationshipType, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
+          
+            //address
+            var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: deletedPerson.Id);
+            address.MarkedForDeletion = true;
+            DatabaseContext.Addresses.Add(address);
+
+            //telephone numbers
+            var telephoneNumber = DatabaseGatewayHelper.CreatePhoneNumberEntity(personId: deletedPerson.Id);
+            address.MarkedForDeletion = true;
+            DatabaseContext.PhoneNumbers.Add(telephoneNumber);
+
+            //other names
+            var otherName = DatabaseGatewayHelper.CreatePersonOtherNameDatabaseEntity(personId: deletedPerson.Id);
+            otherName.MarkedForDeletion = true;
+            DatabaseContext.PersonOtherNames.Add(otherName);
+
+            //allocations
+            var allocation = TestHelpers.CreateAllocation(personId: (int) deletedPerson.Id);
+            allocation.MarkedForDeletion = true;
+            DatabaseContext.Allocations.Add(allocation);
+
+            //warning notes
+            var warningNote = TestHelpers.CreateWarningNote(personId: deletedPerson.Id);
+            warningNote.MarkedForDeletion = true;
+            DatabaseContext.WarningNotes.Add(warningNote);
+
+            //inverse relationship (type not handled for simplicity)
+            var inversePersonalRelationship = PersonalRelationshipsHelper.CreatePersonalRelationship(newMasterPersonRecord, deletedPerson, personalRelationshipType);
+            inversePersonalRelationship.MarkedForDeletion = true;
+            DatabaseContext.PersonalRelationships.Add(inversePersonalRelationship);
+
+            //record marked as deleted
+            DatabaseContext.DeletedPersonRecords.Add(new DeletedPersonRecord()
+            {
+                DeletedId = deletedPerson.Id,
+                MasterId = newMasterPersonRecord.Id
+            });
+
+            DatabaseContext.SaveChanges();
+
+            //TODO: wrap into transaction when running manually (BEGIN; <SCRIPT> END;)
+            //TODO: this is designed to be run against individual IDs. Replace the {deletedPerson.Id} with appropriate MosaicId (long)
+            DatabaseContext.Database.ExecuteSqlInterpolated($@"
+                   UPDATE dbo.dm_persons SET marked_for_deletion = false WHERE person_id = {deletedPerson.Id};
+                   UPDATE dbo.dm_addresses SET marked_for_deletion = false WHERE person_id = {deletedPerson.Id};
+                   UPDATE dbo.dm_telephone_numbers SET marked_for_deletion = false WHERE person_id = {deletedPerson.Id};
+                   UPDATE dbo.sccv_person_other_name SET marked_for_deletion = false WHERE person_id = {deletedPerson.Id};
+                   UPDATE dbo.sccv_allocations_combined SET marked_for_deletion = false WHERE mosaic_id = {deletedPerson.Id};
+                   UPDATE dbo.sccv_warning_note SET marked_for_deletion = false WHERE person_id = {deletedPerson.Id};
+                   UPDATE dbo.sccv_personal_relationship SET marked_for_deletion = false WHERE fk_person_id = {deletedPerson.Id};
+                   UPDATE dbo.sccv_personal_relationship SET marked_for_deletion = false WHERE fk_other_person_id = {deletedPerson.Id};
+                   DELETE from dbo.sccv_deleted_person_record where deleted_person_id = {deletedPerson.Id};
+            ");
+
+            DatabaseContext.Persons.First(x => x.Id == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.Addresses.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.PhoneNumbers.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.PersonOtherNames.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.Allocations.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.WarningNotes.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.PersonalRelationships.First(x => x.PersonId == deletedPerson.Id).MarkedForDeletion.Should().BeFalse();
+            DatabaseContext.PersonalRelationships.First(x => x.OtherPersonId == newMasterPersonRecord.Id).MarkedForDeletion.Should().BeFalse();
+
+            DatabaseContext.DeletedPersonRecords.Any(x => x.DeletedId == deletedPerson.Id).Should().BeFalse();
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
@@ -21,7 +21,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data
         {
             //person to be deleted, new master record and relationship
             var (deletedPerson, newMasterPersonRecord, personalRelationship, personalRelationshipType, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
-          
+
             //address
             var address = DatabaseGatewayHelper.CreateAddressDatabaseEntity(personId: deletedPerson.Id);
             address.MarkedForDeletion = true;

--- a/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/SoftDeleteRecoveryTests.cs
@@ -19,7 +19,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data
         [Test]
         public void SetsTheMarkedForDeletionFlagToFalseForPersonAndRelatedEntitiesAndRemovesTheRecordFromDeletedPersonRecordTable()
         {
-            //person to be deleted, new master record and relationship
+            //person to be restored, new master record and relationship
             var (deletedPerson, newMasterPersonRecord, personalRelationship, personalRelationshipType, _) = PersonalRelationshipsHelper.SavePersonWithPersonalRelationshipToDatabase(DatabaseContext);
 
             //address
@@ -52,7 +52,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data
             inversePersonalRelationship.MarkedForDeletion = true;
             DatabaseContext.PersonalRelationships.Add(inversePersonalRelationship);
 
-            //record marked as deleted
+            //record marked as soft deleted
             DatabaseContext.DeletedPersonRecords.Add(new DeletedPersonRecord()
             {
                 DeletedId = deletedPerson.Id,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-811

## Describe this PR

### *What is the problem we're trying to solve*

When we soft delete records as described in https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/360, we need to be able to restore those records.

### *What changes have we introduced*

Adds a SQL script that can be run against individual MosaicIDs that were previously marked for soft delete.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
