### PR TITLE
Fix(SCT-270): Updating a worker team should remove associations with their old teams

### DIFF
--- a/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
+++ b/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
@@ -8,8 +8,6 @@ namespace SocialCareCaseViewerApi.Tests
 {
     public class MongoDbTestContext : ISccvDbContext
     {
-        private MongoClient _mongoClient;
-        private IMongoDatabase _mongoDatabase;
         public IMongoCollection<BsonDocument> matProcessCollection { get; set; }
         public MongoDbTestContext()
         {
@@ -42,14 +40,14 @@ namespace SocialCareCaseViewerApi.Tests
                 localTrustStore.Close();
             }
 
-            string MONGO_DB_TEST_CONN_STRING = Environment.GetEnvironmentVariable("MONGO_DB_TEST_CONN_STRING") ??
+            string mongoDbTestConnString = Environment.GetEnvironmentVariable("MONGO_DB_TEST_CONN_STRING") ??
                                 @"mongodb://localhost:1433/";
 
-            _mongoClient = new MongoClient(new MongoUrl(MONGO_DB_TEST_CONN_STRING));
+            var mongoClient = new MongoClient(new MongoUrl(mongoDbTestConnString));
             //create a new blank database if database does not exist, otherwise get existing database
-            _mongoDatabase = _mongoClient.GetDatabase("social_care_db_test");
+            var mongoDatabase = mongoClient.GetDatabase("social_care_db_test");
             //create collection to hold the documents if it does not exist, otherwise retrieve existing
-            matProcessCollection = _mongoDatabase.GetCollection<BsonDocument>("form_data_test");
+            matProcessCollection = mongoDatabase.GetCollection<BsonDocument>("form_data_test");
         }
         public IMongoCollection<BsonDocument> getCollection()
         {

--- a/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
+++ b/SocialCareCaseViewerApi.Tests/MongoDbTestContext.cs
@@ -42,10 +42,10 @@ namespace SocialCareCaseViewerApi.Tests
                 localTrustStore.Close();
             }
 
-            string MONGO_CONN_STRING = Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+            string MONGO_DB_TEST_CONN_STRING = Environment.GetEnvironmentVariable("MONGO_DB_TEST_CONN_STRING") ??
                                 @"mongodb://localhost:1433/";
 
-            _mongoClient = new MongoClient(new MongoUrl(MONGO_CONN_STRING));
+            _mongoClient = new MongoClient(new MongoUrl(MONGO_DB_TEST_CONN_STRING));
             //create a new blank database if database does not exist, otherwise get existing database
             _mongoDatabase = _mongoClient.GetDatabase("social_care_db_test");
             //create collection to hold the documents if it does not exist, otherwise retrieve existing

--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/UpdateMosaicIdFormDataCollection.cs
@@ -56,7 +56,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
         public void SetUp()
         {
             string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
-                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+                                           Environment.GetEnvironmentVariable("MONGO_DB_TEST_CONN_STRING") ??
                                            @"mongodb://localhost:1433/";
 
             string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -286,7 +286,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             DatabaseContext.SaveChanges();
 
-            (var createAllocationRequest, _, var createdByWorker, var person, _) = TestHelpers.CreateAllocationRequest(workerId: worker.Id, teamId: workerTeam.TeamId);
+            var (createAllocationRequest, _, createdByWorker, person, _) = TestHelpers.CreateAllocationRequest(workerId: worker.Id, teamId: workerTeam.TeamId);
             DatabaseContext.Workers.Add(createdByWorker);
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
@@ -294,10 +294,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             _classUnderTest.CreateAllocation(createAllocationRequest);
 
             var originalWorker = _classUnderTest.GetWorkerByWorkerId(worker.Id);
-            var originalTeam = DatabaseContext.WorkerTeams.Where(x => x.WorkerId == originalWorker.Id).Single().Team;
+            var originalTeam = DatabaseContext.WorkerTeams.Single(x => x.WorkerId == originalWorker.Id).Team;
 
             originalWorker.WorkerTeams?.Count.Should().Be(1);
-            originalWorker.Allocations.Count.Should().Be(1);
+            originalWorker.Allocations?.Count.Should().Be(1);
 
             var originalAllocation = _classUnderTest.SelectAllocations(0, workerId: originalWorker.Id);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -326,8 +326,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         {
             return new Faker<Team>()
                 .RuleFor(t => t.Id, f => teamId ?? f.UniqueIndex + 1)
-                .RuleFor(t => t.Context, f => name ?? f.Random.String2(1, "AC"))
-                .RuleFor(t => t.Name, f => context ?? f.Random.String2(1, 200));
+                .RuleFor(t => t.Context, f => context ?? f.Random.String2(1, "AC"))
+                .RuleFor(t => t.Name, f => name ?? f.Random.String2(1, 200));
         }
 
         public static WarningNote CreateWarningNote(long? personId = null, string? status = null)

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -79,50 +79,5 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 DateStart = worker.DateStart
             };
         }
-
-        public static Worker UpdateWorkerWithRequest(DatabaseContext databaseContext, Worker worker, UpdateWorkerRequest request)
-        {
-            worker.LastModifiedBy = request.ModifiedBy;
-            worker.FirstName = request.FirstName;
-            worker.LastName = request.LastName;
-            worker.ContextFlag = request.ContextFlag;
-            worker.Role = request.Role;
-            worker.DateStart = request.DateStart;
-            worker.IsActive = true;
-
-            var workerTeams = GetTeams(request.Teams, databaseContext);
-
-            worker.WorkerTeams = new List<WorkerTeam>();
-            foreach (var team in workerTeams)
-            {
-                worker.WorkerTeams.Add(new WorkerTeam { Team = team, Worker = worker });
-            }
-
-            databaseContext.SaveChanges();
-
-            return worker;
-        }
-
-        public static ICollection<Team> GetTeams(List<WorkerTeamRequest> request, DatabaseContext context)
-        {
-            var teamsWorkerBelongsIn = new List<Team>();
-            foreach (var requestTeam in request)
-            {
-                var team = GetTeamByTeamId(context, requestTeam.Id);
-                teamsWorkerBelongsIn.Add(team);
-            }
-
-            return teamsWorkerBelongsIn;
-        }
-
-        public static Team GetTeamByTeamId(DatabaseContext databaseContext, int teamId)
-        {
-            return databaseContext.Teams
-                .Where(x => x.Id == teamId)
-                .Include(x => x.WorkerTeams)
-                .ThenInclude(x => x.Worker)
-                .ThenInclude(x => x.Allocations)
-                .FirstOrDefault();
-        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -10,13 +10,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 {
     public static class IntegrationTestHelpers
     {
-        public static DbPerson CreateExistingPerson(DatabaseContext context, int? personId = null, string ageContext = null, string restricted = null, string firstName = null, string lastName = null)
+        public static DbPerson CreateExistingPerson(DatabaseContext context, int? personId = null, string ageContext = null, string restricted = null)
         {
             var person = new Faker<DbPerson>()
                 .RuleFor(p => p.Id, f => personId ?? f.UniqueIndex + 1)
                 .RuleFor(p => p.Title, f => f.Name.Prefix())
-                .RuleFor(p => p.FirstName, f => firstName ?? f.Person.FirstName)
-                .RuleFor(p => p.LastName, f => lastName ?? f.Person.FirstName)
+                .RuleFor(p => p.FirstName, f => f.Person.FirstName)
+                .RuleFor(p => p.LastName, f => f.Person.FirstName)
                 .RuleFor(p => p.FullName, f => f.Person.FullName)
                 .RuleFor(p => p.DateOfBirth, f => f.Person.DateOfBirth)
                 .RuleFor(p => p.DateOfDeath, f => f.Date.Recent())
@@ -29,7 +29,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 .RuleFor(p => p.NhsNumber, f => f.Random.Number(int.MaxValue))
                 .RuleFor(p => p.PersonIdLegacy, f => f.Random.String2(16))
                 .RuleFor(p => p.AgeContext, f => ageContext ?? f.Random.String2(1, "AC"))
-                .RuleFor(p => p.DataIsFromDmPersonsBackup, f => f.Random.String2(1))
+                .RuleFor(p => p.DataIsFromDmPersonsBackup, f => f.Random.String2(1, "YN"))
                 .RuleFor(p => p.SexualOrientation, f => f.Random.String2(10))
                 .RuleFor(p => p.PreferredMethodOfContact, f => f.Random.String2(10))
                 .RuleFor(p => p.Restricted, f => restricted ?? f.Random.String2(1, "YN")).Generate();
@@ -69,12 +69,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 .RuleFor(w => w.FirstName, f => f.Person.FirstName)
                 .RuleFor(w => w.LastName, f => f.Person.LastName)
                 .RuleFor(w => w.Email, f => f.Person.Email)
-                .RuleFor(w => w.Role, f => f.Random.Word())
+                .RuleFor(w => w.Role, f => f.Name.JobTitle())
                 .RuleFor(w => w.ContextFlag, f => workerContext)
                 .RuleFor(w => w.CreatedBy, f => f.Person.Email)
                 .RuleFor(w => w.CreatedAt, f => f.Date.Soon())
                 .RuleFor(w => w.DateStart, f => f.Date.Recent())
                 .RuleFor(w => w.DateEnd, f => f.Date.Soon())
+                .RuleFor(w => w.CreatedAt, f => f.Date.Soon())
+                .RuleFor(w => w.LastModifiedAt, f => f.Date.Soon())
                 .RuleFor(w => w.IsActive, true)
                 .RuleFor(w => w.Allocations, new List<AllocationSet>())
                 .RuleFor(w => w.WorkerTeams, new List<WorkerTeam> { workerTeam })
@@ -149,7 +151,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         {
             var insertWorkerQuery = $@"insert into dbo.sccv_worker 
             (id, email, first_name, last_name, role, context_flag, created_by, date_start, date_end, last_modified_by, created_at, last_modified_at, is_active ) 
-            values ({worker.Id}, '{worker.Email}', '{worker.FirstName}', '{worker.LastName}', '{worker.Role}', '{worker.ContextFlag}', '{worker.CreatedBy}', NULL, NULL, '{worker.LastModifiedBy}', NULL, NULL, {worker.IsActive});";
+            values ({worker.Id}, '{worker.Email}', '{worker.FirstName}', '{worker.LastName}', '{worker.Role}', 
+            '{worker.ContextFlag}', '{worker.CreatedBy}', '{worker.DateStart?.ToString("s")}', '{worker.DateEnd?.ToString("s")}', 
+            '{worker.LastModifiedBy}', '{worker.CreatedAt?.ToString("s")}', '{worker.LastModifiedAt?.ToString("s")}', {worker.IsActive});";
 
             return insertWorkerQuery;
         }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -15,7 +15,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var team = new Faker<Team>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
                 .RuleFor(t => t.Context, f => workerContext)
-                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+                .RuleFor(t => t.Name, f => f.Random.String2(10, 100)).Generate();
 
             context.Teams.Add(team);
             context.SaveChanges();
@@ -55,7 +55,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var team = new Faker<Team>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
                 .RuleFor(t => t.Context, f => workerContext)
-                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+                .RuleFor(t => t.Name, f => f.Random.String2(10, 100)).Generate();
 
             context.Teams.Add(team);
             context.SaveChanges();

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -1,8 +1,5 @@
 using System.Collections.Generic;
-using System.Linq;
 using Bogus;
-using Microsoft.EntityFrameworkCore;
-using Npgsql;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 
@@ -79,83 +76,23 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
         private static string SeedWorker(Worker worker)
         {
-            // var seedCommand = new NpgsqlCommand();
-            // seedCommand.Connection = new NpgsqlConnection(ConnectionString.TestDatabase());
-            // seedCommand.Connection.Open();
-
-            // var npgsqlCommand = seedCommand.Connection.CreateCommand();
-            // npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
-            // npgsqlCommand.ExecuteNonQuery();
-
-            //             var insertWorkerQuery = @"insert into dbo.sccv_worker 
-            // (id, email, first_name, last_name, role, context_flag, created_by, date_start, date_end, last_modified_by, created_at, last_modified_at, is_active ) 
-            // values (@Id, @Email, @FirstName, @LastName, @Role, @ContextFlag, @CreatedBy, @DateStart, @DateEnd, @LastModifiedBy, @CreatedAt, @LastModifiedAt, @IsActive);";
-
-            var insertWorkerQuery = $@"insert into dbo.sccv_worker (id, email, first_name, last_name, role, context_flag, created_by, date_start, date_end, last_modified_by, created_at, last_modified_at, is_active ) values ({worker.Id}, '{worker.Email}', '{worker.FirstName}', '{worker.LastName}', '{worker.Role}', '{worker.ContextFlag}', '{worker.CreatedBy}', NULL, NULL, '{worker.LastModifiedBy}', NULL, NULL, {worker.IsActive});";
-
-
-            // seedCommand.CommandText = insertWorkerQuery;
-
-            // seedCommand.Parameters.AddWithValue("@Id", worker.Id);
-            // seedCommand.Parameters.AddWithValue("@Email", $"{worker.Email}");
-            // seedCommand.Parameters.AddWithValue("@FirstName", $"{worker.FirstName}");
-            // seedCommand.Parameters.AddWithValue("@LastName", $"{worker.LastName}");
-            // seedCommand.Parameters.AddWithValue("@Role", $"{worker.Role}");
-            // seedCommand.Parameters.AddWithValue("@ContextFlag", $"{worker.ContextFlag}");
-            // seedCommand.Parameters.AddWithValue("@CreatedBy", $"{worker.CreatedBy}");
-            // seedCommand.Parameters.AddWithValue("@DateStart", worker.DateStart);
-            // seedCommand.Parameters.AddWithValue("@DateEnd", worker.DateEnd);
-            // seedCommand.Parameters.AddWithValue("@LastModifiedBy", $"{worker.LastModifiedBy}");
-            // seedCommand.Parameters.AddWithValue("@CreatedAt", worker.CreatedAt);
-            // seedCommand.Parameters.AddWithValue("@LastModifiedAt", worker.LastModifiedAt);
-            // seedCommand.Parameters.AddWithValue("@IsActive", worker.IsActive);
+            var insertWorkerQuery = $@"insert into dbo.sccv_worker 
+            (id, email, first_name, last_name, role, context_flag, created_by, date_start, date_end, last_modified_by, created_at, last_modified_at, is_active ) 
+            values ({worker.Id}, '{worker.Email}', '{worker.FirstName}', '{worker.LastName}', '{worker.Role}', '{worker.ContextFlag}', '{worker.CreatedBy}', NULL, NULL, '{worker.LastModifiedBy}', NULL, NULL, {worker.IsActive});";
 
             return insertWorkerQuery;
         }
 
         private static string SeedTeam(Team team)
         {
-            // var seedCommand = new NpgsqlCommand();
-            // seedCommand.Connection = new NpgsqlConnection(ConnectionString.TestDatabase());
-            // seedCommand.Connection.Open();
-
-            // var npgsqlCommand = seedCommand.Connection.CreateCommand();
-            // npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
-            // npgsqlCommand.ExecuteNonQuery();
-
-            // var insertTeamQuery = "insert into dbo.sccv_team (id, name, context) values (@Id, @Name, @Context);";
-
             var insertTeamQuery = $"insert into dbo.sccv_team (id, name, context) values ({team.Id}, '{team.Name}', '{team.Context}');";
-
-
-            // seedCommand.CommandText = insertTeamQuery;
-
-            // seedCommand.Parameters.AddWithValue("@Id", team.Id);
-            // seedCommand.Parameters.AddWithValue("@Name", $"{team.Name}");
-            // seedCommand.Parameters.AddWithValue("@Context", $"{team.Context}");
 
             return insertTeamQuery;
         }
 
         private static string SeedWorkerTeam(WorkerTeam workerTeam)
         {
-            // var seedCommand = new NpgsqlCommand();
-            // seedCommand.Connection = new NpgsqlConnection(ConnectionString.TestDatabase());
-            // seedCommand.Connection.Open();
-
-            // var npgsqlCommand = seedCommand.Connection.CreateCommand();
-            // npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
-            // npgsqlCommand.ExecuteNonQuery();
-
-            // var insertWorkerTeamQuery = "insert into dbo.sccv_workerteam (id, worker_id, team_id) values (@Id, @WorkerId, @TeamId);";
-
             var insertWorkerTeamQuery = $"insert into dbo.sccv_workerteam (id, worker_id, team_id) values ({workerTeam.Id}, {workerTeam.WorkerId}, {workerTeam.TeamId});";
-
-            // seedCommand.CommandText = insertWorkerTeamQuery;
-
-            // seedCommand.Parameters.AddWithValue("@Id", workerTeam.Id);
-            // seedCommand.Parameters.AddWithValue("@WorkerId", workerTeam.WorkerId);
-            // seedCommand.Parameters.AddWithValue("@TeamId", workerTeam.TeamId);
 
             return insertWorkerTeamQuery;
         }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bogus;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using DomainWorker = SocialCareCaseViewerApi.V1.Domain.Worker;
+using DomainTeam = SocialCareCaseViewerApi.V1.Domain.Team;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
+{
+    public static class IntegrationTestHelpers
+    {
+        public static (DomainWorker,Team) SetupExistingWorker(DatabaseContext context)
+        {
+            var workerId = new Faker().Random.Int(1, 100);
+            var workerContext = new Faker().Random.String2(1, "AC");
+
+            var team = new Faker<Team>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
+                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+
+            context.Teams.Add(team);
+            context.SaveChanges();
+
+            var newTeam = new Faker<Team>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + team.Id)
+                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+
+            context.Teams.Add(newTeam);
+            context.SaveChanges();
+
+            var workerTeam = new Faker<WorkerTeam>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
+                .RuleFor(t => t.WorkerId, f => workerId )
+                .RuleFor(t => t.TeamId, f => team.Id)
+                .RuleFor(t => t.Team, team).Generate();
+
+            context.WorkerTeams.Add(workerTeam);
+            context.SaveChanges();
+
+            var worker = new Faker<Worker>().RuleFor(w => w.Id, workerId)
+                .RuleFor(w => w.FirstName, f => f.Person.FirstName)
+                .RuleFor(w => w.LastName, f => f.Person.LastName)
+                .RuleFor(w => w.Email, f => f.Person.Email)
+                .RuleFor(w => w.Role, f => f.Random.Word())
+                .RuleFor(w => w.ContextFlag, f => workerContext)
+                .RuleFor(w => w.CreatedBy, f => f.Person.Email)
+                .RuleFor(w => w.CreatedAt, f => f.Date.Soon())
+                .RuleFor(w => w.DateStart, f => f.Date.Recent())
+                .RuleFor(w => w.DateEnd, f => f.Date.Soon())
+                .RuleFor(w => w.IsActive, true)
+                .RuleFor(w => w.Allocations, new List<AllocationSet>())
+                .RuleFor(w => w.WorkerTeams, new List<WorkerTeam> { workerTeam })
+                .RuleFor(w => w.LastModifiedBy, f => f.Person.Email).Generate();
+
+            context.Workers.Add(worker);
+            context.SaveChanges();
+
+            var domainWorker = new DomainWorker
+            {
+                Id = worker.Id,
+                Email = worker.Email,
+                FirstName = worker.FirstName,
+                LastName = worker.LastName,
+                Role = worker.Role,
+                ContextFlag = worker.ContextFlag,
+                CreatedBy = worker.CreatedBy,
+                DateStart = worker.DateStart,
+                AllocationCount = worker.Allocations?.Where(x => x.CaseStatus.ToUpper() == "OPEN").Count() ?? 0,
+                Teams = (worker.WorkerTeams?.Select(x =>
+                            new DomainTeam {Id = x.Team.Id, Name = x.Team.Name, Context = x.Team.Context}).ToList()) ??
+                        new List<DomainTeam>()
+            };
+
+            return (domainWorker, newTeam);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -10,14 +10,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 {
     public static class IntegrationTestHelpers
     {
-        public static (DomainWorker,Team) SetupExistingWorker(DatabaseContext context)
+        public static (DomainWorker, Team) SetupExistingWorker(DatabaseContext context)
         {
             var workerId = new Faker().Random.Int(1, 100);
             var workerContext = new Faker().Random.String2(1, "AC");
 
             var team = new Faker<Team>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
-                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Context, f => workerContext)
                 .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
 
             context.Teams.Add(team);
@@ -25,7 +25,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
             var newTeam = new Faker<Team>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex + team.Id)
-                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Context, f => workerContext)
                 .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
 
             context.Teams.Add(newTeam);
@@ -33,7 +33,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
             var workerTeam = new Faker<WorkerTeam>()
                 .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
-                .RuleFor(t => t.WorkerId, f => workerId )
+                .RuleFor(t => t.WorkerId, f => workerId)
                 .RuleFor(t => t.TeamId, f => team.Id)
                 .RuleFor(t => t.Team, team).Generate();
 
@@ -70,7 +70,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 DateStart = worker.DateStart,
                 AllocationCount = worker.Allocations?.Where(x => x.CaseStatus.ToUpper() == "OPEN").Count() ?? 0,
                 Teams = (worker.WorkerTeams?.Select(x =>
-                            new DomainTeam {Id = x.Team.Id, Name = x.Team.Name, Context = x.Team.Context}).ToList()) ??
+                            new DomainTeam { Id = x.Team.Id, Name = x.Team.Name, Context = x.Team.Context }).ToList()) ??
                         new List<DomainTeam>()
             };
 

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -1,0 +1,57 @@
+using System.Net.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
+{
+    [NonParallelizable]
+    [TestFixture]
+    public class IntegrationTestSetup<TStartup> where TStartup : class
+    {
+        private HttpClient _client;
+        private DatabaseContext _databaseContext;
+
+        private MockWebApplicationFactory<TStartup> _factory;
+        private NpgsqlConnection _connection;
+        private IDbContextTransaction _transaction;
+        private DbContextOptionsBuilder _builder;
+
+        protected HttpClient Client => _client;
+        protected DatabaseContext DatabaseContext => _databaseContext;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _connection = new NpgsqlConnection(ConnectionString.TestDatabase());
+            _connection.Open();
+            var npgsqlCommand = _connection.CreateCommand();
+            npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
+            npgsqlCommand.ExecuteNonQuery();
+
+            _builder = new DbContextOptionsBuilder();
+            _builder.UseNpgsql(_connection);
+        }
+
+        [SetUp]
+        public void BaseSetup()
+        {
+            _factory = new MockWebApplicationFactory<TStartup>(_connection);
+            _client = _factory.CreateClient();
+            _databaseContext = new DatabaseContext(_builder.Options);
+            _databaseContext.Database.EnsureCreated();
+            _transaction = DatabaseContext.Database.BeginTransaction();
+        }
+
+        [TearDown]
+        public void BaseTearDown()
+        {
+            _client.Dispose();
+            _factory.Dispose();
+            _transaction.Rollback();
+            _transaction.Dispose();
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -48,19 +48,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void BaseSetup()
         {
-            if (Environment.GetEnvironmentVariable("CONTAINER_ENV") == "DockerTest")
-            {
-                Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", Environment.GetEnvironmentVariable("MONGO_CONN_STRING"));
-            }
-            else
+            if (Environment.GetEnvironmentVariable("CONTAINER_ENV") != "DockerTest")
             {
                 Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
             }
 
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
             Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
             Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
             Environment.SetEnvironmentVariable("SOCIAL_CARE_PLATFORM_API_URL", "https://mockBase");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
 
             _factory = new MockWebApplicationFactory<TStartup>(_connection);
             _client = _factory.CreateClient();

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -48,6 +48,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void BaseSetup()
         {
+            // Set up MongoDB connection string depending on whether the tests are run locally or in docker
+
             if (Environment.GetEnvironmentVariable("CONTAINER_ENV") != "DockerTest")
             {
                 Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -48,8 +48,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void BaseSetup()
         {
+            if (Environment.GetEnvironmentVariable("CONTAINER_ENV") == "DockerTest")
+            {
+                Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", Environment.GetEnvironmentVariable("MONGO_CONN_STRING"));
+            }
+            else
+            {
+                Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
+            }
+
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-            Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
             Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
             Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
             Environment.SetEnvironmentVariable("SOCIAL_CARE_PLATFORM_API_URL", "https://mockBase");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Net.Http;
@@ -44,6 +45,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void BaseSetup()
         {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT","Development");
+            Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
+            Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
+            Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_PLATFORM_API_URL", "https://mockBase");
+
             _factory = new MockWebApplicationFactory<TStartup>(_connection);
             _client = _factory.CreateClient();
 

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -58,8 +58,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             _mongoDbContext = new MongoDbTestContext();
 
             _transaction = _connection.BeginTransaction(IsolationLevel.RepeatableRead);
-
             _databaseContext.Database.UseTransaction(_transaction);
+            // _transaction.Commit();
+            // var whatIsTheString = _databaseContext.Database.GetDbConnection();
+
         }
 
         [TearDown]

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -58,34 +58,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             _client = _factory.CreateClient();
 
             _databaseContext = _factory.Server.Host.Services.GetRequiredService<DatabaseContext>();
-
             _databaseContext.ChangeTracker.LazyLoadingEnabled = false;
-
-            _databaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_team;");
-            _databaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_worker;");
-            _databaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_workerteam;");
-
-            _databaseContext.Database
-            .ExecuteSqlRaw("insert into dbo.sccv_worker (id, email, first_name, last_name, role, context_flag) values (91, 'bhadfield5@example.com', 'Basilio', 'Hadfield', 'non', 'C');");
-
-            _databaseContext.Database.ExecuteSqlRaw("UPDATE DBO.SCCV_WORKER SET is_active = true WHERE is_active isnull;");
-
-            _databaseContext.Database
-            .ExecuteSqlRaw("insert into dbo.sccv_team (id, name, context) values (35, 'Aenean', 'C');");
-
-            _databaseContext.Database
-            .ExecuteSqlRaw("insert into dbo.sccv_team (id, name, context) values (20, 'Tristique', 'C');");
-
-            _databaseContext.Database
-            .ExecuteSqlRaw("insert into dbo.sccv_workerteam (id, worker_id, team_id) values (29, 91, 35);");
 
             _mongoDbContext = new MongoDbTestContext();
 
             _transaction = _connection.BeginTransaction(IsolationLevel.ReadCommitted);
             _databaseContext.Database.UseTransaction(_transaction);
-            // _transaction.Commit();
-            // var whatIsTheString = _databaseContext.Database.GetDbConnection();
-
         }
 
         [TearDown]

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestSetup.cs
@@ -45,7 +45,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void BaseSetup()
         {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT","Development");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
             Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
             Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
             Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MockWebApplicationFactory.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MockWebApplicationFactory.cs
@@ -1,0 +1,38 @@
+using System.Data.Common;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
+{
+    public class MockWebApplicationFactory<TStartup>
+        : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        private readonly DbConnection _connection;
+
+        public MockWebApplicationFactory(DbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration(b => b.AddEnvironmentVariables());
+            builder.ConfigureServices(services =>
+            {
+                var dbBuilder = new DbContextOptionsBuilder();
+                dbBuilder.UseNpgsql(_connection);
+                var context = new DatabaseContext(dbBuilder.Options);
+                services.AddSingleton(context);
+
+                var serviceProvider = services.BuildServiceProvider();
+                var dbContext = serviceProvider.GetRequiredService<DatabaseContext>();
+
+                dbContext.Database.EnsureCreated();
+            });
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -4,14 +4,12 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Bogus;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
-using SocialCareCaseViewerApi.V1.Domain;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
@@ -25,69 +23,51 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [SetUp]
         public void Setup()
         {
-            (var existingDbWorker, var insertTeamQuery, var insertWorkerTeamQuery, var insertWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
-            (var differentDbTeam, var insertDifferentTeamQuery) = IntegrationTestHelpers.CreateAnotherTeam(existingDbWorker.ContextFlag);
-
+            // Clear test database of any rows in the database
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_team;");
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_worker;");
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_workerteam;");
 
+            // Create an existing worker,team and worker team and associated insert statements
+            (var existingDbWorker, var insertTeamQuery, var insertWorkerTeamQuery, var insertWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
+            (var differentDbTeam, var insertDifferentTeamQuery) = IntegrationTestHelpers.CreateAnotherTeam(existingDbWorker.ContextFlag);
+
+            // Seed fake data into the test database before running tests
             DatabaseContext.Database.ExecuteSqlRaw(insertTeamQuery);
             DatabaseContext.Database.ExecuteSqlRaw(insertDifferentTeamQuery);
-
             DatabaseContext.Database.ExecuteSqlRaw(insertWorkerTeamQuery);
             DatabaseContext.Database.ExecuteSqlRaw(insertWorkerQuery);
 
             _existingDbWorker = existingDbWorker;
             _differentDbTeam = differentDbTeam;
-
-            // DatabaseContext.Database
-            // .ExecuteSqlRaw("insert into dbo.sccv_worker (id, email, first_name, last_name, role, context_flag) values (91, 'bhadfield5@example.com', 'Basilio', 'Hadfield', 'non', 'C');");
-
-            // DatabaseContext.Database.ExecuteSqlRaw("UPDATE DBO.SCCV_WORKER SET is_active = true WHERE is_active isnull;");
-
-            // DatabaseContext.Database
-            // .ExecuteSqlRaw("insert into dbo.sccv_team (id, name, context) values (35, 'Aenean', 'C');");
-
-            // DatabaseContext.Database
-            // .ExecuteSqlRaw("insert into dbo.sccv_team (id, name, context) values (20, 'Tristique', 'C');");
-
-            // DatabaseContext.Database
-            // .ExecuteSqlRaw("insert into dbo.sccv_workerteam (id, worker_id, team_id) values (29, 91, 35);");
         }
 
 
         [Test]
         public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
         {
-            var newTeamRequest = new WorkerTeamRequest { Id = _differentDbTeam.Id, Name = _differentDbTeam.Name };
-
             // Patch request to update team
-
-            var patchRequest = IntegrationTestHelpers.CreatePatchRequest(_existingDbWorker, newTeamRequest);
-
             var patchUri = new Uri("/api/v1/workers", UriKind.Relative);
 
+            var newTeamRequest = new WorkerTeamRequest { Id = _differentDbTeam.Id, Name = _differentDbTeam.Name };
+            var patchRequest = IntegrationTestHelpers.CreatePatchRequest(_existingDbWorker, newTeamRequest);
             var serializedRequest = JsonSerializer.Serialize(patchRequest);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
 
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
             var patchWorkerResponse = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
             patchWorkerResponse.StatusCode.Should().Be(204);
 
             // Get request to check team has been updated
             var getUri = new Uri($"/api/v1/workers?email={_existingDbWorker.Email}", UriKind.Relative);
-
             var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);
             getUpdatedWorkersResponse.StatusCode.Should().Be(200);
 
             var updatedContent = await getUpdatedWorkersResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
             var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();
-
             updatedWorkerResponse.Count.Should().Be(1);
 
             // NOTE: This should fail to replicate current bug
             updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
-
             updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeamRequest.Id);
             updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeamRequest.Name);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Bogus;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
@@ -18,6 +19,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
     [TestFixture]
     public class UpdateWorkerDetails : IntegrationTestSetup<Startup>
     {
+
         [Test]
         public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
         {
@@ -42,8 +44,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
             var newTeamRequest = new WorkerTeamRequest { Id = newTeam.Id, Name = newTeam.Name };
 
-            var patchUri = new Uri("/api/v1/workers", UriKind.Relative);
             var patchRequest = IntegrationTestHelpers.CreatePatchRequest(existingWorker, newTeamRequest);
+
+            var patchUri = new Uri("/api/v1/workers", UriKind.Relative);
 
             var serializedRequest = JsonSerializer.Serialize(patchRequest);
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
@@ -60,7 +63,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();
 
             updatedWorkerResponse.Count.Should().Be(1);
+
+            // NOTE: This should fail to replicate current bug
             updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
+
             updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeam.Id);
             updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeam.Name);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -18,7 +18,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
     public class UpdateWorkerDetails : IntegrationTestSetup<Startup>
     {
         private SocialCareCaseViewerApi.V1.Infrastructure.Worker _existingDbWorker;
+        private SocialCareCaseViewerApi.V1.Infrastructure.Worker _anotherWorker;
+        private SocialCareCaseViewerApi.V1.Infrastructure.Team _existingTeam;
         private SocialCareCaseViewerApi.V1.Infrastructure.Team _differentDbTeam;
+        private SocialCareCaseViewerApi.V1.Infrastructure.Person _resident;
 
         [SetUp]
         public void Setup()
@@ -27,19 +30,37 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_team;");
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_worker;");
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.sccv_workerteam;");
+            DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.dm_persons;");
 
-            // Create an existing worker,team and worker team and associated insert statements
-            (var existingDbWorker, var insertTeamQuery, var insertWorkerTeamQuery, var insertWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
+            // Create an existing workers,teams and worker teams and associated insert statements
+            (var existingDbWorker, var existingTeam, var insertTeamQuery, var insertWorkerTeamQuery, var insertWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
+            (var anotherWorker, _, var insertAnotherTeamQuery, var insertAnotherWorkerTeamQuery, var insertAnotherWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
+
             (var differentDbTeam, var insertDifferentTeamQuery) = IntegrationTestHelpers.CreateAnotherTeam(existingDbWorker.ContextFlag);
 
+            //Create existing resident with same context as worker
+            (var resident, var insertResidentQuery) = IntegrationTestHelpers.CreateExistingPerson(ageContext: existingDbWorker.ContextFlag);
+
             // Seed fake data into the test database before running tests
-            DatabaseContext.Database.ExecuteSqlRaw(insertTeamQuery);
             DatabaseContext.Database.ExecuteSqlRaw(insertDifferentTeamQuery);
+
+            //Exisiting worker
+            DatabaseContext.Database.ExecuteSqlRaw(insertTeamQuery);
             DatabaseContext.Database.ExecuteSqlRaw(insertWorkerTeamQuery);
             DatabaseContext.Database.ExecuteSqlRaw(insertWorkerQuery);
 
+            // Another worker
+            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherTeamQuery);
+            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherWorkerTeamQuery);
+            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherWorkerQuery);
+
+            DatabaseContext.Database.ExecuteSqlRaw(insertResidentQuery);
+
             _existingDbWorker = existingDbWorker;
+            _existingTeam = existingTeam;
+            _anotherWorker = anotherWorker;
             _differentDbTeam = differentDbTeam;
+            _resident = resident;
         }
 
 
@@ -70,6 +91,35 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
             updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeamRequest.Id);
             updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeamRequest.Name);
+        }
+
+        [Test]
+        public async Task UpdateWorkerWithNewTeamUpdatesAnyAllocationsAssociated()
+        {
+            // Create Allocation request for test worker
+            var CreateAllocationUri = new Uri("/api/v1/allocations", UriKind.Relative);
+
+            var allocationRequest = IntegrationTestHelpers.CreateAllocationRequest(_resident.Id, _existingTeam.Id, _existingDbWorker.Id, _anotherWorker);
+            var serializedRequest = JsonSerializer.Serialize(allocationRequest);
+
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var allocationResponse = await Client.PostAsync(CreateAllocationUri, requestContent).ConfigureAwait(true);
+            allocationResponse.StatusCode.Should().Be(201);
+
+            // // Get request to check team has been updated
+            // var getUri = new Uri($"/api/v1/workers?email={_existingDbWorker.Email}", UriKind.Relative);
+            // var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);
+            // getUpdatedWorkersResponse.StatusCode.Should().Be(200);
+
+            // var updatedContent = await getUpdatedWorkersResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
+            // var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();
+            // updatedWorkerResponse.Count.Should().Be(1);
+
+            // // NOTE: This should fail to replicate current bug
+            // updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
+            // updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeamRequest.Id);
+            // updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeamRequest.Name);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -113,6 +113,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
             updatedAllocationResponse.Allocations.Count.Should().Be(1);
             updatedAllocationResponse.Allocations.Single().AllocatedWorkerTeam.Should().Be(newTeamRequest.Name);
+            updatedAllocationResponse.Allocations.Single().PersonId.Should().Be(_resident.Id);
+            updatedAllocationResponse.Allocations.Single().AllocatedWorker.Should().Be($"{_existingDbWorker.FirstName} {_existingDbWorker.LastName}");
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
-using SocialCareCaseViewerApi.V1.Infrastructure;
 
 namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 {
@@ -16,7 +18,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         public void SetUp()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT","Development");
-            Environment.SetEnvironmentVariable("CONNECTION_STRING", ConnectionString.TestDatabase());
             Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
             Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
             Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
@@ -26,74 +27,31 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
         [Test]
         public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
         {
-            var workerId = new Faker().Random.Int(1, 100);
-            var workerContext = new Faker().Random.String2(1, "AC");
-
-            var team = new Faker<Team>()
-                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
-                .RuleFor(t => t.Context, f => workerContext )
-                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
-
-            var newTeam = new Faker<Team>()
-                .RuleFor(t => t.Id, f => f.UniqueIndex + team.Id)
-                .RuleFor(t => t.Context, f => workerContext )
-                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
-
-            DatabaseContext.Teams.Add(team);
-            DatabaseContext.Teams.Add(newTeam);
-
-            var workerTeam = new Faker<WorkerTeam>()
-                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
-                .RuleFor(t => t.WorkerId, f => workerId )
-                .RuleFor(t => t.TeamId, f => team.Id)
-                .RuleFor(t => t.Team, team).Generate();
-
-            DatabaseContext.WorkerTeams.Add(workerTeam);
-
-            var worker = new Faker<Worker>().RuleFor(w => w.Id, workerId)
-                .RuleFor(w => w.FirstName, f => f.Person.FirstName)
-                .RuleFor(w => w.LastName, f => f.Person.LastName)
-                .RuleFor(w => w.Email, f => f.Person.Email)
-                .RuleFor(w => w.Role, f => f.Random.Word())
-                .RuleFor(w => w.ContextFlag, f => workerContext)
-                .RuleFor(w => w.CreatedBy, f => f.Person.Email)
-                .RuleFor(w => w.CreatedAt, f => f.Date.Soon())
-                .RuleFor(w => w.DateStart, f => f.Date.Recent())
-                .RuleFor(w => w.DateEnd, f => f.Date.Soon())
-                .RuleFor(w => w.IsActive, true)
-                .RuleFor(w => w.Allocations, new List<AllocationSet>())
-                .RuleFor(w => w.WorkerTeams, new List<WorkerTeam> { workerTeam })
-                .RuleFor(w => w.LastModifiedBy, f => f.Person.Email).Generate();
-
-            DatabaseContext.Workers.Add(worker);
-            await DatabaseContext.SaveChangesAsync().ConfigureAwait(true);
-
-            // var expectedResponse = E2ETestHelpers.AddPersonWithRelatedEntitiesToDb(MosaicContext, personId);
+            var (existingWorker, newTeam) = IntegrationTestHelpers.SetupExistingWorker(DatabaseContext);
 
             var patchUri = new Uri("http://localhost:5000/api/v1/workers");
             var patchRequest = new UpdateWorkerRequest
             {
-                WorkerId = worker.Id,
+                WorkerId = existingWorker.Id,
                 ModifiedBy = new Faker().Person.Email,
-                FirstName = worker.FirstName,
-                LastName = worker.LastName,
-                ContextFlag = worker.ContextFlag,
+                FirstName = existingWorker.FirstName,
+                LastName = existingWorker.LastName,
+                ContextFlag = existingWorker.ContextFlag,
                 Teams = new List<WorkerTeamRequest>
                 {
                     new WorkerTeamRequest{Id = newTeam.Id, Name = newTeam.Name}
                 },
-                Role = worker.Role,
+                Role = existingWorker.Role,
                 DateStart = new Faker().Date.Recent()
-
             };
-            // var serializedRequest = JsonConvert.SerializeObject(patchRequest);
-            // var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json-patch+json");
-            // var patchResponse = await Client.PatchAsync(patchUri,requestContent).ConfigureAwait(true);
-            // var patchResult = patchResponse.ReasonPhrase;
-            // var patchStatusCode = patchResponse.StatusCode;
-            // patchStatusCode.Should().Be(204);
 
-            var getUri = new Uri($"http://localhost:5000/api/v1/workers?id={workerId}");
+            var serializedRequest = JsonSerializer.Serialize(patchRequest);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json-patch+json");
+            var patchResponse = await Client.PatchAsync(patchUri,requestContent).ConfigureAwait(true);
+            var patchStatusCode = patchResponse.StatusCode;
+            patchStatusCode.Should().Be(204);
+
+            var getUri = new Uri($"http://localhost:5000/api/v1/workers?id={existingWorker.Id}");
             var getResponse = Client.GetAsync(getUri);
 
             var getStatusCode = getResponse.Result.StatusCode;

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -103,10 +103,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var patchWorkerResponse = await Client.PatchAsync(patchUri, patchRequestContent).ConfigureAwait(true);
             patchWorkerResponse.StatusCode.Should().Be(204);
 
-            // // Get request to check team has been updated
-            // var getUri = new Uri($"/api/v1/workers?email={_existingDbWorker.Email}", UriKind.Relative);
-            // var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);
-            // getUpdatedWorkersResponse.StatusCode.Should().Be(200);
+            // Get request to check team has been updated on the allocation
+            var getUri = new Uri($"/api/v1/allocations?mosaic_id={_resident.Id}", UriKind.Relative);
+            var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);
+            getUpdatedWorkersResponse.StatusCode.Should().Be(200);
 
             // var updatedContent = await getUpdatedWorkersResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
             // var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -18,8 +18,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
     public class UpdateWorkerDetails : IntegrationTestSetup<Startup>
     {
         private SocialCareCaseViewerApi.V1.Infrastructure.Worker _existingDbWorker;
-        private SocialCareCaseViewerApi.V1.Infrastructure.Worker _anotherWorker;
-        private SocialCareCaseViewerApi.V1.Infrastructure.Team _existingTeam;
+        private SocialCareCaseViewerApi.V1.Infrastructure.Worker _allocationWorker;
+        private SocialCareCaseViewerApi.V1.Infrastructure.Team _existingDbTeam;
         private SocialCareCaseViewerApi.V1.Infrastructure.Team _differentDbTeam;
         private SocialCareCaseViewerApi.V1.Infrastructure.Person _resident;
 
@@ -33,32 +33,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             DatabaseContext.Database.ExecuteSqlRaw("DELETE from dbo.dm_persons;");
 
             // Create an existing workers,teams and worker teams and associated insert statements
-            (var existingDbWorker, var existingTeam, var insertTeamQuery, var insertWorkerTeamQuery, var insertWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
-            (var anotherWorker, _, var insertAnotherTeamQuery, var insertAnotherWorkerTeamQuery, var insertAnotherWorkerQuery) = IntegrationTestHelpers.SetupExistingWorker();
+            (var existingDbWorker, var existingDbTeam, var existingDbWorkerTeam) = IntegrationTestHelpers.SetupExistingWorker(DatabaseContext);
+            (var allocationWorker, var allocatorTeam, var allocatorWorkerTeam) = IntegrationTestHelpers.SetupExistingWorker(DatabaseContext);
 
-            (var differentDbTeam, var insertDifferentTeamQuery) = IntegrationTestHelpers.CreateAnotherTeam(existingDbWorker.ContextFlag);
+            var differentDbTeam = IntegrationTestHelpers.CreateAnotherTeam(DatabaseContext, existingDbWorker.ContextFlag);
 
             //Create existing resident with same context as worker
-            (var resident, var insertResidentQuery) = IntegrationTestHelpers.CreateExistingPerson(ageContext: existingDbWorker.ContextFlag);
-
-            // Seed fake data into the test database before running tests
-            DatabaseContext.Database.ExecuteSqlRaw(insertDifferentTeamQuery);
-
-            //Exisiting worker
-            DatabaseContext.Database.ExecuteSqlRaw(insertTeamQuery);
-            DatabaseContext.Database.ExecuteSqlRaw(insertWorkerTeamQuery);
-            DatabaseContext.Database.ExecuteSqlRaw(insertWorkerQuery);
-
-            // Another worker
-            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherTeamQuery);
-            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherWorkerTeamQuery);
-            DatabaseContext.Database.ExecuteSqlRaw(insertAnotherWorkerQuery);
-
-            DatabaseContext.Database.ExecuteSqlRaw(insertResidentQuery);
+            var resident = IntegrationTestHelpers.CreateExistingPerson(DatabaseContext, ageContext: existingDbWorker.ContextFlag);
 
             _existingDbWorker = existingDbWorker;
-            _existingTeam = existingTeam;
-            _anotherWorker = anotherWorker;
+            _existingDbTeam = existingDbTeam;
+            _allocationWorker = allocationWorker;
             _differentDbTeam = differentDbTeam;
             _resident = resident;
         }
@@ -99,7 +84,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             // Create Allocation request for test worker
             var CreateAllocationUri = new Uri("/api/v1/allocations", UriKind.Relative);
 
-            var allocationRequest = IntegrationTestHelpers.CreateAllocationRequest(_resident.Id, _existingTeam.Id, _existingDbWorker.Id, _anotherWorker);
+            var allocationRequest = IntegrationTestHelpers.CreateAllocationRequest(_resident.Id, _existingDbTeam.Id, _existingDbWorker.Id, _allocationWorker);
             var serializedRequest = JsonSerializer.Serialize(allocationRequest);
 
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -92,6 +92,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var allocationResponse = await Client.PostAsync(CreateAllocationUri, requestContent).ConfigureAwait(true);
             allocationResponse.StatusCode.Should().Be(201);
 
+            // Patch request to update team
+            var patchUri = new Uri("/api/v1/workers", UriKind.Relative);
+
+            var newTeamRequest = new WorkerTeamRequest { Id = _differentDbTeam.Id, Name = _differentDbTeam.Name };
+            var patchRequest = IntegrationTestHelpers.CreatePatchRequest(_existingDbWorker, newTeamRequest);
+            var patchTeamSerializedRequest = JsonSerializer.Serialize(patchRequest);
+
+            var patchRequestContent = new StringContent(patchTeamSerializedRequest, Encoding.UTF8, "application/json");
+            var patchWorkerResponse = await Client.PatchAsync(patchUri, patchRequestContent).ConfigureAwait(true);
+            patchWorkerResponse.StatusCode.Should().Be(204);
+
             // // Get request to check team has been updated
             // var getUri = new Uri($"/api/v1/workers?email={_existingDbWorker.Email}", UriKind.Relative);
             // var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -60,6 +60,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();
 
             updatedWorkerResponse.Count.Should().Be(1);
+            updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
             updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeam.Id);
             updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeam.Name);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -104,18 +104,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             patchWorkerResponse.StatusCode.Should().Be(204);
 
             // Get request to check team has been updated on the allocation
-            var getUri = new Uri($"/api/v1/allocations?mosaic_id={_resident.Id}", UriKind.Relative);
-            var getUpdatedWorkersResponse = await Client.GetAsync(getUri).ConfigureAwait(true);
-            getUpdatedWorkersResponse.StatusCode.Should().Be(200);
+            var getAllocationsUri = new Uri($"/api/v1/allocations?mosaic_id={_resident.Id}", UriKind.Relative);
+            var getAllocationsResponse = await Client.GetAsync(getAllocationsUri).ConfigureAwait(true);
+            getAllocationsResponse.StatusCode.Should().Be(200);
 
-            // var updatedContent = await getUpdatedWorkersResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
-            // var updatedWorkerResponse = JsonConvert.DeserializeObject<List<WorkerResponse>>(updatedContent).ToList();
-            // updatedWorkerResponse.Count.Should().Be(1);
+            var allocationsContent = await getAllocationsResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var updatedAllocationResponse = JsonConvert.DeserializeObject<AllocationList>(allocationsContent);
 
-            // // NOTE: This should fail to replicate current bug
-            // updatedWorkerResponse.Single().Teams.Count.Should().Be(1);
-            // updatedWorkerResponse.Single().Teams.Single().Id.Should().Be(newTeamRequest.Id);
-            // updatedWorkerResponse.Single().Teams.Single().Name.Should().Be(newTeamRequest.Name);
+            updatedAllocationResponse.Allocations.Count.Should().Be(1);
+            updatedAllocationResponse.Allocations.Single().AllocatedWorkerTeam.Should().Be(newTeamRequest.Name);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -14,16 +14,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
     [TestFixture]
     public class UpdateWorkerDetails: IntegrationTestSetup<Startup>
     {
-        [SetUp]
-        public void SetUp()
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT","Development");
-            Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
-            Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
-            Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
-            Environment.SetEnvironmentVariable("SOCIAL_CARE_PLATFORM_API_URL", "https://mockBase");
-        }
-
         [Test]
         public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
         {

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bogus;
+using FluentAssertions;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
+{
+    [TestFixture]
+    public class UpdateWorkerDetails: IntegrationTestSetup<Startup>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT","Development");
+            Environment.SetEnvironmentVariable("CONNECTION_STRING", ConnectionString.TestDatabase());
+            Environment.SetEnvironmentVariable("SCCV_MONGO_CONN_STRING", "mongodb://localhost:1433/");
+            Environment.SetEnvironmentVariable("SCCV_MONGO_DB_NAME", "social_care_db_test");
+            Environment.SetEnvironmentVariable("SCCV_MONGO_COLLECTION_NAME", "form_data_test");
+            Environment.SetEnvironmentVariable("SOCIAL_CARE_PLATFORM_API_URL", "https://mockBase");
+        }
+
+        [Test]
+        public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
+        {
+            var workerId = new Faker().Random.Int(1, 100);
+            var workerContext = new Faker().Random.String2(1, "AC");
+
+            var team = new Faker<Team>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
+                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+
+            var newTeam = new Faker<Team>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + team.Id)
+                .RuleFor(t => t.Context, f => workerContext )
+                .RuleFor(t => t.Name, f => f.Name.JobType()).Generate();
+
+            DatabaseContext.Teams.Add(team);
+            DatabaseContext.Teams.Add(newTeam);
+
+            var workerTeam = new Faker<WorkerTeam>()
+                .RuleFor(t => t.Id, f => f.UniqueIndex + 1)
+                .RuleFor(t => t.WorkerId, f => workerId )
+                .RuleFor(t => t.TeamId, f => team.Id)
+                .RuleFor(t => t.Team, team).Generate();
+
+            DatabaseContext.WorkerTeams.Add(workerTeam);
+
+            var worker = new Faker<Worker>().RuleFor(w => w.Id, workerId)
+                .RuleFor(w => w.FirstName, f => f.Person.FirstName)
+                .RuleFor(w => w.LastName, f => f.Person.LastName)
+                .RuleFor(w => w.Email, f => f.Person.Email)
+                .RuleFor(w => w.Role, f => f.Random.Word())
+                .RuleFor(w => w.ContextFlag, f => workerContext)
+                .RuleFor(w => w.CreatedBy, f => f.Person.Email)
+                .RuleFor(w => w.CreatedAt, f => f.Date.Soon())
+                .RuleFor(w => w.DateStart, f => f.Date.Recent())
+                .RuleFor(w => w.DateEnd, f => f.Date.Soon())
+                .RuleFor(w => w.IsActive, true)
+                .RuleFor(w => w.Allocations, new List<AllocationSet>())
+                .RuleFor(w => w.WorkerTeams, new List<WorkerTeam> { workerTeam })
+                .RuleFor(w => w.LastModifiedBy, f => f.Person.Email).Generate();
+
+            DatabaseContext.Workers.Add(worker);
+            await DatabaseContext.SaveChangesAsync().ConfigureAwait(true);
+
+            // var expectedResponse = E2ETestHelpers.AddPersonWithRelatedEntitiesToDb(MosaicContext, personId);
+
+            var patchUri = new Uri("http://localhost:5000/api/v1/workers");
+            var patchRequest = new UpdateWorkerRequest
+            {
+                WorkerId = worker.Id,
+                ModifiedBy = new Faker().Person.Email,
+                FirstName = worker.FirstName,
+                LastName = worker.LastName,
+                ContextFlag = worker.ContextFlag,
+                Teams = new List<WorkerTeamRequest>
+                {
+                    new WorkerTeamRequest{Id = newTeam.Id, Name = newTeam.Name}
+                },
+                Role = worker.Role,
+                DateStart = new Faker().Date.Recent()
+
+            };
+            // var serializedRequest = JsonConvert.SerializeObject(patchRequest);
+            // var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json-patch+json");
+            // var patchResponse = await Client.PatchAsync(patchUri,requestContent).ConfigureAwait(true);
+            // var patchResult = patchResponse.ReasonPhrase;
+            // var patchStatusCode = patchResponse.StatusCode;
+            // patchStatusCode.Should().Be(204);
+
+            var getUri = new Uri($"http://localhost:5000/api/v1/workers?id={workerId}");
+            var getResponse = Client.GetAsync(getUri);
+
+            var getStatusCode = getResponse.Result.StatusCode;
+            getStatusCode.Should().Be(200);
+
+            // var content = response.Result.Content;
+            // var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            // var convertedResponse = JsonConvert.DeserializeObject<ResidentInformation>(stringContent);
+            //
+            // convertedResponse.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateWorkerDetails.cs
@@ -12,7 +12,7 @@ using SocialCareCaseViewerApi.V1.Boundary.Requests;
 namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 {
     [TestFixture]
-    public class UpdateWorkerDetails: IntegrationTestSetup<Startup>
+    public class UpdateWorkerDetails : IntegrationTestSetup<Startup>
     {
         [Test]
         public async Task UpdateWorkerWithNewTeamReturnsTheOnlyTheUpdatedTeam()
@@ -37,7 +37,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
 
             var serializedRequest = JsonSerializer.Serialize(patchRequest);
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json-patch+json");
-            var patchResponse = await Client.PatchAsync(patchUri,requestContent).ConfigureAwait(true);
+            var patchResponse = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
             var patchStatusCode = patchResponse.StatusCode;
             patchStatusCode.Should().Be(204);
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -548,11 +548,12 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 return;
             };
 
-            var updatedTeamId = _databaseContext.WorkerTeams.FirstOrDefault(x => x.WorkerId.Equals(worker.Id)).TeamId;
+            var updatedTeam = _databaseContext.WorkerTeams.FirstOrDefault(x => x.WorkerId.Equals(worker.Id)).Team;
 
             foreach (var allocation in allocations)
             {
-                allocation.TeamId = updatedTeamId;
+                allocation.TeamId = updatedTeam.Id;
+                allocation.Team = updatedTeam;
                 _databaseContext.SaveChanges();
             };
         }

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -543,19 +543,16 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             // Update any assigned allocations to reflect the worker's new team
             var allocations = _databaseContext.Allocations.Where(x => x.WorkerId == request.WorkerId).ToList();
 
-            if (allocations == null || !allocations.Any())
-            {
-                return;
-            };
+            if (!allocations.Any()) return;
 
-            var updatedTeam = _databaseContext.WorkerTeams.FirstOrDefault(x => x.WorkerId.Equals(worker.Id)).Team;
+            var updatedTeam = _databaseContext.WorkerTeams.FirstOrDefault(x => x.WorkerId.Equals(worker.Id))?.Team;
 
             foreach (var allocation in allocations)
             {
-                allocation.TeamId = updatedTeam.Id;
+                allocation.TeamId = updatedTeam?.Id;
                 allocation.Team = updatedTeam;
                 _databaseContext.SaveChanges();
-            };
+            }
         }
 
         private ICollection<Team> GetTeams(List<WorkerTeamRequest> request)

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -539,6 +539,22 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             }
 
             _databaseContext.SaveChanges();
+
+            //Update any assigned allocations to reflect the worker's new team
+            var allocations = _databaseContext.Allocations.Where(x => x.WorkerId == request.WorkerId).ToList();
+
+            if (allocations == null || !allocations.Any())
+            {
+                return;
+            };
+
+            var updatedTeamId = _databaseContext.WorkerTeams.FirstOrDefault(x => x.WorkerId.Equals(worker.Id)).TeamId;
+
+            foreach (var allocation in allocations)
+            {
+                allocation.TeamId = updatedTeamId;
+                _databaseContext.SaveChanges();
+            };
         }
 
         private ICollection<Team> GetTeams(List<WorkerTeamRequest> request)

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -528,6 +528,10 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             var workerTeams = GetTeams(request.Teams);
 
+            // Remove any previous associations in the worker teams table
+            _databaseContext.WorkerTeams.RemoveRange(_databaseContext.WorkerTeams.Where(x => x.WorkerId.Equals(worker.Id)));
+            _databaseContext.SaveChanges();
+
             worker.WorkerTeams = new List<WorkerTeam>();
             foreach (var team in workerTeams)
             {

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -540,7 +540,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             _databaseContext.SaveChanges();
 
-            //Update any assigned allocations to reflect the worker's new team
+            // Update any assigned allocations to reflect the worker's new team
             var allocations = _databaseContext.Allocations.Where(x => x.WorkerId == request.WorkerId).ToList();
 
             if (allocations == null || !allocations.Any())

--- a/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MongoGateway.cs
@@ -13,7 +13,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public MongoGateway()
         {
             string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
-                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+                                           Environment.GetEnvironmentVariable("MONGO_DB_TEST_CONN_STRING") ??
                                            @"mongodb://localhost:1433/";
 
             string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,8 @@ services:
       dockerfile: SocialCareCaseViewerApi.Tests/Dockerfile
     environment:
       - CONTAINER_ENV=DockerTest
-      - MONGO_CONN_STRING=mongodb://sccv-api-test-mongo-db:27017/?gssapiServiceName=mongodb
+      - MONGO_DB_TEST_CONN_STRING=mongodb://sccv-api-test-mongo-db:27017/?gssapiServiceName=mongodb
+      - SCCV_MONGO_CONN_STRING=mongodb://sccv-api-test-mongo-db:27017/?gssapiServiceName=mongodb
       - DB_HOST=sccv-api-test-postgresql
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,27 +34,27 @@ services:
     env_file:
       - database.env
 
-
   social-care-case-viewer-api-test:
     image: social-care-case-viewer-api-test
     build:
       context: .
       dockerfile: SocialCareCaseViewerApi.Tests/Dockerfile
     environment:
-            - MONGO_CONN_STRING=mongodb://sccv-api-test-mongo-db:27017/?gssapiServiceName=mongodb
-            - DB_HOST=sccv-api-test-postgresql
-            - DB_USERNAME=postgres
-            - DB_PASSWORD=mypassword
-            - DB_DATABASE=testdb
-            - DB_PORT=5432
+      - CONTAINER_ENV=DockerTest
+      - MONGO_CONN_STRING=mongodb://sccv-api-test-mongo-db:27017/?gssapiServiceName=mongodb
+      - DB_HOST=sccv-api-test-postgresql
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=mypassword
+      - DB_DATABASE=testdb
+      - DB_PORT=5432
     links:
-        - sccv-api-test-mongo-db
-        - sccv-api-test-postgresql
+      - sccv-api-test-mongo-db
+      - sccv-api-test-postgresql
 
   sccv-api-test-mongo-db:
-      image: mongo:3.6
-      ports:
-        - 1433:27017
+    image: mongo:3.6
+    ports:
+      - 1433:27017
 
   sccv-api-test-postgresql:
     image: sccv-api-test-postgresql


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/SCT-270

### *What is the problem we're trying to solve*

From a user’s perspective, the issue is that when a user’s team is updated, their associated allocations are expected to have the updated team name and not the previous team. So after updating a worker, the allocations for the worker are still referencing the old team.

i.e. Users are expecting any update of a worker’s team to reflect in the allocations associated with the worker.

However, when the worker's team does look like its updated in the UI. The team is added to the worker, so now the worker is assigned to multiple teams but the UI would grab just the first one returned in the list.

### *What changes have we introduced*

This adds an integration test to replicate the user journey of updating a worker team and expecting any worker info page and any allocations for the person to be updated with the updated team as well. 

When a worker's team is updated, all previous associated teams in the `workerteam` table are removed and only the team in the update request is added as the only team for the worker. (Previously, this would just add the new team to a list of teams for the worker but now removes all previous associations and adds the new one)

When a worker's team is updated, any allocations already assigned to that worker prior to the update, have their details updated to use the new team. (Previously, this had the previous team set on the allocation object but now, when a worker's team is updated, we update every allocation to use the new team and save the changes in the database)

This also adds new setup that should hopefully help with adding future integration tests.

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

In Staging, test that when a worker's team is updated: 
- The worker's information page displays the new team,
- The response from getting a worker, only has one team in it i.e the updated team
- Any allocations that existed prior to the change are also updated once the update occurs.