### PR TITLE
refactor(SCT-479): refactor deleting relationship to cascade on delete

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/DeleteRelationshipsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/DeleteRelationshipsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using FluentAssertions;
 using Moq;
@@ -7,7 +6,6 @@ using SocialCareCaseViewerApi.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Infrastructure;
-using Microsoft.EntityFrameworkCore;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 {
@@ -31,7 +29,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void DeletesAPersonalRelationship()
         {
-            _databaseGateway.DeleteRelationships(_relationship);
+            _databaseGateway.DeleteRelationship(_relationship.Id);
 
             var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault(pr => pr.Id == _relationship.Id);
 
@@ -41,7 +39,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void DeletesAPersonalRelationshipInverse()
         {
-            _databaseGateway.DeleteRelationships(_relationship);
+            _databaseGateway.DeleteRelationship(_relationship.Id);
 
             var personalRelationship = DatabaseContext.PersonalRelationships.FirstOrDefault(pr => pr.Id == _oppositeRelationship.Id);
 
@@ -51,7 +49,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void DeletesAPersonalRelationshipDetails()
         {
-            _databaseGateway.DeleteRelationships(_relationship);
+            _databaseGateway.DeleteRelationship(_relationship.Id);
 
             var personalRelationshipDetails = DatabaseContext.PersonalRelationshipDetails.FirstOrDefault(pr => pr.Id == _relationship.Id);
 
@@ -61,7 +59,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void DeletesAPersonalRelationshipInverseDetails()
         {
-            _databaseGateway.DeleteRelationships(_relationship);
+            _databaseGateway.DeleteRelationship(_relationship.Id);
 
             var reverseRelationshipDetails = DatabaseContext.PersonalRelationshipDetails.FirstOrDefault(pr => pr.Id == _oppositeRelationship.Id);
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecuteDeleteUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/PersonalRelationships/PersonalRelationshipsExecuteDeleteUseCaseTests.cs
@@ -7,7 +7,6 @@ using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.UseCase;
-using System.Collections.Generic;
 using System;
 
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase.PersonalRelationships
@@ -71,7 +70,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.PersonalRelationships
 
             _personalRelationshipsUseCase.ExecuteDelete(_relationship.Id);
 
-            _mockDatabaseGateway.Verify(gateway => gateway.DeleteRelationships(_relationship));
+            _mockDatabaseGateway.Verify(gateway => gateway.DeleteRelationship(_relationship.Id));
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -944,28 +944,21 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .FirstOrDefault(prt => prt.Id == relationshipId);
         }
 
-        public void DeleteRelationships(Infrastructure.PersonalRelationship relationship)
+        public void DeleteRelationship(long id)
         {
-            var type = _databaseContext.PersonalRelationshipTypes.FirstOrDefault(tp => tp.Id == relationship.TypeId);
+            var relationship = _databaseContext.PersonalRelationships
+                .Where(prt => prt.Id == id)
+                .Include(pr => pr.Type)
+                .Include(pr => pr.Details)
+                .FirstOrDefault();
 
-            var inverseType = _databaseContext.PersonalRelationshipTypes.FirstOrDefault(tp => tp.Id == type.InverseTypeId);
-
-            var secondRelationship = _databaseContext.PersonalRelationships.Where(prt => prt.PersonId == relationship.OtherPersonId && prt.TypeId == inverseType.Id).FirstOrDefault();
-
-            var relationshipDetails = _databaseContext.PersonalRelationshipDetails.FirstOrDefault(prd => prd.PersonalRelationshipId == relationship.Id);
-            var secondRelationshipDetails = _databaseContext.PersonalRelationshipDetails.FirstOrDefault(prd => prd.PersonalRelationshipId == secondRelationship.Id);
-
-            if (relationshipDetails != null)
-            {
-                _databaseContext.PersonalRelationshipDetails.Remove(relationshipDetails);
-            }
-            if (secondRelationshipDetails != null)
-            {
-                _databaseContext.PersonalRelationshipDetails.Remove(secondRelationshipDetails);
-            }
+            var inverseRelationship = _databaseContext.PersonalRelationships
+                .Where(pr => pr.PersonId == relationship.OtherPersonId && pr.TypeId == relationship.Type.InverseTypeId)
+                .Include(pr => pr.Details)
+                .FirstOrDefault();
 
             _databaseContext.PersonalRelationships.Remove(relationship);
-            _databaseContext.PersonalRelationships.Remove(secondRelationship);
+            _databaseContext.PersonalRelationships.Remove(inverseRelationship);
 
             _databaseContext.SaveChanges();
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/IDatabaseGateway.cs
@@ -41,6 +41,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         PersonalRelationshipType GetPersonalRelationshipTypeByDescription(string description);
         PersonalRelationship CreatePersonalRelationship(CreatePersonalRelationshipRequest request);
         PersonalRelationship GetPersonalRelationshipById(long relationshipId);
-        void DeleteRelationships(PersonalRelationship relationship);
+        void DeleteRelationship(long relationshipId);
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/PersonalRelationshipsUseCase.cs
@@ -18,10 +18,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         public void ExecuteDelete(long id)
         {
             var relationship = _databaseGateway.GetPersonalRelationshipById(id);
+
             var relationshipDoesNotExist = relationship == null;
             if (relationshipDoesNotExist) throw new PersonalRelationshipNotFoundException($"'relationshipId' with '{id}' was not found.");
 
-            _databaseGateway.DeleteRelationships(relationship);
+            _databaseGateway.DeleteRelationship(relationship.Id);
         }
 
         public void ExecutePost(CreatePersonalRelationshipRequest request)


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-479

## Describe this PR

### *What is the problem we're trying to solve*

In #376, we create a new DB gateway to delete a relationship (technically deleting two rows though). We did this by doing multiple calls to the database to get the type, the inverse relationship and the details for both.

We want to take advantage of EF Core and utilise cascade on delete so that can write less code, see https://docs.microsoft.com/en-us/ef/core/saving/cascade-delete.

### *What changes have we introduced*

This PR refactors deleting a relationship to reduce the amount of calls by using `Include` and taking advantage of cascade on delete which means when we delete the `PersonalRelationship` it will also delete `PersonalRelationshipDetail` because we've included it when searching.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
