### PR TITLE
Setup alarms for staging

### DIFF
--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -1,0 +1,72 @@
+resource "aws_sns_topic" "social_care_alerts" {
+  name = "social-care-application-alerts"
+}
+
+data "aws_cloudwatch_log_group" "social_care_frontend" {
+  name = "/aws/lambda/lbh-social-care-staging"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "social_care_frontend_critical_errors" {
+  name           = "social-care-frontend-critical-errors"
+  pattern        = "ERROR -400 -422 -\"status: 404\""
+  log_group_name = data.aws_cloudwatch_log_group.social_care_frontend.name
+
+  metric_transformation {
+    name          = "SocialCareFrontendCriticalErrors"
+    namespace     = "SocialCareFrontend"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "social_care_frontend_critical_errors" {
+
+  alarm_name          = "social-care-frontend-critical-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "SocialCareFrontendCriticalErrors"
+  namespace           = "SocialCareFrontend"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "2"
+  alarm_description   = "Triggers an alarm every time there are 2 critical errors in a minute for the Social Care Frontend."
+  alarm_actions       = [aws_sns_topic.social_care_alerts.arn]
+  datapoints_to_alarm = "1"
+}
+
+resource "aws_cloudwatch_dashboard" "social_care" {
+  dashboard_name = "social-care-system"
+
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "height": 6,
+            "width": 6,
+            "y": 0,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "SocialCareFrontend", "SocialCareFrontendCriticalErrors" ]
+                ],
+                "region": "eu-west-2",
+                "view": "timeSeries",
+                "stacked": false,
+                "period": 60,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "label": "SocialCareFrontendCriticalErrors > 0 for 1 datapoints within 1 minute",
+                            "value": 0
+                        }
+                    ]
+                },
+                "title": "Social Care Frontend Critical Errors",
+                "stat": "Sum"
+            }
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-923

## Describe this PR

### *What is the problem we're trying to solve*

We don't have a test setup for alarms on staging. This makes it difficult to validate configuration changes before applying them to production.

### *What changes have we introduced*

Update terraform config for staging to include resources required for complete alarms setup.

- Add metric filter for capturing critical errors in front end lambda log group
- Add SNS topic that will receive CloudWatch alarm messages
- Add CloudWatch alarm that gets triggered by the metric filter
- Add dashboard for easy access to the alarms raised  

Please note this setup is for staging only. Production infrastructure is maintained by the common infrastructure repo.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update serverless config for alarms handler to subscribe to the alerts SNS topic created by this PR.
