### PR TITLE
Sct 923 subscribe alerts handler to alerts sns topic

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -165,3 +165,4 @@ custom:
   mongoDBImportBucket:
     staging: mosaic-social-care-csv-staging
     mosaic-prod: social-care-case-viewer-api-qlik-bucket-prod
+    

--- a/serverless.yml
+++ b/serverless.yml
@@ -73,6 +73,16 @@ functions:
     environment:
         GOOGLE_API_URL: ${ssm:/social-care-alerts-handler/${self:provider.stage}/google-api-url}
         GOOGLE_CHAT_ROOM_PATH: ${ssm:/social-care-alerts-handler/${self:provider.stage}/google-chat-room-path~true}
+    events: 
+      - sns:
+          arn:
+            Fn::Join:
+              - ':'
+              - - 'arn:aws:sns'
+                - Ref: 'AWS::Region'
+                - Ref: 'AWS::AccountId'
+                - 'social-care-application-alerts'
+          topicName: social-care-application-alerts
 resources:
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-923

## Describe this PR

### *What is the problem we're trying to solve*

Alarms handler lambda needs to subscribe to the alerts SNS topic so it can send out messages whenever alarm is raised.

### *What changes have we introduced*

Update serverless config to include the SNS event for the alarms handler

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy to production ones SNS topic has been created
