### PR TITLE
Increase memory for data import lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,7 @@ functions:
     name: social-care-case-viewer-mongodb-import-${self:provider.stage}
     handler: MongoDBImport::MongoDBImport.Handler::ImportFormData
     role: lambdaExecutionRole
-    memorySize: 2048
+    memorySize: 4096
     timeout: 900
     package:
       artifact: ./MongoDBImport/bin/release/netcoreapp3.1/mongodb-import.zip


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Data import Lambda is still running very close to the 15min hard limit and occassionally timing out

### *What changes have we introduced*

Double the memory to see if that's enough to give some headroom to the limit

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly