### PR TITLE
fix: Return pruned response for in progress submissions

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -612,20 +612,22 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             bool? includeFormAnswers = null,
             string? ageContext = null,
             string? workerEmail = null,
-            long? personID = null)
+            long? personID = null,
+            bool? pruneUnfinished = null)
         {
             return new Faker<QueryCaseSubmissionsRequest>()
-               .RuleFor(q => q.FormId, formId)
-               .RuleFor(q => q.SubmissionStates, submissionStates)
-               .RuleFor(q => q.CreatedBefore, createdBefore)
-               .RuleFor(q => q.CreatedAfter, createdAfter)
-               .RuleFor(q => q.Page, page)
-               .RuleFor(q => q.Size, size)
-               .RuleFor(q => q.IncludeEditHistory, f => includeEditHistory ?? f.Random.Bool())
-               .RuleFor(q => q.IncludeFormAnswers, f => includeFormAnswers ?? f.Random.Bool())
-               .RuleFor(q => q.AgeContext, ageContext)
-               .RuleFor(q => q.WorkerEmail, workerEmail)
-               .RuleFor(q => q.PersonID, personID);
+                .RuleFor(q => q.FormId, formId)
+                .RuleFor(q => q.SubmissionStates, submissionStates)
+                .RuleFor(q => q.CreatedBefore, createdBefore)
+                .RuleFor(q => q.CreatedAfter, createdAfter)
+                .RuleFor(q => q.Page, page)
+                .RuleFor(q => q.Size, size)
+                .RuleFor(q => q.IncludeEditHistory, f => includeEditHistory ?? f.Random.Bool())
+                .RuleFor(q => q.IncludeFormAnswers, f => includeFormAnswers ?? f.Random.Bool())
+                .RuleFor(q => q.AgeContext, ageContext)
+                .RuleFor(q => q.WorkerEmail, workerEmail)
+                .RuleFor(q => q.PersonID, personID)
+                .RuleFor(q => q.PruneUnfinished, f => pruneUnfinished ?? f.Random.Bool());
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -1,45 +1,44 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 #nullable enable
 {
     public class QueryCaseSubmissionsRequest
     {
-        [JsonPropertyName("formId")]
+        [FromQuery(Name = "formId")]
         public string? FormId { get; set; }
 
-        [JsonPropertyName("submissionStates")]
+        [FromQuery(Name = "submissionStates")]
         public IEnumerable<string>? SubmissionStates { get; set; }
 
-        [JsonPropertyName("createdAfter")]
+        [FromQuery(Name = "createdAfter")]
         public DateTime? CreatedAfter { get; set; }
 
-        [JsonPropertyName("createdBefore")]
+        [FromQuery(Name = "createdBefore")]
         public DateTime? CreatedBefore { get; set; }
 
-        [JsonPropertyName("includeFormAnswers")]
+        [FromQuery(Name = "includeFormAnswers")]
         public bool IncludeFormAnswers { get; set; } = false;
 
-        [JsonPropertyName("includeEditHistory")]
+        [FromQuery(Name = "includeEditHistory")]
         public bool IncludeEditHistory { get; set; } = false;
 
-        [JsonPropertyName("page")]
+        [FromQuery(Name = "page")]
         public int Page { get; set; } = 1;
 
-        [JsonPropertyName("size")]
+        [FromQuery(Name = "size")]
         public int Size { get; set; } = 100;
 
-
-        [JsonPropertyName("ageContext")]
+        [FromQuery(Name = "ageContext")]
         public string? AgeContext { get; set; }
 
-        [JsonPropertyName("workerEmail")]
+        [FromQuery(Name = "workerEmail")]
         public string? WorkerEmail { get; set; }
 
-        [JsonPropertyName("personId")]
+        [FromQuery(Name = "personId")]
         public long? PersonID { get; set; }
     }
 

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -40,6 +40,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromQuery(Name = "personId")]
         public long? PersonID { get; set; }
+
+        [FromQuery(Name = "pruneUnfinished")]
+        public bool PruneUnfinished { get; set; } = false;
     }
 
     public class QueryCaseSubmissionsValidator : AbstractValidator<QueryCaseSubmissionsRequest>

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/WorkersResponse.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/WorkersResponse.cs
@@ -1,28 +1,29 @@
 using System.Collections.Generic;
 using SocialCareCaseViewerApi.V1.Domain;
 
+#nullable enable
 namespace SocialCareCaseViewerApi.V1.Boundary.Response
 {
     public class WorkerResponse
     {
-        public int Id { get; set; }
+        public int? Id { get; set; }
 
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
-        public string FirstName { get; set; }
+        public string? FirstName { get; set; }
 
-        public string LastName { get; set; }
+        public string? LastName { get; set; }
 
-        public string Role { get; set; }
+        public string? Role { get; set; }
 
-        public string ContextFlag { get; set; }
+        public string? ContextFlag { get; set; }
 
-        public string CreatedBy { get; set; }
+        public string? CreatedBy { get; set; }
 
-        public string DateStart { get; set; }
+        public string? DateStart { get; set; }
 
-        public int AllocationCount { get; set; }
+        public int? AllocationCount { get; set; }
 
-        public IList<Team> Teams { get; set; } = new List<Team>();
+        public IList<Team>? Teams { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Domain/Worker.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/Worker.cs
@@ -6,24 +6,24 @@ namespace SocialCareCaseViewerApi.V1.Domain
 {
     public class Worker
     {
-        public int Id { get; set; }
+        public int? Id { get; set; }
 
         public string Email { get; set; } = null!;
 
-        public string FirstName { get; set; } = null!;
+        public string? FirstName { get; set; } = null;
 
-        public string LastName { get; set; } = null!;
+        public string? LastName { get; set; } = null;
 
-        public string? Role { get; set; }
+        public string? Role { get; set; } = null;
 
-        public string? ContextFlag { get; set; }
+        public string? ContextFlag { get; set; } = null;
 
-        public string? CreatedBy { get; set; }
+        public string? CreatedBy { get; set; } = null;
 
-        public DateTime? DateStart { get; set; }
+        public DateTime? DateStart { get; set; } = null;
 
-        public int AllocationCount { get; set; }
+        public int? AllocationCount { get; set; } = null;
 
-        public IList<Team> Teams { get; set; } = new List<Team>();
+        public IList<Team>? Teams { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -113,7 +113,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
             };
         }
 
-        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission, bool includeFormAnswers = true, bool includeEditHistory = true)
+        public static Domain.CaseSubmission ToDomain(this CaseSubmission caseSubmission,
+            bool includeFormAnswers = true, bool includeEditHistory = true, bool pruneUnfinished = false)
         {
             var mapSubmissionStateToString = new Dictionary<SubmissionState, string> {
                 { SubmissionState.InProgress, "In progress" },
@@ -122,6 +123,33 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 { SubmissionState.Discarded, "Discarded" },
                 { SubmissionState.PanelApproved, "Panel Approved" }
             };
+
+            if (pruneUnfinished)
+            {
+                return new Domain.CaseSubmission
+                {
+                    SubmissionId = caseSubmission.SubmissionId.ToString(),
+                    FormId = caseSubmission.FormId,
+                    CreatedBy = new Worker { Email = caseSubmission.CreatedBy.Email, },
+                    CreatedAt = caseSubmission.CreatedAt,
+                    Residents = caseSubmission.Residents.Select(r => new Person
+                    {
+                        Id = r.Id,
+                        AgeContext = r.AgeContext,
+                        FirstName = r.FirstName,
+                        LastName = r.LastName,
+                        Restricted = r.Restricted
+                    }).ToList(),
+                    Workers = caseSubmission.Workers.Select(w => new Worker
+                    {
+                        Email = w.Email
+                    }).ToList(),
+                    SubmissionState = mapSubmissionStateToString[caseSubmission.SubmissionState],
+                    LastEdited = caseSubmission.EditHistory.Last().EditTime,
+                    CompletedSteps = caseSubmission.FormAnswers.Count,
+                    Title = caseSubmission.Title,
+                };
+            }
 
             return new Domain.CaseSubmission
             {

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -121,10 +121,10 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Email = worker.Email,
                 FirstName = worker.FirstName,
                 LastName = worker.LastName,
-                Role = worker.Role ?? "",
-                ContextFlag = worker.ContextFlag ?? "",
-                CreatedBy = worker.CreatedBy ?? "",
-                DateStart = worker.DateStart?.ToString("s") ?? "",
+                Role = worker.Role,
+                ContextFlag = worker.ContextFlag,
+                CreatedBy = worker.CreatedBy,
+                DateStart = worker.DateStart?.ToString("s"),
                 AllocationCount = worker.AllocationCount,
                 Teams = worker.Teams
             };
@@ -245,7 +245,6 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 Title = caseSubmission.Title,
                 LastEdited = caseSubmission.LastEdited?.ToString("O"),
                 CompletedSteps = caseSubmission.CompletedSteps
-
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -142,8 +142,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return new Paginated<CaseSubmissionResponse>
             {
                 Count = totalCount,
-                Items = foundSubmission?.Select(s =>
-                    s.ToDomain(request.IncludeFormAnswers, request.IncludeEditHistory).ToResponse()).ToList()
+                Items = foundSubmission?.Select(s => s.ToDomain(request.IncludeFormAnswers, request.IncludeEditHistory, request.PruneUnfinished).ToResponse()).ToList()
             };
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

No ticket.

## Describe this PR

### *What is the problem we're trying to solve*

Reducing the response size/reducing the response time.
Can see the response size difference below, roughly a 2/3rds reduction in response size. Ignore the response time as those requests are running locally, hoping for a 50% reduction in speed which I'll test out of curiosity once this is on staging.

Before:

![Screenshot from 2021-09-17 00-24-47](https://user-images.githubusercontent.com/29123700/133703161-0c4ae1e7-1b48-463d-8f5c-dec5b47201be.png)

After:

![Screenshot from 2021-09-17 00-22-27](https://user-images.githubusercontent.com/29123700/133703160-f223f28a-cb54-47bf-9097-b15d480d95f4.png)

### *What changes have we introduced*

Created an optional parameter for pruning our unfinished submission response. This can go into prod before any FE changes are released as the parameter if not provided is defaulted to false.

All we do is if the parameter is set to true in out entity factory/response factory do not return anything not required by the frontend, any property not required is null and therefore not return in the JSON response.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly