### PR TITLE
feat(SCT-961): Capture date of event from answers

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -506,9 +506,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         public void CaseSubmissionToCareCaseDataReturnsCaseFormTimeStampAsDateTimeNowIfSubmittedAtNull()
         {
             var residents = new List<Person> { TestHelpers.CreatePerson() };
-            var workers = new List<dbWorker> { TestHelpers.CreateWorker(), TestHelpers.CreateWorker() };
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
-            var submission = TestHelpers.CreateCaseSubmission(workers: workers, residents: residents, submittedAt: null);
+            var submission = TestHelpers.CreateCaseSubmission(residents: residents, submittedAt: null);
 
             var response = submission.ToCareCaseData(request);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -499,7 +499,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var response = submission.ToCareCaseData(request);
 
-            response.CaseFormTimestamp.Should().Be(submittedAt.ToString("yyyy-MM-dd"));
+            response.CaseFormTimestamp.Should().Be("2021-07-20");
         }
 
         [Test]
@@ -515,8 +515,31 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             response.CaseFormTimestamp.Should().Be(DateTime.Now.ToString("yyyy-MM-dd"));
         }
 
-        // need a datetime provider class
-        // date of event uses dateofevent property if not null otherwise uses created at
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsDateOfEventIfNotNull()
+        {
+            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var dateOfEvent = new DateTime(2021, 07, 19, 14, 40, 30);
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(dateOfEvent: dateOfEvent, residents: residents);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.DateOfEvent.Should().Be("2021-07-19");
+        }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsDateOfEventAsCreatedAtIfDateOfEventNull()
+        {
+            var createdAt = new DateTime(2021, 07, 18, 14, 40, 30);
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(residents: residents, dateOfEvent: null, createdAt: createdAt);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.DateOfEvent.Should().Be("2021-07-18");
+        }
     }
 }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -465,7 +465,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void CaseSubmissionToCareCaseDataReturnsAssociatedResidentInformation()
         {
-            var residents = new List<Person> {TestHelpers.CreatePerson(), TestHelpers.CreatePerson()};
+            var residents = new List<Person> { TestHelpers.CreatePerson(), TestHelpers.CreatePerson() };
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
             var submission = TestHelpers.CreateCaseSubmission(residents: residents);
 
@@ -479,7 +479,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void CaseSubmissionToCareCaseDataReturnsOfficeEmailOfFirstWorkerAssociatedWithCaseSubmission()
         {
-            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
             var workers = new List<dbWorker> { TestHelpers.CreateWorker(), TestHelpers.CreateWorker() };
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
             var submission = TestHelpers.CreateCaseSubmission(workers: workers, residents: residents);
@@ -492,7 +492,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void CaseSubmissionToCareCaseDataReturnsCaseFormTimeStampFromSubmittedAtIfNotNull()
         {
-            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
             var submittedAt = new DateTime(2021, 07, 20, 14, 40, 30);
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
             var submission = TestHelpers.CreateCaseSubmission(submittedAt: submittedAt, residents: residents);
@@ -518,7 +518,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         [Test]
         public void CaseSubmissionToCareCaseDataReturnsDateOfEventIfNotNull()
         {
-            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
             var dateOfEvent = new DateTime(2021, 07, 19, 14, 40, 30);
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
             var submission = TestHelpers.CreateCaseSubmission(dateOfEvent: dateOfEvent, residents: residents);

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -380,7 +379,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var infrastructurePhoneNumber = new dbPhoneNumber()
             {
-                Number = phoneNumber.ToString(),
+                Number = phoneNumber,
                 PersonId = personId,
                 Type = phoneNumberType,
                 CreatedBy = createdBy
@@ -467,21 +466,56 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         public void CaseSubmissionToCareCaseDataReturnsAssociatedResidentInformation()
         {
             var residents = new List<Person> {TestHelpers.CreatePerson(), TestHelpers.CreatePerson()};
-            var worker = TestHelpers.CreateWorker();
             var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
-            var submission = TestHelpers.CreateCaseSubmission(worker: worker, residents: residents);
+            var submission = TestHelpers.CreateCaseSubmission(residents: residents);
 
             var response = submission.ToCareCaseData(request);
 
             response.PersonId.Should().Be(residents[0].Id);
             response.FirstName.Should().Be(residents[0].FirstName);
             response.LastName.Should().Be(residents[0].LastName);
-
-            // it returns the resident associated with the request
         }
 
-        // it only returns the email for the first worker associated with the case submission
-        // caseformtimestamp uses submittedAt if not null otherwise uses now
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsOfficeEmailOfFirstWorkerAssociatedWithCaseSubmission()
+        {
+            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var workers = new List<dbWorker> { TestHelpers.CreateWorker(), TestHelpers.CreateWorker() };
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(workers: workers, residents: residents);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.OfficerEmail.Should().Be(workers[0].Email);
+        }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsCaseFormTimeStampFromSubmittedAtIfNotNull()
+        {
+            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var submittedAt = new DateTime(2021, 07, 20, 14, 40, 30);
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(submittedAt: submittedAt, residents: residents);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.CaseFormTimestamp.Should().Be(submittedAt.ToString("yyyy-MM-dd"));
+        }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsCaseFormTimeStampAsDateTimeNowIfSubmittedAtNull()
+        {
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
+            var workers = new List<dbWorker> { TestHelpers.CreateWorker(), TestHelpers.CreateWorker() };
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(workers: workers, residents: residents, submittedAt: null);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.CaseFormTimestamp.Should().Be(DateTime.Now.ToString("yyyy-MM-dd"));
+        }
+
+        // need a datetime provider class
         // date of event uses dateofevent property if not null otherwise uses created at
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -524,7 +524,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var response = submission.ToCareCaseData(request);
 
-            response.DateOfEvent.Should().Be("2021-07-19");
+            response.DateOfEvent.Should().Be("2021-07-19T14:40:30");
         }
 
         [Test]
@@ -537,7 +537,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             var response = submission.ToCareCaseData(request);
 
-            response.DateOfEvent.Should().Be("2021-07-18");
+            response.DateOfEvent.Should().Be("2021-07-18T14:40:30");
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -24,6 +25,7 @@ using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
 using DomainCaseSubmission = SocialCareCaseViewerApi.V1.Domain.CaseSubmission;
+using Person = SocialCareCaseViewerApi.V1.Infrastructure.Person;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Factories
 {
@@ -460,6 +462,27 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
 
             (DateTime.TryParseExact(timestamp, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date)).Should().BeTrue();
         }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsAssociatedResidentInformation()
+        {
+            var residents = new List<Person> {TestHelpers.CreatePerson(), TestHelpers.CreatePerson()};
+            var worker = TestHelpers.CreateWorker();
+            var request = TestHelpers.CreateListCasesRequest(residents[0].Id);
+            var submission = TestHelpers.CreateCaseSubmission(worker: worker, residents: residents);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.PersonId.Should().Be(residents[0].Id);
+            response.FirstName.Should().Be(residents[0].FirstName);
+            response.LastName.Should().Be(residents[0].LastName);
+
+            // it returns the resident associated with the request
+        }
+
+        // it only returns the email for the first worker associated with the case submission
+        // caseformtimestamp uses submittedAt if not null otherwise uses now
+        // date of event uses dateofevent property if not null otherwise uses created at
     }
 }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -477,7 +477,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             int? residentId = null,
             ObjectId? id = null,
             string? formId = null,
-            List<string>? tags = null)
+            DateTime? dateOfEvent = null)
         {
             worker ??= CreateWorker();
             resident ??= CreatePerson(residentId);
@@ -496,7 +496,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                     })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
                 .RuleFor(s => s.FormAnswers, new Dictionary<string, string>())
-                .RuleFor(s => s.Tags, tags);
+                .RuleFor(s => s.DateOfEvent, dateOfEvent);
         }
 
         public static ListCasesRequest CreateListCasesRequest(bool nullMosaicId = false)
@@ -509,16 +509,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? updatedBy = null,
             string? submissionState = null,
             List<long>? residents = null,
-            string? rejectionReason = null,
-            List<string>? tags = null
+            string? rejectionReason = null
         )
         {
             return new Faker<UpdateCaseSubmissionRequest>()
                 .RuleFor(s => s.EditedBy, f => updatedBy ?? f.Person.Email)
                 .RuleFor(s => s.SubmissionState, submissionState)
                 .RuleFor(s => s.Residents, residents)
-                .RuleFor(s => s.RejectionReason, rejectionReason)
-                .RuleFor(s => s.Tags, tags);
+                .RuleFor(s => s.RejectionReason, rejectionReason);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
-using Bogus.DataSets;
 using MongoDB.Bson;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -477,19 +476,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         public static CaseSubmission CreateCaseSubmission(SubmissionState? submissionState = null,
             DateTime? dateTime = null,
             Worker? worker = null,
-            InfrastructurePerson? resident = null,
+            List<InfrastructurePerson>? residents = null,
             int? residentId = null,
             ObjectId? id = null,
             string? formId = null,
             DateTime? dateOfEvent = null)
         {
             worker ??= CreateWorker();
-            resident ??= CreatePerson(residentId);
+            residents ??= new List<InfrastructurePerson> {CreatePerson(residentId)};
 
             return new Faker<CaseSubmission>()
                 .RuleFor(s => s.SubmissionId, f => id ?? ObjectId.Parse(f.Random.String2(24, "0123456789abcdef")))
                 .RuleFor(s => s.FormId, f => formId ?? f.Random.String2(20))
-                .RuleFor(s => s.Residents, new List<InfrastructurePerson> { resident })
+                .RuleFor(s => s.Residents, residents)
                 .RuleFor(s => s.Workers, new List<Worker> { worker })
                 .RuleFor(s => s.CreatedAt, f => dateTime ?? f.Date.Recent())
                 .RuleFor(s => s.CreatedBy, worker)
@@ -503,10 +502,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.DateOfEvent, dateOfEvent);
         }
 
-        public static ListCasesRequest CreateListCasesRequest(bool nullMosaicId = false)
+        public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null)
         {
             return new Faker<ListCasesRequest>()
-                .RuleFor(r => r.MosaicId, f => nullMosaicId ? null : f.Random.Long(0, 100000).ToString());
+                .RuleFor(r => r.MosaicId, f => mosaicId?.ToString() ?? f.Random.Long(0, 100000).ToString());
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -475,31 +475,33 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
         public static CaseSubmission CreateCaseSubmission(SubmissionState? submissionState = null,
             DateTime? dateTime = null,
-            Worker? worker = null,
+            List<Worker>? workers = null,
             List<InfrastructurePerson>? residents = null,
             int? residentId = null,
             ObjectId? id = null,
             string? formId = null,
-            DateTime? dateOfEvent = null)
+            DateTime? dateOfEvent = null,
+            DateTime? submittedAt = null)
         {
-            worker ??= CreateWorker();
+            workers ??= new List<Worker> {CreateWorker()};
             residents ??= new List<InfrastructurePerson> {CreatePerson(residentId)};
 
             return new Faker<CaseSubmission>()
                 .RuleFor(s => s.SubmissionId, f => id ?? ObjectId.Parse(f.Random.String2(24, "0123456789abcdef")))
                 .RuleFor(s => s.FormId, f => formId ?? f.Random.String2(20))
                 .RuleFor(s => s.Residents, residents)
-                .RuleFor(s => s.Workers, new List<Worker> { worker })
+                .RuleFor(s => s.Workers, workers)
                 .RuleFor(s => s.CreatedAt, f => dateTime ?? f.Date.Recent())
-                .RuleFor(s => s.CreatedBy, worker)
+                .RuleFor(s => s.CreatedBy, workers[0])
                 .RuleFor(s => s.EditHistory,
                     f => new List<EditHistory<Worker>>
                     {
-                        new EditHistory<Worker> {Worker = worker, EditTime = dateTime ?? f.Date.Recent()}
+                        new EditHistory<Worker> {Worker = workers[0], EditTime = dateTime ?? f.Date.Recent()}
                     })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
                 .RuleFor(s => s.FormAnswers, new Dictionary<string, string>())
-                .RuleFor(s => s.DateOfEvent, dateOfEvent);
+                .RuleFor(s => s.DateOfEvent, dateOfEvent)
+                .RuleFor(s => s.SubmittedAt, submittedAt);
         }
 
         public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
+using Bogus.DataSets;
 using MongoDB.Bson;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -461,13 +462,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.CreatedBy, f => createdBy ?? f.Person.Email);
         }
 
-        public static UpdateFormSubmissionAnswersRequest CreateUpdateFormSubmissionAnswersRequest(string? editedBy = null, string? stepAnswers = null)
+        public static UpdateFormSubmissionAnswersRequest CreateUpdateFormSubmissionAnswersRequest(string? editedBy = null,
+            string? stepAnswers = null,
+            DateTime? dateOfEvent = null)
         {
             stepAnswers ??= "{\"1\":\"one\"}";
 
             return new Faker<UpdateFormSubmissionAnswersRequest>()
                 .RuleFor(u => u.EditedBy, f => editedBy ?? f.Person.Email)
-                .RuleFor(u => u.StepAnswers, stepAnswers);
+                .RuleFor(u => u.StepAnswers, stepAnswers)
+                .RuleFor(u => u.DateOfEvent, dateOfEvent);
         }
 
         public static CaseSubmission CreateCaseSubmission(SubmissionState? submissionState = null,

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -474,7 +474,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         }
 
         public static CaseSubmission CreateCaseSubmission(SubmissionState? submissionState = null,
-            DateTime? dateTime = null,
+            DateTime? createdAt = null,
             List<Worker>? workers = null,
             List<InfrastructurePerson>? residents = null,
             int? residentId = null,
@@ -491,12 +491,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.FormId, f => formId ?? f.Random.String2(20))
                 .RuleFor(s => s.Residents, residents)
                 .RuleFor(s => s.Workers, workers)
-                .RuleFor(s => s.CreatedAt, f => dateTime ?? f.Date.Recent())
+                .RuleFor(s => s.CreatedAt, f => createdAt ?? f.Date.Recent())
                 .RuleFor(s => s.CreatedBy, workers[0])
                 .RuleFor(s => s.EditHistory,
                     f => new List<EditHistory<Worker>>
                     {
-                        new EditHistory<Worker> {Worker = workers[0], EditTime = dateTime ?? f.Date.Recent()}
+                        new EditHistory<Worker> {Worker = workers[0], EditTime = createdAt ?? f.Date.Recent()}
                     })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
                 .RuleFor(s => s.FormAnswers, new Dictionary<string, string>())

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -483,8 +483,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             DateTime? dateOfEvent = null,
             DateTime? submittedAt = null)
         {
-            workers ??= new List<Worker> {CreateWorker()};
-            residents ??= new List<InfrastructurePerson> {CreatePerson(residentId)};
+            workers ??= new List<Worker> { CreateWorker() };
+            residents ??= new List<InfrastructurePerson> { CreatePerson(residentId) };
 
             return new Faker<CaseSubmission>()
                 .RuleFor(s => s.SubmissionId, f => id ?? ObjectId.Parse(f.Random.String2(24, "0123456789abcdef")))

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -592,27 +592,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void ExecuteUpdateSubmissionUpdatesSubmissionsTagsIfTheRequestIncludesTags()
-        {
-            var tags = new List<string> { "tag one", "tag two" };
-
-            var resident = TestHelpers.CreatePerson();
-            var request = TestHelpers.UpdateCaseSubmissionRequest(tags: tags);
-            var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress);
-            var worker = TestHelpers.CreateWorker();
-
-            _mockDatabaseGateway.Setup(x => x.GetPersonDetailsById(resident.Id)).Returns(resident);
-            _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(worker);
-            _mockMongoGateway.Setup(x => x.LoadRecordById<CaseSubmission>(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()))).Returns(createdSubmission);
-
-            var response = _formSubmissionsUseCase.ExecuteUpdateSubmission(createdSubmission.SubmissionId.ToString(), request);
-
-            _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, ObjectId.Parse(createdSubmission.SubmissionId.ToString()), createdSubmission), Times.Once);
-            response.Should().BeEquivalentTo(createdSubmission.ToDomain().ToResponse());
-            response.Tags.Should().BeEquivalentTo(tags);
-        }
-
-        [Test]
         public void ExecuteUpdateSubmissionToApprovedThrowsUpdateSubmissionExceptionIfApproverIsAlsoWorkerOnTheSubmission()
         {
             var resident = TestHelpers.CreatePerson();

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -47,8 +47,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExecutePostSuccessfully()
         {
             var request = TestHelpers.CreateCaseSubmissionRequest();
-            var workers = new List<Worker> {TestHelpers.CreateWorker()};
-            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var workers = new List<Worker> { TestHelpers.CreateWorker() };
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
 
             _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.CreatedBy)).Returns(workers[0]);
             _mockDatabaseGateway.Setup(x => x.GetPersonDetailsById(request.ResidentId)).Returns(residents[0]);
@@ -367,7 +367,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void ExecuteUpdateSubmissionDoesNotChangeResidentsIfNoListIsPassed()
         {
-            var residents = new List<Person> {TestHelpers.CreatePerson()};
+            var residents = new List<Person> { TestHelpers.CreatePerson() };
             var request = TestHelpers.UpdateCaseSubmissionRequest();
             var createdSubmission = TestHelpers.CreateCaseSubmission(residents: residents);
             var worker = TestHelpers.CreateWorker();
@@ -537,7 +537,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void UpdateAnswersSetsTheWorkersTeamsAndAllocationsToNull()
         {
             var request = TestHelpers.CreateUpdateFormSubmissionAnswersRequest();
-            var workers = new List<Worker> {TestHelpers.CreateWorker()};
+            var workers = new List<Worker> { TestHelpers.CreateWorker() };
             var createdSubmission = TestHelpers.CreateCaseSubmission(SubmissionState.InProgress, null, workers);
             const string stepId = "1";
             _mockDatabaseGateway.Setup(x => x.GetWorkerByEmail(request.EditedBy)).Returns(workers[0]);
@@ -615,7 +615,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         public void ExecuteUpdateSubmissionToApprovedThrowsUpdateSubmissionExceptionIfApproverIsAlsoWorkerOnTheSubmission()
         {
             var resident = TestHelpers.CreatePerson();
-            var workers = new List<Worker>() {TestHelpers.CreateWorker()};
+            var workers = new List<Worker>() { TestHelpers.CreateWorker() };
             var request = TestHelpers.UpdateCaseSubmissionRequest(updatedBy: workers[0].Email, submissionState: "approved");
             var createdSubmission = TestHelpers.CreateCaseSubmission(workers: workers, submissionState: SubmissionState.Submitted);
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseSubmissionRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseSubmissionRequest.cs
@@ -18,9 +18,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [JsonPropertyName("rejectionReason")]
         public string? RejectionReason { get; set; }
-
-        [JsonPropertyName("tags")]
-        public List<string>? Tags { get; set; }
     }
 
     public class UpdateCaseSubmissionRequestValidator : AbstractValidator<UpdateCaseSubmissionRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateFormSubmissionAnswersRequest.cs
@@ -15,12 +15,10 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromBody]
         [JsonPropertyName("stepAnswers")]
-        public string
-        StepAnswers
-        { get; set; } = null!;
+        public string StepAnswers { get; set; } = null!;
 
-        [JsonPropertyName("tags")]
-        public List<string>? Tags { get; set; }
+        [JsonPropertyName("dateOfEvent")]
+        public DateTime? DateOfEvent { get; set; }
     }
 
     public class UpdateFormSubmissionAnswersValidator : AbstractValidator<UpdateFormSubmissionAnswersRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -12,6 +12,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public string FormId { get; set; } = null!;
         public WorkerResponse CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public DateTime? DateOfEvent { get; set; }
         public WorkerResponse? SubmittedBy { get; set; }
         public DateTime? SubmittedAt { get; set; }
         public WorkerResponse? ApprovedBy { get; set; }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -24,7 +24,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<WorkerResponse> Workers { get; set; } = null!;
         public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
         public string SubmissionState { get; set; } = null!;
-        public List<string>? Tags { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/FormSubmissionController.cs
@@ -78,11 +78,6 @@ namespace SocialCareCaseViewerApi.V1.Controllers
             {
                 var createdSubmission = _formSubmissionsUseCase.ExecutePost(request).Item1;
 
-                if (createdSubmission.SubmissionId == null)
-                {
-                    return StatusCode(500, "Case submission created with a null submission ID");
-                }
-
                 return CreatedAtAction(nameof(CreateSubmission), createdSubmission);
             }
             catch (WorkerNotFoundException e)

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -24,7 +24,6 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<Worker> Workers { get; set; } = null!;
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public string SubmissionState { get; set; } = null!;
-        public List<string>? Tags { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -12,6 +12,7 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string FormId { get; set; } = null!;
         public Worker CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public DateTime? DateOfEvent { get; set; }
         public Worker? SubmittedBy { get; set; }
         public DateTime? SubmittedAt { get; set; }
         public Worker? ApprovedBy { get; set; }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -196,7 +196,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CaseFormTimestamp = caseSubmission.SubmittedAt?.ToString("yyyy-MM-dd") ?? DateTime.Now.ToString("yyyy-MM-dd"),
                 FormName = caseSubmission.FormId,
                 DateOfBirth = resident.DateOfBirth?.ToString("dd/MM/yyyy"),
-                DateOfEvent = caseSubmission.CreatedAt.ToString("yyyy-MM-dd"),
+                DateOfEvent = caseSubmission.DateOfEvent?.ToString("yyyy-MM-dd") ?? caseSubmission.CreatedAt.ToString("yyyy-MM-dd"),
                 CaseFormUrl = caseSubmission.SubmissionId.ToString()
             };
         }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -196,7 +196,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 CaseFormTimestamp = caseSubmission.SubmittedAt?.ToString("yyyy-MM-dd") ?? DateTime.Now.ToString("yyyy-MM-dd"),
                 FormName = caseSubmission.FormId,
                 DateOfBirth = resident.DateOfBirth?.ToString("dd/MM/yyyy"),
-                DateOfEvent = caseSubmission.DateOfEvent?.ToString("yyyy-MM-dd") ?? caseSubmission.CreatedAt.ToString("yyyy-MM-dd"),
+                DateOfEvent = caseSubmission.DateOfEvent?.ToString("s") ?? caseSubmission.CreatedAt.ToString("s"),
                 CaseFormUrl = caseSubmission.SubmissionId.ToString()
             };
         }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -152,7 +152,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 { SubmissionState.Submitted, "Submitted" },
                 { SubmissionState.Approved, "Approved" },
                 { SubmissionState.Discarded, "Discarded" },
-                {SubmissionState.PanelApproved, "Panel Approved"}
+                { SubmissionState.PanelApproved, "Panel Approved" }
             };
 
             return new Domain.CaseSubmission
@@ -162,6 +162,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Residents = caseSubmission.Residents,
                 Workers = caseSubmission.Workers.Select(w => w.ToDomain(false)).ToList(),
                 CreatedAt = caseSubmission.CreatedAt,
+                DateOfEvent = caseSubmission.DateOfEvent,
                 CreatedBy = caseSubmission.CreatedBy.ToDomain(false),
                 SubmittedAt = caseSubmission.SubmittedAt,
                 SubmittedBy = caseSubmission.SubmittedBy?.ToDomain(false),
@@ -176,7 +177,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     Worker = e.Worker.ToDomain(false)
                 }).ToList(),
                 SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
-                Tags = caseSubmission.Tags,
                 FormAnswers = caseSubmission.FormAnswers
             };
         }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -226,6 +226,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Residents = caseSubmission.Residents,
                 Workers = caseSubmission.Workers.Select(w => w.ToResponse()).ToList(),
                 CreatedAt = caseSubmission.CreatedAt,
+                DateOfEvent = caseSubmission.DateOfEvent,
                 CreatedBy = caseSubmission.CreatedBy.ToResponse(),
                 SubmittedAt = caseSubmission.SubmittedAt,
                 SubmittedBy = caseSubmission.SubmittedBy?.ToResponse(),

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -241,7 +241,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
                     Worker = e.Worker.ToResponse()
                 }).ToList(),
                 SubmissionState = caseSubmission.SubmissionState,
-                Tags = caseSubmission.Tags,
                 FormAnswers = caseSubmission.FormAnswers
             };
         }

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseSubmission.cs
@@ -18,6 +18,7 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public string FormId { get; set; } = null!;
         public Worker CreatedBy { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
+        public DateTime? DateOfEvent { get; set; }
         public Worker? SubmittedBy { get; set; }
         public DateTime? SubmittedAt { get; set; }
         public Worker? ApprovedBy { get; set; }
@@ -29,8 +30,6 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         public List<Worker> Workers { get; set; } = null!;
         public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
         public SubmissionState SubmissionState { get; set; }
-
-        public List<string>? Tags { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -79,7 +79,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             UpdateSubmissionState(updatedSubmission, request, worker);
             UpdateResidents(updatedSubmission, request);
-            UpdateTags(updatedSubmission, request.Tags);
 
             updatedSubmission.EditHistory.Add(new EditHistory<Worker> { Worker = worker, EditTime = DateTime.Now });
 
@@ -108,7 +107,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 Worker = worker,
                 EditTime = DateTime.Now
             });
-            UpdateTags(submission, request.Tags);
+            UpdateDateOfEvent(submission, request.DateOfEvent);
             _mongoGateway.UpsertRecord(_collectionName, ObjectId.Parse(submissionId), submission);
             return submission.ToDomain().ToResponse();
         }
@@ -218,11 +217,11 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             caseSubmission.Residents = newResident;
         }
 
-        private static void UpdateTags(CaseSubmission caseSubmission, List<string>? tags)
+        private static void UpdateDateOfEvent(CaseSubmission caseSubmission, DateTime? dateOfEvent)
         {
-            if (tags == null) return;
+            if (dateOfEvent == null) return;
 
-            caseSubmission.Tags = tags;
+            caseSubmission.DateOfEvent = dateOfEvent;
         }
 
         private Worker GetSanitisedWorker(string workerEmail)


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-961)

## Describe this PR

### *What is the problem we're trying to solve*

Some of our forms ask the user for the date of event, we should be capturing this value.
This will allow us to store forms against a resident from the date of event instead of when the form was created.

### *What changes have we introduced*

Added a new property DateOfEvent to our CaseSubmission.
Capture DateOfEvent from controller.
In usecase if DateOfEvent provided with answers then update the CaseSubmission DateOfEvent property.
Updated CaseSubmission to ToCareCaseData to utilise the new DateOfEvent property if it exists.
Remove references to tags, this is a property our forms no longer use.
Tested.


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Do the frontend piece of work to make sure the DateOfEvent is sent in the request with the answers.
