### PR TITLE
fix: Remove unused visit information

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -34,10 +34,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(v => v.ReasonVisitNotMade, f => f.Random.String2(1, 16))
                 .RuleFor(v => v.SeenAloneFlag, f => f.Random.Bool())
                 .RuleFor(v => v.CompletedFlag, f => f.Random.Bool())
-                .RuleFor(v => v.CpRegistrationId, f => f.UniqueIndex)
-                .RuleFor(v => v.CpVisitScheduleStepId, f => f.UniqueIndex)
-                .RuleFor(v => v.CpVisitScheduleDays, f => f.Random.Number(999))
-                .RuleFor(v => v.CpVisitOnTime, f => f.Random.Bool())
                 .RuleFor(v => v.CreatedByEmail, f => f.Person.Email)
                 .RuleFor(v => v.CreatedByName, f => f.Person.FullName);
         }

--- a/SocialCareCaseViewerApi/V1/Domain/Visit.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/Visit.cs
@@ -27,13 +27,5 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public bool SeenAloneFlag { get; set; }
 
         public bool CompletedFlag { get; set; }
-
-        public long? CpRegistrationId { get; set; }
-
-        public long? CpVisitScheduleStepId { get; set; }
-
-        public long? CpVisitScheduleDays { get; set; }
-
-        public bool CpVisitOnTime { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -15,7 +15,6 @@ using DbTeam = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 using dbWarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
 using DbWorker = SocialCareCaseViewerApi.V1.Infrastructure.Worker;
 using PhoneNumber = SocialCareCaseViewerApi.V1.Domain.PhoneNumber;
-using ResidentInformation = SocialCareCaseViewerApi.V1.Domain.ResidentInformation;
 using Team = SocialCareCaseViewerApi.V1.Domain.Team;
 using WarningNote = SocialCareCaseViewerApi.V1.Domain.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Domain.Worker;
@@ -25,22 +24,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
 {
     public static class EntityFactory
     {
-        public static ResidentInformation ToDomain(this Person databaseEntity)
-        {
-            return new ResidentInformation
-            {
-                PersonId = databaseEntity.Id.ToString(),
-                Title = databaseEntity.Title,
-                FirstName = databaseEntity.FirstName,
-                LastName = databaseEntity.LastName,
-                DateOfBirth = databaseEntity.DateOfBirth?.ToString("O"),
-                Gender = databaseEntity.Gender,
-                Nationality = databaseEntity.Nationality,
-                NhsNumber = databaseEntity.NhsNumber?.ToString(),
-
-            };
-        }
-
         public static Address ToDomain(this DbAddress address)
         {
             return new Address


### PR DESCRIPTION
Frontend never uses 4 of the properties from our historic visits so deleted them

CpRegistrationId
CpVisitScheduleStepId
CpVisitScheduleDays
CpVisitOnTime

Also deleted an unused entity factory method.