### PR TITLE
Sct 647 asc emergency ids import script

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Data/ASCEmergencyIdImportTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/ASCEmergencyIdImportTests.cs
@@ -1,0 +1,174 @@
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates;
+using System;
+using System.Linq;
+
+#nullable enable
+namespace SocialCareCaseViewerApi.Tests.V1.Data
+{
+    [TestFixture]
+    public class ASCEmergencyIdImportTests : DatabaseTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+
+        private static readonly FormattableString _queryUnderTest = $@"
+                   do
+                    $$
+                            declare
+                                    new_person record;
+                                    new_person_mosaic_id bigint;
+                            begin
+                                    for new_person
+                                    in SELECT
+                                            imports.first_name,
+                                            imports.last_name,
+                                            imports.full_name,
+                                            imports.date_of_birth,
+                                            imports.person_id,
+                                            imports.gender,
+                                            imports.restricted,
+                                            imports.context_flag
+
+                            FROM
+                                    dbo.SCCV_PERSONS_LOOKUP as lookup RIGHT OUTER JOIN
+                                    dbo.SCCV_PERSONS_IMPORT as imports ON lookup.NC_ID = imports.PERSON_ID
+                            WHERE lookup.PERSON_ID is null AND LOWER(imports.PERSON_ID) like 'tmp%'
+
+                            loop
+                                    new_person_mosaic_id = null;
+
+                                    insert into dbo.dm_persons(
+                                            first_name,
+                                            last_name,
+                                            full_name,
+                                            date_of_birth,
+                                            gender,
+                                            restricted,
+                                            context_flag,
+                                            from_dm_person
+                                    )
+                                    values (
+                                            new_person.first_name,
+                                            new_person.last_name,
+                                            new_person.full_name,
+                                            new_person.date_of_birth,
+                                            new_person.gender,
+                                            new_person.restricted,
+                                            new_person.context_flag,
+                                            'N'
+                                    )
+                                    returning person_id into new_person_mosaic_id;
+
+                                    insert into dbo.sccv_persons_lookup(person_id, nc_id)
+                                            values (new_person_mosaic_id, new_person.person_id);
+
+                                    raise notice '% - %', new_person.person_id, new_person_mosaic_id;
+                            end loop;
+                    end;
+                    $$
+                   ";
+
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
+
+        [Test]
+        public void ImportsNewPersonWithASCEmergencyIdFromPersonsImportTableToPersonTable()
+        {
+            var newPersonRecordToImport = _fixture.Build<PersonImport>().With(x => x.Id, "tmp123").Create();
+            DatabaseContext.PersonImport.Add(newPersonRecordToImport);
+
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            DatabaseContext.Persons.Count().Should().Be(1);
+        }
+
+        [Test]
+        public void CreatesNewLookupRecordInThePersonLookupTable()
+        {
+            var newPersonRecordToImport = _fixture.Build<PersonImport>().With(x => x.Id, "tmp123").Create();
+            DatabaseContext.PersonImport.Add(newPersonRecordToImport);
+
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            var importedPerson = DatabaseContext.Persons.First();
+
+            var lookup = DatabaseContext.PersonLookups.First();
+
+            lookup.NCId.Should().Be(newPersonRecordToImport.Id);
+            lookup.MosaicId.Should().Be(importedPerson.Id.ToString());
+        }
+
+        [Test]
+        public void CreatesNewPersonRecordWithCorrectValuesForSupportedColumns()
+        {
+            var dateOfBirth = new DateTime(2000, 1, 1, 15, 30, 0);
+
+            var newPersonRecordToImport = _fixture.Build<PersonImport>()
+                .With(x => x.Id, "tmp123")
+                .With(x => x.DateOfBirth, dateOfBirth).Create();
+
+            DatabaseContext.PersonImport.Add(newPersonRecordToImport);
+
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            var importedPerson = DatabaseContext.Persons.First();
+
+            importedPerson.FirstName.Should().Be(newPersonRecordToImport.FirstName);
+            importedPerson.LastName.Should().Be(newPersonRecordToImport.LastName);
+            importedPerson.FullName.Should().Be(newPersonRecordToImport.FullName);
+            importedPerson.DateOfBirth.Should().Be(newPersonRecordToImport.DateOfBirth);
+            importedPerson.Gender.Should().Be(newPersonRecordToImport.Gender);
+            importedPerson.Restricted.Should().Be(newPersonRecordToImport.Restricted);
+            importedPerson.AgeContext.Should().Be(newPersonRecordToImport.AgeContext);
+            importedPerson.DataIsFromDmPersonsBackup.Should().Be("N");
+        }
+
+        [Test]
+        [TestCase("tmp123")]
+        [TestCase("tmp003344")]
+
+        public void OnlyImportsRecordsThatArePrefixedWithTmpAsRequestedByASC(string emergencyId)
+        {
+            var newPersonRecordToImport = _fixture.Build<PersonImport>().With(x => x.Id, emergencyId).Create();
+            DatabaseContext.PersonImport.Add(newPersonRecordToImport);
+
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            DatabaseContext.Persons.Count().Should().Be(1);
+        }
+
+        [Test]
+        [TestCase("nc123")]
+        [TestCase("asc003344")]
+        [TestCase("123tmp")]
+        [TestCase("123")]
+
+        public void DoesNotImportRecordsThatDoNotHaveTmpPrefix(string emergencyId)
+        {
+            var newPersonRecordToImport = _fixture.Build<PersonImport>().With(x => x.Id, emergencyId).Create();
+            DatabaseContext.PersonImport.Add(newPersonRecordToImport);
+
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            DatabaseContext.Persons.Count().Should().Be(0);
+        }
+    }
+}
+

--- a/SocialCareCaseViewerApi.Tests/V1/Data/ASCEmergencyIdImportTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/ASCEmergencyIdImportTests.cs
@@ -15,6 +15,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data
     {
         private readonly Fixture _fixture = new Fixture();
 
+        /// <summary>
+        /// Imports emergency ID person records from sccv_persons_import to dm_persons table and adds lookup records to sccv_persons_lookup table
+        /// Must be run manually on the db server after sccv_persons_import table has been populated with the data from the service
+        /// </summary>
         private static readonly FormattableString _queryUnderTest = $@"
                    do
                     $$

--- a/SocialCareCaseViewerApi/V1/Infrastructure/DataUpdates/PersonImport.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/DataUpdates/PersonImport.cs
@@ -1,0 +1,125 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates
+{
+    [Table("sccv_persons_import", Schema = "dbo")]
+    public class PersonImport
+    {
+        [Column("person_id"), Required]
+        [MaxLength(100)]
+        [Key]
+        public string Id { get; set; }
+
+        [Column("ssda903_id")]
+        [MaxLength(10)]
+        public string SSDA903ID { get; set; }
+
+        [Column("nhs_id")]
+        [MaxLength(10)]
+        public long? NhsNumber { get; set; }
+
+        [Column("scn_id")]
+        [MaxLength(9)]
+        public long? ScnId { get; set; }
+
+        [Column("upn_id")]
+        [MaxLength(13)]
+        public string UpnId { get; set; }
+
+        [Column("former_upn_id")]
+        [MaxLength(13)]
+        public string FormerUpnId { get; set; }
+
+        [Column("full_name"), Required]
+        [MaxLength(255)]
+        public string FullName { get; set; }
+
+        [Column("title")]
+        [MaxLength(8)]
+        public string Title { get; set; }
+
+        [Column("first_name")]
+        [MaxLength(100)]
+        public string FirstName { get; set; }
+
+        [Column("last_name")]
+        [MaxLength(100)]
+        public string LastName { get; set; }
+    
+        [Column("date_of_birth")]
+        public DateTime? DateOfBirth { get; set; }
+
+        [Column("date_of_death")]
+        public DateTime? DateOfDeath { get; set; }
+
+        [Column("gender")]
+        [MaxLength(1)]
+        public string Gender { get; set; }
+
+        [Column("restricted")]
+        [MaxLength(1)]
+        public string Restricted { get; set; }
+
+        [Column("person_id_legacy")]
+        [MaxLength(16)]
+        public string PersonIdLegacy { get; set; }
+
+        [Column("full_ethnicity_code")]
+        [MaxLength(33)]
+        public string Ethnicity { get; set; }
+
+        [Column("country_of_birth_code")]
+        [MaxLength(16)]
+        public string CountryOfBirthCode { get; set; }
+
+        [Column("is_child_legacy")]
+        [MaxLength(1)]
+        public string IsChildLegacy { get; set; }
+
+        [Column("is_adult_legacy")]
+        [MaxLength(1)]
+        public string IsAdultLegacy { get; set; }
+
+        [Column("nationality")]
+        [MaxLength(80)]
+        public string Nationality { get; set; }
+
+        [Column("religion")]
+        [MaxLength(80)]
+        public string Religion { get; set; }
+
+        [Column("marital_status")]
+        [MaxLength(80)]
+        public string MaritalStatus { get; set; }
+
+        [Column("first_language")]
+        [MaxLength(100)]
+        public string FirstLanguage { get; set; }
+
+        [Column("fluency_in_english")]
+        [MaxLength(100)]
+        public string FluencyInEnglish { get; set; }
+
+        [Column("email_address")]
+        [MaxLength(240)]
+        public string EmailAddress { get; set; }
+
+        [MaxLength(1)]
+        [Column("context_flag")]
+        public string AgeContext { get; set; }
+
+        [MaxLength(13)]
+        [Column("scra_id")]
+        public string ScraId { get; set; }
+
+        [MaxLength(1)]
+        [Column("interpreter_required")]
+        public string InterpreterRequired { get; set; }
+
+        [Column("from_dm_person")]
+        [MaxLength(1)]
+        public string DataIsFromDmPersonsBackup { get; set; }
+    }
+}

--- a/SocialCareCaseViewerApi/V1/Infrastructure/DataUpdates/PersonImport.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/DataUpdates/PersonImport.cs
@@ -47,7 +47,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure.DataUpdates
         [Column("last_name")]
         [MaxLength(100)]
         public string LastName { get; set; }
-    
+
         [Column("date_of_birth")]
         public DateTime? DateOfBirth { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Infrastructure/DatabaseContext.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/DatabaseContext.cs
@@ -31,6 +31,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public DbSet<PersonRecordToBeDeleted> PersonRecordsToBeDeleted { get; set; }
         public DbSet<DeletedPersonRecord> DeletedPersonRecords { get; set; }
         public DbSet<RequestAudit> RequestAudits { get; set; }
+        public DbSet<PersonImport> PersonImport { get; set; }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<WorkerTeam>().HasKey(wt => new { wt.WorkerId, wt.TeamId });


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-647

## Describe this PR

### *What is the problem we're trying to solve*

We need to be able to import new person records with emergency ids for ASC. We also have to keep the lookup between mosaic ids and emergency ids in place, so we can identify the person by both ids.

### *What changes have we introduced*

Adds a SQL script that can be run manually on the server to import the records.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
