### PR TITLE
SCT-856 add support for 0 prefixes in emergency ids in person search

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1442,7 +1442,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         [Test]
         public void GetPersonIdsByEmergencyIdReturnsEmptyListWhenNoMatchingRecordsFound()
         {
-            _classUnderTest.GetPersonIdsByEmergencyId(123).Count.Should().Be(0);
+            _classUnderTest.GetPersonIdsByEmergencyId("123").Count.Should().Be(0);
         }
 
         [Test]
@@ -1470,12 +1470,35 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             DatabaseContext.SaveChanges();
 
-            var result = _classUnderTest.GetPersonIdsByEmergencyId(123);
+            var result = _classUnderTest.GetPersonIdsByEmergencyId("123");
 
             result.Count.Should().Be(2);
             result.Any(x => x == person1.Id).Should().BeTrue();
             result.Any(x => x == person2.Id).Should().BeTrue();
             result.Any(x => x == person3.Id).Should().BeFalse();
+        }
+
+        [Test]
+        [TestCase("041")]
+        [TestCase("0041")]
+        [TestCase("00041")]
+        [TestCase("000041")]
+        public void GetPersonIdsByEmergencyIdReturnsListOfMatchingPersonIdsWhenEmergencyIdHasLeadingZerosInId(string id)
+        {
+            var person = SavePersonToDatabase(DatabaseGatewayHelper.CreatePersonDatabaseEntity(personId: 33004455));
+
+            DatabaseContext.PersonLookups.Add(
+                new PersonIdLookup()
+                {
+                    MosaicId = person.Id.ToString(),
+                    NCId = id
+                });
+
+            DatabaseContext.SaveChanges();
+
+            var result = _classUnderTest.GetPersonIdsByEmergencyId(id);
+
+            result.Count.Should().Be(1);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetAllUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetAllUseCaseTests.cs
@@ -211,7 +211,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
 
             var expectedIdParameter = Regex.Replace(mosaicId, "[^0-9.]", "");
 
-            _mockDatabaseGateway.Verify(x => x.GetPersonIdsByEmergencyId(request.MosaicId));
+            _mockDatabaseGateway.Verify(x => x.GetPersonIdsByEmergencyId(expectedIdParameter));
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -898,13 +898,13 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             return _databaseContext.Persons.Where(x => ids.Contains(x.Id) && x.MarkedForDeletion == false).ToList();
         }
 
-        public List<long> GetPersonIdsByEmergencyId(long id)
+        public List<long> GetPersonIdsByEmergencyId(string id)
         {
             return _databaseContext
                .PersonLookups
                .AsNoTracking()
                .AsEnumerable()
-               .Where(x => Regex.Replace(x.NCId, "[^0-9.]", "") == id.ToString())
+               .Where(x => Regex.Replace(x.NCId, "[^0-9.]", "") == id)
                .Select(x => Convert.ToInt64(x.MosaicId)).ToList();
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -36,7 +36,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         void UpdatePerson(UpdatePersonRequest request);
         List<Person> GetPersonsByListOfIds(List<long> ids);
         Person GetPersonByMosaicId(long mosaicId);
-        List<long> GetPersonIdsByEmergencyId(long id);
+        List<long> GetPersonIdsByEmergencyId(string id);
         Person GetPersonWithPersonalRelationshipsByPersonId(long personId, bool includeEndedRelationships = false);
         PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description);
         PersonalRelationship CreatePersonalRelationship(CreatePersonalRelationshipRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/GetAllUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/GetAllUseCase.cs
@@ -38,17 +38,20 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             //if Mosaic ID is provided, use that as a search criteria ignoring other parameters
             if (mosaicId != null)
             {
-                //check for individual
-                var resident = _databaseGateway.GetPersonByMosaicId(mosaicId.Value);
-
-                if (resident != null)
+                //check for individual. Ignore if provided id contains leading zeros as those won't be system Ids
+                if (!rqp.MosaicId.StartsWith("0"))
                 {
-                    residents.Add(resident.ToResidentInformationResponse());
+                    var resident = _databaseGateway.GetPersonByMosaicId(mosaicId.Value);
+
+                    if (resident != null)
+                    {
+                        residents.Add(resident.ToResidentInformationResponse());
+                    }
                 }
 
                 //check for matching emergency Ids
                 //This enables overlapping Mosaic and emergency IDs to be included in the results set
-                var residentsWithMatchingEmergencyIds = _databaseGateway.GetPersonIdsByEmergencyId(mosaicId.Value);
+                var residentsWithMatchingEmergencyIds = _databaseGateway.GetPersonIdsByEmergencyId(rqp.MosaicId);
 
                 //if IDs found, get the person records
                 if (residentsWithMatchingEmergencyIds.Any())


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-856

## Describe this PR

### *What is the problem we're trying to solve*

Some emergency IDs have zero prefixes in them and the initial implementation didn't take those into account, so the search wasn't returning correct results.

### *What changes have we introduced*

Add leading zero handling to the use case and to the gateway.

When provided id contains leading zeros, it's handled as emergency id since Mosaic/system ids cannot have those (long type).

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
