### PR TITLE
chore: Update the make restart db command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ start-test-dbs:
 
 .PHONY: restart-db
 restart-db:
-	docker stop $$(docker ps -q --filter ancestor=test-database -a)
-	-docker rm $$(docker ps -q --filter ancestor=test-database -a)
-	docker rmi test-database
-	docker-compose up -d test-database
+	docker stop $$(docker ps -q --filter ancestor=sccv-api-test-postgresql -a)
+	-docker rm $$(docker ps -q --filter ancestor=sccv-api-test-postgresql -a)
+	docker rmi sccv-api-test-postgresql
+	docker-compose up -d sccv-api-test-postgresql
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ test:
 start-test-dbs:
 	docker-compose up -d sccv-api-test-postgresql && docker-compose up -d sccv-api-test-mongo-db
 
-.PHONY: restart-db
-restart-db:
+.PHONY: restart-test-pg-db
+restart-test-pg-db:
 	docker stop $$(docker ps -q --filter ancestor=sccv-api-test-postgresql -a)
 	-docker rm $$(docker ps -q --filter ancestor=sccv-api-test-postgresql -a)
 	docker rmi sccv-api-test-postgresql

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ $ dotnet test --filter GivenHttpClientReturnsValidResponseThenGatewayReturnsList
 $ dotnet test --filter SocialCarePlatformAPIGatewayTests
 ```
 
-If your docker test database is out of sync with the schema on your current branch run
+If your docker test postgres database is out of sync with the schema on your current branch run
 
 ```sh
-$ make restart-db
+$ make restart-test-pg-db
 ```
 
 See [Microsoft's documentation on running selective unit tests](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest) for more information.


### PR DESCRIPTION
The make command to restart the test databases was referencing the old image name of the Postgres test database.

We use `make restart-db` to make sure our local docker databases are up to date with any schema changes in the current branch.

This updates the command to reference the new image and service name for the docker test database.

This might not work if the old `test-database` image still exists
or if the new image name: `sccv-api-test-postgresql` does not exist.

Would recommend checking and cleaning up the docker images to match what we be expecting before running this command.