### PR TITLE
fix(SCT-1082): large response size getting submissions

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -285,7 +285,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 }).ToList(),
                 SubmissionState = "In progress",
                 FormAnswers = databaseCaseSubmission1.FormAnswers,
-                Title = null
+                Title = null,
+                LastEdited = databaseCaseSubmission1.EditHistory.Last().EditTime,
+                CompletedSteps = 1
             };
 
             var databaseCaseSubmission2 = TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, title: "test-title");
@@ -304,7 +306,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 }).ToList(),
                 SubmissionState = "Submitted",
                 FormAnswers = databaseCaseSubmission2.FormAnswers,
-                Title = "test-title"
+                Title = "test-title",
+                LastEdited = databaseCaseSubmission2.EditHistory.Last().EditTime,
+                CompletedSteps = 1
             };
 
             databaseCaseSubmission1.ToDomain().Should().BeEquivalentTo(domainCaseSubmission1);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -586,7 +586,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(q => q.CreatedBefore, createdBefore)
                 .RuleFor(q => q.CreatedAfter, createdAfter)
                 .RuleFor(q => q.Page, page)
-                .RuleFor(q => q.Size, size);
+                .RuleFor(q => q.Size, size)
+                .RuleFor(q => q.IncludeEditHistory, f => f.Random.Bool())
+                .RuleFor(q => q.IncludeFormAnswers, f => f.Random.Bool());
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -503,7 +503,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                         new EditHistory<Worker> {Worker = workers[0], EditTime = createdAt ?? f.Date.Recent()}
                     })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
-                .RuleFor(s => s.FormAnswers, new Dictionary<string, string>(){{"foo","bar"}})
+                .RuleFor(s => s.FormAnswers, new Dictionary<string, string>() { { "foo", "bar" } })
                 .RuleFor(s => s.DateOfEvent, dateOfEvent)
                 .RuleFor(s => s.SubmittedAt, submittedAt)
                 .RuleFor(s => s.Title, title);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -503,7 +503,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                         new EditHistory<Worker> {Worker = workers[0], EditTime = createdAt ?? f.Date.Recent()}
                     })
                 .RuleFor(s => s.SubmissionState, f => submissionState ?? SubmissionState.InProgress)
-                .RuleFor(s => s.FormAnswers, new Dictionary<string, string>())
+                .RuleFor(s => s.FormAnswers, new Dictionary<string, string>(){{"foo","bar"}})
                 .RuleFor(s => s.DateOfEvent, dateOfEvent)
                 .RuleFor(s => s.SubmittedAt, submittedAt)
                 .RuleFor(s => s.Title, title);
@@ -578,7 +578,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             DateTime? createdBefore = null,
             DateTime? createdAfter = null,
             int page = 0,
-            int size = 100)
+            int size = 100,
+            bool? includeEditHistory = null,
+            bool? includeFormAnswers = null)
         {
             return new Faker<QueryCaseSubmissionsRequest>()
                 .RuleFor(q => q.FormId, formId)
@@ -587,8 +589,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(q => q.CreatedAfter, createdAfter)
                 .RuleFor(q => q.Page, page)
                 .RuleFor(q => q.Size, size)
-                .RuleFor(q => q.IncludeEditHistory, f => f.Random.Bool())
-                .RuleFor(q => q.IncludeFormAnswers, f => f.Random.Bool());
+                .RuleFor(q => q.IncludeEditHistory, f => includeEditHistory ?? f.Random.Bool())
+                .RuleFor(q => q.IncludeFormAnswers, f => includeFormAnswers ?? f.Random.Bool());
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -793,6 +793,74 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockMongoGateway.Verify(x =>
                 x.LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], It.Is<FilterDefinition<CaseSubmission>>(innerFilter => innerFilter.RenderToJson().Equals(expectedJsonFilter)), It.IsAny<Pagination>()), Times.Once);
         }
+
+        [Test]
+        public void ExecuteGetByQueryStripsEditHistoryIfIncludeEditHistoryIsFalse()
+        {
+            var request = TestHelpers.CreateQueryCaseSubmissions("foo", includeEditHistory: false);
+            var caseSubmissions = new List<CaseSubmission> { TestHelpers.CreateCaseSubmission() };
+
+            caseSubmissions.First()?.EditHistory.Count.Should().Be(1);
+
+            _mockMongoGateway.Setup(m =>
+                    m.LoadRecordsByFilter(It.IsAny<string>(), It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns(caseSubmissions);
+
+            var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
+
+            response?.First()?.EditHistory?.Count.Should().Be(null);
+        }
+
+        [Test]
+        public void ExecuteGetByQueryContainsEditHistoryIfIncludeEditHistoryIsTrue()
+        {
+            var request = TestHelpers.CreateQueryCaseSubmissions("foo", includeEditHistory: true);
+            var caseSubmissions = new List<CaseSubmission> { TestHelpers.CreateCaseSubmission() };
+
+            caseSubmissions.First()?.EditHistory.Count.Should().Be(1);
+
+            _mockMongoGateway.Setup(m =>
+                    m.LoadRecordsByFilter(It.IsAny<string>(), It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns(caseSubmissions);
+
+            var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
+
+            response?.First()?.EditHistory?.Count.Should().Be(1);
+        }
+
+        [Test]
+        public void ExecuteGetByQueryStripsFormAnswersIfIncludeFormAnswersIsFalse()
+        {
+            var request = TestHelpers.CreateQueryCaseSubmissions("foo", includeFormAnswers: false);
+            var caseSubmissions = new List<CaseSubmission> { TestHelpers.CreateCaseSubmission() };
+
+            caseSubmissions.First()?.FormAnswers.Count.Should().Be(1);
+
+            _mockMongoGateway.Setup(m =>
+                    m.LoadRecordsByFilter(It.IsAny<string>(), It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns(caseSubmissions);
+
+            var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
+
+            response?.First()?.FormAnswers?.Count.Should().Be(null);
+        }
+
+        [Test]
+        public void ExecuteGetByQueryContainsFormAnswersIfIncludeFormAnswersIsTrue()
+        {
+            var request = TestHelpers.CreateQueryCaseSubmissions("foo", includeFormAnswers: true);
+            var caseSubmissions = new List<CaseSubmission> { TestHelpers.CreateCaseSubmission() };
+
+            caseSubmissions.First()?.EditHistory.Count.Should().Be(1);
+
+            _mockMongoGateway.Setup(m =>
+                    m.LoadRecordsByFilter(It.IsAny<string>(), It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns(caseSubmissions);
+
+            var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
+
+            response?.First()?.FormAnswers?.Count.Should().Be(1);
+        }
     }
 }
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -459,8 +459,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var response = _formSubmissionsUseCase.UpdateAnswers(createdSubmission.SubmissionId.ToString(), stepId, request);
 
-            response.FormAnswers[stepId].Should().BeEquivalentTo(request.StepAnswers);
-            response.EditHistory.LastOrDefault()?.Worker.Should().BeEquivalentTo(worker.ToDomain(false).ToResponse());
+            response.FormAnswers?[stepId].Should().BeEquivalentTo(request.StepAnswers);
+            response.EditHistory?.LastOrDefault()?.Worker.Should().BeEquivalentTo(worker.ToDomain(false).ToResponse());
             _mockDatabaseGateway.Verify(x => x.GetWorkerByEmail(request.EditedBy), Times.Once);
             _mockMongoGateway.Verify(x => x.LoadRecordById<CaseSubmission>(CollectionName, createdSubmission.SubmissionId), Times.Once);
             _mockMongoGateway.Verify(x => x.UpsertRecord(CollectionName, createdSubmission.SubmissionId, It.IsAny<CaseSubmission>()), Times.Once);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/FormSubmissionUseCaseTests.cs
@@ -808,7 +808,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
 
-            response?.First()?.EditHistory?.Count.Should().Be(null);
+            response?.First()?.EditHistory.Should().BeNull();
         }
 
         [Test]
@@ -842,7 +842,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             var response = _formSubmissionsUseCase.ExecuteGetByQuery(request);
 
-            response?.First()?.FormAnswers?.Count.Should().Be(null);
+            response?.First()?.FormAnswers.Should().BeNull();
         }
 
         [Test]
@@ -851,7 +851,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var request = TestHelpers.CreateQueryCaseSubmissions("foo", includeFormAnswers: true);
             var caseSubmissions = new List<CaseSubmission> { TestHelpers.CreateCaseSubmission() };
 
-            caseSubmissions.First()?.EditHistory.Count.Should().Be(1);
+            caseSubmissions.First()?.FormAnswers.Count.Should().Be(1);
 
             _mockMongoGateway.Setup(m =>
                     m.LoadRecordsByFilter(It.IsAny<string>(), It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -20,6 +20,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("createdBefore")]
         public DateTime? CreatedBefore { get; set; }
 
+        [JsonPropertyName("includeFormAnswers")]
+        public bool IncludeFormAnswers { get; set; } = false;
+
         [JsonPropertyName("page")]
         public int Page { get; set; } = 1;
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -23,6 +23,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("includeFormAnswers")]
         public bool IncludeFormAnswers { get; set; } = false;
 
+        [JsonPropertyName("includeFormAnswers")]
+        public bool IncludeEditHistory { get; set; } = false;
+
         [JsonPropertyName("page")]
         public int Page { get; set; } = 1;
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -23,7 +23,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("includeFormAnswers")]
         public bool IncludeFormAnswers { get; set; } = false;
 
-        [JsonPropertyName("includeFormAnswers")]
+        [JsonPropertyName("includeEditHistory")]
         public bool IncludeEditHistory { get; set; } = false;
 
         [JsonPropertyName("page")]

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CaseSubmissionResponse.cs
@@ -22,14 +22,18 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public string? RejectionReason { get; set; }
         public List<Person> Residents { get; set; } = null!;
         public List<WorkerResponse> Workers { get; set; } = null!;
-        public List<EditHistory<WorkerResponse>> EditHistory { get; set; } = null!;
+        public List<EditHistory<WorkerResponse>>? EditHistory { get; set; } = null!;
         public string SubmissionState { get; set; } = null!;
         public string? Title { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
         // either string, string[] or List<Dictionary<string,string>>
-        public Dictionary<string, string> FormAnswers { get; set; } = null!;
+        public Dictionary<string, string>? FormAnswers { get; set; } = null!;
+
+        public string? LastEdited { get; set; }
+
+        public int? CompletedSteps { get; set; }
 
         public override int GetHashCode()
         {

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -25,6 +25,8 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public List<EditHistory<Worker>>? EditHistory { get; set; } = null!;
         public string SubmissionState { get; set; } = null!;
         public string? Title { get; set; }
+        public DateTime? LastEdited { get; set; }
+        public int? CompletedSteps { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -26,7 +26,7 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string SubmissionState { get; set; } = null!;
         public string? Title { get; set; }
         public DateTime? LastEdited { get; set; }
-        public int? CompletedSteps { get; set; }
+        public int CompletedSteps { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format

--- a/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseSubmission.cs
@@ -22,14 +22,14 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string? RejectionReason { get; set; }
         public List<Person> Residents { get; set; } = null!;
         public List<Worker> Workers { get; set; } = null!;
-        public List<EditHistory<Worker>> EditHistory { get; set; } = null!;
+        public List<EditHistory<Worker>>? EditHistory { get; set; } = null!;
         public string SubmissionState { get; set; } = null!;
         public string? Title { get; set; }
 
         // outer hashset string represents step id for form
         // value represents JSON string of question ids (as stringified ints) to answers, answers in the format
         // either string, string[] or List<Dictionary<string,string>>
-        public Dictionary<string, string> FormAnswers { get; set; } = null!;
+        public Dictionary<string, string>? FormAnswers { get; set; } = null!;
     }
 }
 

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -130,7 +130,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission, bool includeAllFields = true)
+        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission, bool includeFormAnswers = true, bool includeEditHistory = true)
         {
             var mapSubmissionStateToString = new Dictionary<SubmissionState, string> {
                 { SubmissionState.InProgress, "In progress" },
@@ -156,16 +156,16 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 PanelApprovedAt = caseSubmission.PanelApprovedAt,
                 PanelApprovedBy = caseSubmission.PanelApprovedBy?.ToDomain(false),
                 RejectionReason = caseSubmission.RejectionReason,
-                EditHistory = includeAllFields ? caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
+                EditHistory = includeEditHistory ? caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
                 }).ToList() : null,
                 SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
-                FormAnswers = includeAllFields ? caseSubmission.FormAnswers : null,
+                FormAnswers = includeFormAnswers ? caseSubmission.FormAnswers : null,
                 Title = caseSubmission.Title,
-                LastEdited = caseSubmission.EditHistory.Last().EditTime,                
-                CompletedSteps = caseSubmission.FormAnswers.Count()               
+                LastEdited = caseSubmission.EditHistory.Last().EditTime,
+                CompletedSteps = caseSubmission.FormAnswers.Count
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -163,7 +163,9 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 }).ToList() : null,
                 SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
                 FormAnswers = includeAllFields ? caseSubmission.FormAnswers : null,
-                Title = caseSubmission.Title
+                Title = caseSubmission.Title,
+                LastEdited = caseSubmission.EditHistory.Last().EditTime,                
+                CompletedSteps = caseSubmission.FormAnswers.Count()               
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -130,7 +130,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission)
+        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission, bool includeAllFields = true)
         {
             var mapSubmissionStateToString = new Dictionary<SubmissionState, string> {
                 { SubmissionState.InProgress, "In progress" },
@@ -156,13 +156,13 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 PanelApprovedAt = caseSubmission.PanelApprovedAt,
                 PanelApprovedBy = caseSubmission.PanelApprovedBy?.ToDomain(false),
                 RejectionReason = caseSubmission.RejectionReason,
-                EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
+                EditHistory = includeAllFields ? caseSubmission.EditHistory.Select(e => new EditHistory<Worker>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToDomain(false)
-                }).ToList(),
+                }).ToList() : null,
                 SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
-                FormAnswers = caseSubmission.FormAnswers,
+                FormAnswers = includeAllFields ? caseSubmission.FormAnswers : null,
                 Title = caseSubmission.Title
             };
         }

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -242,7 +242,10 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 }).ToList(),
                 SubmissionState = caseSubmission.SubmissionState,
                 FormAnswers = caseSubmission.FormAnswers,
-                Title = caseSubmission.Title
+                Title = caseSubmission.Title,
+                LastEdited = caseSubmission.LastEdited?.ToString("O"),
+                CompletedSteps =caseSubmission.CompletedSteps
+
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -235,7 +235,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 PanelApprovedBy = caseSubmission.PanelApprovedBy?.ToResponse(),
                 ApprovedBy = caseSubmission.ApprovedBy?.ToResponse(),
                 RejectionReason = caseSubmission.RejectionReason,
-                EditHistory = caseSubmission.EditHistory.Select(e => new EditHistory<WorkerResponse>
+                EditHistory = caseSubmission.EditHistory?.Select(e => new EditHistory<WorkerResponse>
                 {
                     EditTime = e.EditTime,
                     Worker = e.Worker.ToResponse()

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -244,7 +244,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 FormAnswers = caseSubmission.FormAnswers,
                 Title = caseSubmission.Title,
                 LastEdited = caseSubmission.LastEdited?.ToString("O"),
-                CompletedSteps =caseSubmission.CompletedSteps
+                CompletedSteps = caseSubmission.CompletedSteps
 
             };
         }

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -111,7 +111,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             var foundSubmission = _mongoGateway.LoadRecordsByFilter(_collectionName, filter, pagination);
 
-            return foundSubmission?.Select(s => s.ToDomain().ToResponse());
+            return foundSubmission?.Select(s => s.ToDomain(request.IncludeFormAnswers, request.IncludeEditHistory).ToResponse());
         }
 
         public CaseSubmissionResponse ExecuteUpdateSubmission(string submissionId, UpdateCaseSubmissionRequest request)

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -118,7 +118,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             var worker = GetSanitisedWorker(request.EditedBy);
 
-            var updatedSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
+            var updatedSubmission = _mongoGateway.LoadRecordById<CaseSubmission?>(_collectionName, ObjectId.Parse(submissionId));
             if (updatedSubmission == null)
             {
                 throw new GetSubmissionException($"Submission with ID {submissionId} not found");

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -63,7 +63,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             var foundSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
 
-            return foundSubmission?.ToDomain().ToResponse();
+            return foundSubmission.ToDomain().ToResponse();
         }
 
         public IEnumerable<CaseSubmissionResponse>? ExecuteGetByQuery(QueryCaseSubmissionsRequest request)

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -63,7 +63,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             var foundSubmission = _mongoGateway.LoadRecordById<CaseSubmission>(_collectionName, ObjectId.Parse(submissionId));
 
-            return foundSubmission.ToDomain().ToResponse();
+            return foundSubmission?.ToDomain().ToResponse();
         }
 
         public IEnumerable<CaseSubmissionResponse>? ExecuteGetByQuery(QueryCaseSubmissionsRequest request)


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-1082)

## Describe this PR

### *What is the problem we're trying to solve*

Response size from GET /api/v1/submissions is way too large.

### *What changes have we introduced*

By default do not include EditHistory or FormAnswers when getting a list of case submissions to reduce JSON response size.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Associated frontend changes
