### PR TITLE
fix(SCT-1168): Updating db_engine_version from 11.10 to 11.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -53,7 +53,7 @@ module "postgres_db_staging" {
   db_port  = 5602
   subnet_ids = data.aws_subnet_ids.staging.ids
   db_engine = "postgres"
-  db_engine_version = "11.10" //DMS does not work well with v12, use 11. to ignore minor version upgrades
+  db_engine_version = "11." //DMS does not work well with v12, use 11. to ignore minor version upgrades
   db_instance_class = "db.t3.medium"
   db_allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"


### PR DESCRIPTION
## Link to JIRA ticket

[Link to ticket](https://hackney.atlassian.net/browse/SCT-1168)

## Describe this PR

### *What is the problem we're trying to solve*

While pushing some code backend (ServiceAPI) to Staging, terraform returned an error.
The reason is because AWS is indeed upgrading minor versions automatically.
 
### *What changes have we introduced*

Update `db_engine_version` from `11.10` to `11.`