### PR TITLE
feat(SCT-1128): Speed up document db query using eq instead of elemmatch

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -59,5 +59,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             response.Cases.Count.Should().Be(2);
             response.Cases.Should().BeEquivalentTo(expectedResponse.Take(2).Select(x => x.ToCareCaseData(request)).ToList());
         }
+
+        [Test]
+        public void GenerateFilterDefinitionQueriesForResidentMosaicId()
+        {
+            var emptyRequest = TestHelpers.CreateListCasesRequest();
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(emptyRequest);
+
+            var builder = Builders<CaseSubmission>.Filter;
+            var expectedFilter = builder.Empty;
+            expectedFilter &= Builders<CaseSubmission>.Filter.Eq(x =>
+                x.SubmissionState, SubmissionState.Submitted);
+
+            response.RenderToJson().Should().Be(expectedFilter.RenderToJson());
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -63,34 +63,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GenerateFilterDefinitionForDefaultCase()
         {
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1 }";
             var emptyRequest = TestHelpers.CreateListCasesRequest();
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(emptyRequest);
 
-            var builder = Builders<CaseSubmission>.Filter;
-            var expectedFilter = builder.Empty;
-            expectedFilter &= Builders<CaseSubmission>.Filter.Eq(x =>
-                x.SubmissionState, SubmissionState.Submitted);
-
-            response.RenderToJson().Should().Be(expectedFilter.RenderToJson());
+            response.RenderToJson().Should().Be(expectedJsonQuery);
         }
 
         [Test]
         public void GenerateFilterDefinitionWithProvidedMosaicId()
         {
+            const string expectedJsonQuery = "{ \"Residents._id\" : 1, \"SubmissionState\" : 1 }";
             const long mosaicId = 1L;
             var requestWithMosaicId = TestHelpers.CreateListCasesRequest(mosaicId);
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
 
-            var builder = Builders<CaseSubmission>.Filter;
-            var expectedFilter = builder.Empty;
-            expectedFilter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                r => r.Id == mosaicId);
-            expectedFilter &= Builders<CaseSubmission>.Filter.Eq(x =>
-                x.SubmissionState, SubmissionState.Submitted);
-
-            response.RenderToJson().Should().Be(expectedFilter.RenderToJson());
+            response.RenderToJson().Should().Be(expectedJsonQuery);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -61,7 +61,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void GenerateFilterDefinitionQueriesForResidentMosaicId()
+        public void GenerateFilterDefinitionForDefaultCase()
         {
             var emptyRequest = TestHelpers.CreateListCasesRequest();
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -74,5 +74,23 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
 
             response.RenderToJson().Should().Be(expectedFilter.RenderToJson());
         }
+
+        [Test]
+        public void GenerateFilterDefinitionWithProvidedMosaicId()
+        {
+            const long mosaicId = 1L;
+            var requestWithMosaicId = TestHelpers.CreateListCasesRequest(mosaicId);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
+
+            var builder = Builders<CaseSubmission>.Filter;
+            var expectedFilter = builder.Empty;
+            expectedFilter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
+                r => r.Id == mosaicId);
+            expectedFilter &= Builders<CaseSubmission>.Filter.Eq(x =>
+                x.SubmissionState, SubmissionState.Submitted);
+
+            response.RenderToJson().Should().Be(expectedFilter.RenderToJson());
+        }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -49,7 +50,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 }
             }
 
-            var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
+            var (response, totalCount) = (new List<CareCaseData>(), 0);
             var allCareCaseData = response.ToList();
 
             if (request.MosaicId != null || request.WorkerEmail != null || request.FormName != null || request.FirstName != null || request.LastName != null)
@@ -86,10 +87,12 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             var builder = Builders<CaseSubmission>.Filter;
             var filter = builder.Empty;
+
             if (request.MosaicId != null)
             {
-                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                    r => r.Id == long.Parse(request.MosaicId));
+                var bsonQuery = "{'Residents._id':" + request.MosaicId + "}";
+
+                filter &= MongoDB.Bson.Serialization.BsonSerializer.Deserialize<BsonDocument>(bsonQuery);
             }
             if (request.WorkerEmail != null)
             {

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -52,43 +52,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
             var allCareCaseData = response.ToList();
 
-
-
             if (request.MosaicId != null || request.WorkerEmail != null || request.FormName != null || request.FirstName != null || request.LastName != null)
             {
-                var builder = Builders<CaseSubmission>.Filter;
-                var filter = builder.Empty;
-                if (request.MosaicId != null)
-                {
-                    filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                        r => r.Id == long.Parse(request.MosaicId));
-                }
-                if (request.WorkerEmail != null)
-                {
-                    filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Workers, w => w.Email == request.WorkerEmail);
-                }
-
-                if (request.FormName == "Case Note")
-                {
-                    filter &= Builders<CaseSubmission>.Filter.Eq(x =>
-                    x.FormId, "adult-case-note") | Builders<CaseSubmission>.Filter.Eq(x =>
-                    x.FormId, "child-case-note");
-                }
-
-                if (request.FirstName != null)
-                {
-                    filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                        r => r.FirstName.ToLower() == request.FirstName.ToLower());
-                }
-
-                if (request.LastName != null)
-                {
-                    filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                        r => r.LastName.ToLower() == request.LastName.ToLower());
-                }
-
-                filter &= Builders<CaseSubmission>.Filter.Eq(x =>
-                    x.SubmissionState, SubmissionState.Submitted);
+                var filter = GenerateFilterDefinition(request);
 
                 var caseSubmissions = _mongoGateway
                     .LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], filter, null)
@@ -114,6 +80,45 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 Cases = careCaseData.ToList(),
                 NextCursor = nextCursor
             };
+        }
+
+        public static FilterDefinition<CaseSubmission> GenerateFilterDefinition(ListCasesRequest request)
+        {
+            var builder = Builders<CaseSubmission>.Filter;
+            var filter = builder.Empty;
+            if (request.MosaicId != null)
+            {
+                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
+                    r => r.Id == long.Parse(request.MosaicId));
+            }
+            if (request.WorkerEmail != null)
+            {
+                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Workers, w => w.Email == request.WorkerEmail);
+            }
+
+            if (request.FormName == "Case Note")
+            {
+                filter &= Builders<CaseSubmission>.Filter.Eq(x =>
+                    x.FormId, "adult-case-note") | Builders<CaseSubmission>.Filter.Eq(x =>
+                    x.FormId, "child-case-note");
+            }
+
+            if (request.FirstName != null)
+            {
+                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
+                    r => r.FirstName.ToLower() == request.FirstName.ToLower());
+            }
+
+            if (request.LastName != null)
+            {
+                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
+                    r => r.LastName.ToLower() == request.LastName.ToLower());
+            }
+
+            filter &= Builders<CaseSubmission>.Filter.Eq(x =>
+                x.SubmissionState, SubmissionState.Submitted);
+
+            return filter;
         }
 
         public CareCaseData? Execute(string recordId)

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -50,7 +50,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 }
             }
 
-            var (response, totalCount) = (new List<CareCaseData>(), 0);
+            var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
             var allCareCaseData = response.ToList();
 
             if (request.MosaicId != null || request.WorkerEmail != null || request.FormName != null || request.FirstName != null || request.LastName != null)

--- a/database/manual-updates/2021-09-20_1-index-resident-case-submissions-resident-id.md
+++ b/database/manual-updates/2021-09-20_1-index-resident-case-submissions-resident-id.md
@@ -1,0 +1,31 @@
+# Index By Case Submission Resident Id (Mosaic Id)
+
+## The problem we're trying to solve
+
+Querying DocumentDB for case submissions by Resident Id (Mosaic Id) is slow.
+
+## Justification for doing a manual update
+
+Currently the only way to update our indexes.
+
+## The plan
+
+1. Simply connect to DocumentDB instance
+2. Run the query
+
+## Link to Jira ticket
+
+[Assess overloading Mongo DB queries](https://hackney.atlassian.net/browse/SCT-1128)
+
+## MongoDB query
+
+```
+db['resident-case-submissions'].createIndex(
+    {
+        "Residents._id": 1
+    },
+    {
+        name: "residents_id", background: true
+    }
+);
+```


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-1128)

## Describe this PR

### *What is the problem we're trying to solve*

Utilise getting case submissions by resident id using mosaic query equality operatior.

DocumentDB does not allow to use indexes on fields access with elemmatch.

https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.indexes

### *What changes have we introduced*

Changed the generated filter to utilise eq when filtering by resident id.
Added some preliminary tests around our GenerateFilter functionality.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test staging, if good deploy.
