### PR TITLE
feat: Filter by resident age context

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/QueryCaseSubmissionsRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/QueryCaseSubmissionsRequestTests.cs
@@ -17,7 +17,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
             new object?[] { TestHelpers.CreateQueryCaseSubmissions(formId: "form-id"), true, null},
             new object?[] { TestHelpers.CreateQueryCaseSubmissions(submissionStates: new List<string>{"submission-state"}), true, null},
             new object?[] { TestHelpers.CreateQueryCaseSubmissions(createdBefore: DateTime.Now), true, null},
-            new object?[] { TestHelpers.CreateQueryCaseSubmissions(createdAfter: DateTime.Now), true, null}
+            new object?[] { TestHelpers.CreateQueryCaseSubmissions(createdAfter: DateTime.Now), true, null},
+            new object?[] { TestHelpers.CreateQueryCaseSubmissions(ageContext: "A"), true, null},
         };
 
         [TestCaseSource(nameof(_queryCaseSubmissionRequests))]

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -600,7 +600,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             int page = 0,
             int size = 100,
             bool? includeEditHistory = null,
-            bool? includeFormAnswers = null)
+            bool? includeFormAnswers = null,
+            string? ageContext = null)
         {
             return new Faker<QueryCaseSubmissionsRequest>()
                 .RuleFor(q => q.FormId, formId)
@@ -610,7 +611,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(q => q.Page, page)
                 .RuleFor(q => q.Size, size)
                 .RuleFor(q => q.IncludeEditHistory, f => includeEditHistory ?? f.Random.Bool())
-                .RuleFor(q => q.IncludeFormAnswers, f => includeFormAnswers ?? f.Random.Bool());
+                .RuleFor(q => q.IncludeFormAnswers, f => includeFormAnswers ?? f.Random.Bool())
+                .RuleFor(q => q.AgeContext, ageContext);
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -48,12 +48,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                                query.SubmissionStates != null ||
                                query.CreatedAfter != null ||
                                query.CreatedBefore != null ||
-<<<<<<< HEAD
-                               query.AgeContext != null)
-=======
+                               query.AgeContext != null ||
                                query.WorkerEmail != null)
->>>>>>> feature-filter-case-submission-by-worker-email
-                .WithMessage("Must provide at least one query parameter");
+                                   .WithMessage("Must provide at least one query parameter");
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -31,6 +31,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [JsonPropertyName("size")]
         public int Size { get; set; } = 100;
+
+        [JsonPropertyName("ageContext")]
+        public string? AgeContext { get; set; }
     }
 
     public class QueryCaseSubmissionsValidator : AbstractValidator<QueryCaseSubmissionsRequest>
@@ -41,7 +44,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                 .Must(query => !string.IsNullOrEmpty(query.FormId) ||
                                query.SubmissionStates != null ||
                                query.CreatedAfter != null ||
-                               query.CreatedBefore != null)
+                               query.CreatedBefore != null ||
+                               query.AgeContext != null)
                 .WithMessage("Must provide at least one query parameter");
         }
     }

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -107,6 +107,12 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Workers, w => w.Email == request.WorkerEmail);
             }
 
+            if (request.AgeContext != null)
+            {
+                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
+                    r => string.Equals(r.AgeContext.ToUpper(), request.AgeContext.ToUpper(), StringComparison.OrdinalIgnoreCase));
+            }
+
             return filter;
         }
 


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Frontend is currently filtering some of the responses by age context (adults or children's), this filter should be done on the backend to reduce response size, allow future pagination to work properly.

### *What changes have we introduced*

Introduced a new query parameter "ageContext".
If "ageContext" provided in requrest filter our CaseSubmissions using it by returning any submissions that have a resident that match the provide AgeContext (either A or C, case insensitive)

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
