### PR TITLE
SCT-815 update mongodb record with new mosaic id

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
@@ -104,9 +104,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
             string mosaicIdTwo = "556677";
             string masterPersonId = "77889900";
 
-            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
-            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
-            var casenoteThree = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicIdTwo).Create();
+            var casenoteOneForMosaicId = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteTwoForMosaicId = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteThreeForMosaicIdTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicIdTwo).Create();
 
             var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
@@ -6,6 +6,7 @@ using MongoDB.Driver;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using System;
+using System.Linq;
 
 #nullable enable
 namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
@@ -110,9 +111,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
 
             var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
 
-            collection?.InsertOne(casenoteOne);
-            collection?.InsertOne(casenoteTwo);
-            collection?.InsertOne(casenoteThree);
+            collection?.InsertOne(casenoteOneForMosaicId);
+            collection?.InsertOne(casenoteTwoForMosaicId);
+            collection?.InsertOne(casenoteThreeForMosaicIdTwo);
 
             var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
 
@@ -129,7 +130,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
         public void DoesNotUpdateAuditTypeRecordsThatHaveAPIInTheFormNameOverallField()
         {
             string mosaicId = "334445566";
-            string masterPersonId = "77889900";
 
             var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).With(x => x.FormNameOverall, "API_Event").Create();
             var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
@@ -143,9 +143,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
 
             var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
 
-            var filterByNewId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", masterPersonId);
-            var recordsWithNewId = collection.Find(filterByNewId).ToList();
-            recordsWithNewId.Count.Should().Be(2);
+            var filterByFormNameOverall = Builders<MongoDBTestObject>.Filter.Eq("FormNameOverall", "API_Event");
+            var filteredRecords = collection.Find(filterByFormNameOverall).ToList();
+
+            filteredRecords.Count.Should().Be(1);
+            filteredRecords.First().MosaicId.Should().Be(mosaicId);
         }
     }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
@@ -1,0 +1,156 @@
+using AutoFixture;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using System;
+
+#nullable enable
+namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
+{
+    [TestFixture]
+    public class UpdateMosaicIdFormDataCollection
+    {
+        private readonly Fixture _fixture = new Fixture();
+        private const string MainFormCollection = "form_data";
+        private IMongoDatabase? _mongoDatabase;
+
+        private static readonly JsonCommand<BsonDocument> _dbCommandUnderTest = new JsonCommand<BsonDocument>(
+                @"{
+                    update: ""form_data"",
+                    updates:
+                        [
+                            {
+                                q: { MosaicId: ""334445566"", FormNameOverall: { $not: /^API_/ } }, u: { $set: { MosaicId: ""77889900"" } }, multi: true
+                            }
+                        ]
+                }");
+
+        /// <summary>
+        ///  This script is designed to be run against a single ID as a workaround until the appropriate API endpoint is in place
+        ///  Only runs against form_data collection
+        ///  Updates all matching records that are not any of the audit event types created by the service API
+        /// </summary>
+        /// <howto>
+        /// To run this script manually on the server:
+        /// - remove double quotes
+        /// - add appropriate IDs (one in the query (q) is the current one and the one in the $set is the new master id)
+        /// - pass it to the db.runCommand() like this:
+        ///
+        /// db.runCommand({
+        ///  update: "form_data",
+        ///  updates:
+        ///      [
+        ///          {
+        ///              q: { MosaicId: "334445566", FormNameOverall: { $not: /^API_/ } }, u: { $set: { MosaicId: "77889900" } }, multi: true
+        ///          }
+        ///      ]
+        /// });
+        /// </howto>      
+
+
+        [SetUp]
+        public void SetUp()
+        {
+            string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
+                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+                                           @"mongodb://localhost:1433/";
+
+            string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";
+
+            var mongoClient = new MongoClient(new MongoUrl(mongoConnectionString));
+            _mongoDatabase = mongoClient.GetDatabase(databaseName);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mongoDatabase?.DropCollection(MainFormCollection);
+        }
+
+        [Test]
+        public void UpdatesMosaicIdToNewMasterPersonIdForAllMatchingRecords()
+        {
+            string mosaicId = "334445566";
+            string masterPersonId = "77889900";
+
+            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteThree = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+
+            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
+
+            collection?.InsertOne(casenoteOne);
+            collection?.InsertOne(casenoteTwo);
+            collection?.InsertOne(casenoteThree);
+
+            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
+
+            var filterByNewId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", masterPersonId);
+            var recordsWithNewId = collection.Find(filterByNewId).ToList();
+            recordsWithNewId.Count.Should().Be(3);
+            
+            var filterByOldId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", mosaicId);
+            var recordsWithOldId = collection.Find(filterByOldId).ToList();
+            recordsWithOldId.Count.Should().Be(0);
+        }
+
+        [Test]
+        public void DoesNotUpdateOtherThanMatchingRecords()
+        {
+            string mosaicId = "334445566";
+            string mosaicIdTwo = "556677";
+            string masterPersonId = "77889900";
+
+            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteThree = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicIdTwo).Create();
+
+            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
+
+            collection?.InsertOne(casenoteOne);
+            collection?.InsertOne(casenoteTwo);
+            collection?.InsertOne(casenoteThree);
+
+            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
+
+            var filterByNewId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", masterPersonId);
+            var recordsWithNewId = collection.Find(filterByNewId).ToList();
+            recordsWithNewId.Count.Should().Be(2);
+
+            var filterByExcludedId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", mosaicIdTwo);
+            var recordsWitExcludedId = collection.Find(filterByExcludedId).ToList();
+            recordsWitExcludedId.Count.Should().Be(1);
+        }
+
+        [Test]
+        public void DoesNotUpdateAuditTypeRecordsThatHaveAPIInTheFormNameOverallField()
+        {
+            string mosaicId = "334445566";
+            string masterPersonId = "77889900";
+
+            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).With(x => x.FormNameOverall, "API_Event").Create();
+            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+            var casenoteThree = _fixture.Build<MongoDBTestObject>().With(x => x.MosaicId, mosaicId).Create();
+
+            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
+
+            collection?.InsertOne(casenoteOne);
+            collection?.InsertOne(casenoteTwo);
+            collection?.InsertOne(casenoteThree);
+
+            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
+
+            var filterByNewId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", masterPersonId);
+            var recordsWithNewId = collection.Find(filterByNewId).ToList();
+            recordsWithNewId.Count.Should().Be(2);
+        }
+    }
+
+    [BsonIgnoreExtraElements]
+    public class MongoDBTestObject : CaseNoteBase
+    {
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
@@ -91,7 +91,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
             var filterByNewId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", masterPersonId);
             var recordsWithNewId = collection.Find(filterByNewId).ToList();
             recordsWithNewId.Count.Should().Be(3);
-            
+
             var filterByOldId = Builders<MongoDBTestObject>.Filter.Eq("MosaicId", mosaicId);
             var recordsWithOldId = collection.Find(filterByOldId).ToList();
             recordsWithOldId.Count.Should().Be(0);

--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/DeletePersonRecordsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/DeletePersonRecordsTests.cs
@@ -7,7 +7,7 @@ using SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates;
 using System;
 using System.Linq;
 
-namespace SocialCareCaseViewerApi.Tests.V1.Data
+namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
 {
     [TestFixture]
     public class DeletePersonRecordsTests : DatabaseTests

--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/SoftDeleteRecoveryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/SoftDeleteRecoveryTests.cs
@@ -6,7 +6,7 @@ using SocialCareCaseViewerApi.V1.Infrastructure;
 using SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates;
 using System.Linq;
 
-namespace SocialCareCaseViewerApi.Tests.V1.Data
+namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
 {
     public class SoftDeleteRecoveryTests : DatabaseTests
     {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-815

## Describe this PR

### *What is the problem we're trying to solve*

When person records are soft deleted in postgreSQL the existing form records must be transferred over to the new master person id. This scripts updates all relevant records for a given ID in `form_data` collection.

Comments from the script:
**summary**
 This script is designed to be run against a single ID as a workaround until the appropriate API endpoint is in place
 Only runs against form_data collection
 Updates all matching records that are not any of the audit event types created by the service API

**Howto**
To run this script manually on the server:
- remove double quotes
- add appropriate IDs (one in the query (q) is the current one and the one in the $set is the new master id)
- pass it to the db.runCommand() like this:

```
db.runCommand({
 update: "form_data",
 updates:
     [
         {
              q: { MosaicId: "334445566", FormNameOverall: { $not: /^API_/ } }, u: { $set: { MosaicId: "77889900" } }, multi: true
         }
     ]
});
```


### *What changes have we introduced*

Added a script that can be run against form_data collection to update the form records.
Please note this does not handle any other collections, so residents submissions collection for example has to be handled separately (done in separate PR once the transfer method is agreed).

Re-structured data script tests to new namsespaces

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly