### PR TITLE
bug: handle null mosaic id when requesting cases

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -483,6 +483,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void CaseSubmissionToCareCaseDataReturnsFirstResidentInformationWhenNullMosaicId()
+        {
+            var residents = new List<Person> { TestHelpers.CreatePerson(), TestHelpers.CreatePerson() };
+            var request = TestHelpers.CreateListCasesRequest();
+            var submission = TestHelpers.CreateCaseSubmission(residents: residents);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.PersonId.Should().Be(residents[0].Id);
+            response.FirstName.Should().Be(residents[0].FirstName);
+            response.LastName.Should().Be(residents[0].LastName);
+        }
+
+        [Test]
         public void CaseSubmissionToCareCaseDataReturnsOfficeEmailOfFirstWorkerAssociatedWithCaseSubmission()
         {
             var residents = new List<Person> { TestHelpers.CreatePerson() };

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -514,7 +514,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null)
         {
             return new Faker<ListCasesRequest>()
-                .RuleFor(r => r.MosaicId, f => mosaicId?.ToString() ?? f.Random.Long(0, 100000).ToString());
+                .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString());
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -37,13 +37,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GetResidentCasesCallMongoGatewayAndReturnsResidentsSubmittedCases()
         {
-            var request = TestHelpers.CreateListCasesRequest();
+            var request = TestHelpers.CreateListCasesRequest(1L);
 
             var expectedResponse = new List<CaseSubmission>
             {
                 TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
-                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
-                TestHelpers.CreateCaseSubmission(SubmissionState.InProgress, residentId: int.Parse(request.MosaicId ?? ""))
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""))
             };
 
             _mockDatabaseGateWay.Setup(x => x.GetNCReferenceByPersonId(request.MosaicId)).Returns(request.MosaicId ?? "");
@@ -53,7 +52,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             _mockMongoGateway
                 .Setup(x => x.LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
                     It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
-                .Returns((expectedResponse, 3));
+                .Returns((expectedResponse, 2));
 
             var response = _caseRecordsUseCase.GetResidentCases(request);
 

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -171,8 +171,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
 
         public static CareCaseData ToCareCaseData(this CaseSubmission caseSubmission, ListCasesRequest listCasesRequest)
         {
-            var resident = caseSubmission.Residents
-                .First(x => x.Id == long.Parse(listCasesRequest.MosaicId ?? ""));
+            var resident = listCasesRequest.MosaicId != null ? caseSubmission.Residents
+                .First(x => x.Id == long.Parse(listCasesRequest.MosaicId)) : caseSubmission.Residents[0];
 
             return new CareCaseData
             {

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -91,7 +91,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 var caseSubmissions = _mongoGateway
                     .LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], filter, null)
                     .Item1
-                    .Where(x => x.SubmissionState == SubmissionState.Submitted)
                     .Select(x => x.ToCareCaseData(request))
                     .ToList();
 


### PR DESCRIPTION
## Link to JIRA ticket

No ticket

## Describe this PR

### *What is the problem we're trying to solve*

When a null mosaic id was provided we tried to parse an empty string to a long, this throws an unhanded exception.

### *What changes have we introduced*

When null mosaic id provided get the first resident instead of trying to parse empty string.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
