### PR TITLE
Disable marked for deletion support for now

### DIFF
--- a/MongoDBImport/FormRecord.cs
+++ b/MongoDBImport/FormRecord.cs
@@ -53,8 +53,8 @@ namespace MongoDBImport
         [BsonElement("date_of_event")]
         public string DateOfEvent { get; set; }
 
-        [Name("marked_for_deletion")]
-        [BsonElement("marked_for_deletion")]
-        public string MarkedForDeletion { get; set; }
+        //[Name("marked_for_deletion")]
+        //[BsonElement("marked_for_deletion")]
+        //public string MarkedForDeletion { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/MongoDBImportTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/MongoDB/MongoDBImportTests.cs
@@ -1,112 +1,112 @@
-using AutoFixture;
-using FluentAssertions;
-using MongoDB.Bson;
-using MongoDB.Driver;
-using NUnit.Framework;
-using System;
-using System.Linq;
+//using AutoFixture;
+//using FluentAssertions;
+//using MongoDB.Bson;
+//using MongoDB.Driver;
+//using NUnit.Framework;
+//using System;
+//using System.Linq;
 
-#nullable enable
-namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
-{
-    [TestFixture]
-    public class MongoDBImportTests
-    {
-        private readonly Fixture _fixture = new Fixture();
-        private const string MainFormCollection = "form_data";
-        private IMongoDatabase? _mongoDatabase;
+//#nullable enable
+//namespace SocialCareCaseViewerApi.Tests.V1.Data.MongoDB
+//{
+//    [TestFixture]
+//    public class MongoDBImportTests
+//    {
+//        private readonly Fixture _fixture = new Fixture();
+//        private const string MainFormCollection = "form_data";
+//        private IMongoDatabase? _mongoDatabase;
 
-        private static readonly JsonCommand<BsonDocument> _dbCommandUnderTest = new JsonCommand<BsonDocument>(
-                @"{
-                    delete: ""form_data"",
-                    deletes:
-                        [
-                            {
-                                q: { MarkedForDeletion: ""true"" }, limit: 0
-                            }
-                        ]
-                }");
+//        private static readonly JsonCommand<BsonDocument> _dbCommandUnderTest = new JsonCommand<BsonDocument>(
+//                @"{
+//                    delete: ""form_data"",
+//                    deletes:
+//                        [
+//                            {
+//                                q: { MarkedForDeletion: ""true"" }, limit: 0
+//                            }
+//                        ]
+//                }");
 
-        /// <summary>
-        ///  This script deletes all documents marked for deletion from form_data collection. Limit: 0 means all matching records will be deleted 
-        /// </summary>
-        /// <howto>
-        /// To run this script manually on the server:
-        /// - pass it to the db.runCommand() like this:
-        ///
-        /// db.runCommand({
-        /// delete: ""form_data"",
-        ///            deletes:
-        ///                [
-        ///                    {
-        ///                        q: { MarkedForDeletion: ""true"" }, limit: 0
-        ///                    }
-        ///                ]
-        ///        });
-        /// </howto>     
+//        /// <summary>
+//        ///  This script deletes all documents marked for deletion from form_data collection. Limit: 0 means all matching records will be deleted 
+//        /// </summary>
+//        /// <howto>
+//        /// To run this script manually on the server:
+//        /// - pass it to the db.runCommand() like this:
+//        ///
+//        /// db.runCommand({
+//        /// delete: ""form_data"",
+//        ///            deletes:
+//        ///                [
+//        ///                    {
+//        ///                        q: { MarkedForDeletion: ""true"" }, limit: 0
+//        ///                    }
+//        ///                ]
+//        ///        });
+//        /// </howto>     
 
 
-        [SetUp]
-        public void SetUp()
-        {
-            string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
-                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
-                                           @"mongodb://localhost:1433/";
+//        [SetUp]
+//        public void SetUp()
+//        {
+//            string mongoConnectionString = Environment.GetEnvironmentVariable("SCCV_MONGO_CONN_STRING") ??
+//                                           Environment.GetEnvironmentVariable("MONGO_CONN_STRING") ??
+//                                           @"mongodb://localhost:1433/";
 
-            string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";
+//            string databaseName = Environment.GetEnvironmentVariable("SCCV_MONGO_DB_NAME") ?? "social_care_db_name";
 
-            var mongoClient = new MongoClient(new MongoUrl(mongoConnectionString));
-            _mongoDatabase = mongoClient.GetDatabase(databaseName);
-        }
+//            var mongoClient = new MongoClient(new MongoUrl(mongoConnectionString));
+//            _mongoDatabase = mongoClient.GetDatabase(databaseName);
+//        }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _mongoDatabase?.DropCollection(MainFormCollection);
-        }
+//        [TearDown]
+//        public void TearDown()
+//        {
+//            _mongoDatabase?.DropCollection(MainFormCollection);
+//        }
 
-        [Test]
-        public void DeletesRecordsMarkedForDeletion()
-        {
-            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "true").Create();
+//        [Test]
+//        public void DeletesRecordsMarkedForDeletion()
+//        {
+//            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "true").Create();
 
-            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
+//            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
 
-            collection?.InsertOne(casenoteOne);
+//            collection?.InsertOne(casenoteOne);
 
-            //verify filter
-            var filterByMarkedForDeletionFlag = Builders<MongoDBTestObject>.Filter.Eq("MarkedForDeletion", "true");
-            var originalMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
-            originalMatchingRecords.Count.Should().Be(1);
+//            //verify filter
+//            var filterByMarkedForDeletionFlag = Builders<MongoDBTestObject>.Filter.Eq("MarkedForDeletion", "true");
+//            var originalMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
+//            originalMatchingRecords.Count.Should().Be(1);
 
-            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
+//            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
 
-            var newMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
-            newMatchingRecords.Count.Should().Be(0);
-        }
+//            var newMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
+//            newMatchingRecords.Count.Should().Be(0);
+//        }
 
-        [Test]
-        public void DoesNotDeleteRecordsNotMarkedForDeletion()
-        {
-            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "true").Create();
-            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "false").Create();
-            var casenoteThree = _fixture.Create<MongoDBTestObject>();
+//        [Test]
+//        public void DoesNotDeleteRecordsNotMarkedForDeletion()
+//        {
+//            var casenoteOne = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "true").Create();
+//            var casenoteTwo = _fixture.Build<MongoDBTestObject>().With(x => x.MarkedForDeletion, "false").Create();
+//            var casenoteThree = _fixture.Create<MongoDBTestObject>();
 
-            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
+//            var collection = _mongoDatabase?.GetCollection<MongoDBTestObject>(MainFormCollection);
 
-            collection?.InsertOne(casenoteOne);
-            collection?.InsertOne(casenoteTwo);
-            collection?.InsertOne(casenoteThree);
+//            collection?.InsertOne(casenoteOne);
+//            collection?.InsertOne(casenoteTwo);
+//            collection?.InsertOne(casenoteThree);
 
-            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
+//            var result = _mongoDatabase?.RunCommand(_dbCommandUnderTest);
 
-            var filterByMarkedForDeletionFlag = Builders<MongoDBTestObject>.Filter.Eq("MarkedForDeletion", "true");
-            var newMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
-            newMatchingRecords.Count.Should().Be(0);
+//            var filterByMarkedForDeletionFlag = Builders<MongoDBTestObject>.Filter.Eq("MarkedForDeletion", "true");
+//            var newMatchingRecords = collection.Find(filterByMarkedForDeletionFlag).ToList();
+//            newMatchingRecords.Count.Should().Be(0);
 
-            var unchangedRecordsFilter = Builders<MongoDBTestObject>.Filter.Ne("MarkedForDeletion", "true");
-            var unchangedRecords = collection.Find(unchangedRecordsFilter).ToList();
-            unchangedRecords.Count.Should().Be(2);
-        }
-    }
-}
+//            var unchangedRecordsFilter = Builders<MongoDBTestObject>.Filter.Ne("MarkedForDeletion", "true");
+//            var unchangedRecords = collection.Find(unchangedRecordsFilter).ToList();
+//            unchangedRecords.Count.Should().Be(2);
+//        }
+//    }
+//}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Disable the marked for deletion column until the import spreadsheet is in sync. The column must be in the spreadsheet before this is enabled, otherwise the import will fail

### *What changes have we introduced*

Comment out the column and tests 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly