### PR TITLE
change the alarm to use sum rather average

### DIFF
--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "social_care_frontend_critical_errors" {
   metric_name         = "SocialCareFrontendCriticalErrors"
   namespace           = "SocialCareFrontend"
   period              = "60"
-  statistic           = "Average"
+  statistic           = "Sum"
   threshold           = "2"
   alarm_description   = "Triggers an alarm every time there are 2 critical errors in a minute for the Social Care Frontend."
   alarm_actions       = [aws_sns_topic.social_care_alerts.arn]


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Test alarm is not quite sensitive enough

### *What changes have we introduced*
Tweak the alarm configuration to use sum instead of average to make it trigger more easily for testing

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
