### PR TITLE
fix(SCT-1155): Align endpoint names

### DIFF
--- a/SocialCareCaseViewerApi/V1/Controllers/CaseStatusController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/CaseStatusController.cs
@@ -30,7 +30,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="404">Case status type not found, or no fields exist</response>
         [ProducesResponseType(typeof(GetCaseStatusFieldsResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("case-status/form-options/{type?}")]
+        [Route("case-statuses/form-options/{type?}")]
         public IActionResult GetCaseStatusTypeFields([FromRoute] GetCaseStatusFieldsRequest request)
         {
             try
@@ -51,7 +51,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// <response code="404">Case status not found</response>
         [ProducesResponseType(typeof(ListRelationshipsResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        [Route("residents/{personId:long}/casestatuses")]
+        [Route("residents/{personId:long}/case-statuses")]
         public IActionResult ListCaseStatuses(long personId)
         {
             try


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1555](https://hackney.atlassian.net/browse/SCT-1155)

## Describe this PR

### *What is the problem we're trying to solve*

Case status endpoint names have various way of spelling "case status".
This PR aligns them to "case-statuses"

### *What changes have we introduced*

`case-status/form-options/{type?}` now becomes `case-statuses/form-options/{type?}`
`residents/{personId:long}/casestatuses` is now `residents/{personId:long}/case-statuses`

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Align endpoints name in the FE
