### PR TITLE
fix(SCT-1266, SCT-1267): Optimise and index query for Residents.Firstname and Residents.LastName

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -507,11 +507,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.Title, title);
         }
 
-        public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null, string? firstName = null)
+        public static ListCasesRequest CreateListCasesRequest(
+            long? mosaicId = null,
+            string? firstName = null,
+            string? lastName = null)
         {
             return new Faker<ListCasesRequest>()
                 .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString())
-                .RuleFor(r => r.FirstName, firstName);
+                .RuleFor(r => r.FirstName, firstName)
+                .RuleFor(r => r.LastName, lastName);
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -507,10 +507,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(s => s.Title, title);
         }
 
-        public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null)
+        public static ListCasesRequest CreateListCasesRequest(long? mosaicId = null, string? firstName = null)
         {
             return new Faker<ListCasesRequest>()
-                .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString());
+                .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString())
+                .RuleFor(r => r.FirstName, firstName);
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -84,11 +84,23 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void GenerateFilterDefinitionWithProvidedLastName()
+        public void GenerateFilterDefinitionWithProvidedFirstName()
         {
             const string expectedJsonQuery = "{ \"Residents.FirstName\" : /^testington$/i, \"SubmissionState\" : 1 }";
             const string firstName = "testington";
             var requestWithMosaicId = TestHelpers.CreateListCasesRequest(firstName: firstName);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithProvidedLastName()
+        {
+            const string expectedJsonQuery = "{ \"Residents.LastName\" : /^toastington$/i, \"SubmissionState\" : 1 }";
+            const string lastName = "toastington";
+            var requestWithMosaicId = TestHelpers.CreateListCasesRequest(lastName: lastName);
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -76,7 +76,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         {
             const string expectedJsonQuery = "{ \"Residents._id\" : 1, \"SubmissionState\" : 1 }";
             const long mosaicId = 1L;
-            var requestWithMosaicId = TestHelpers.CreateListCasesRequest(mosaicId);
+            var requestWithMosaicId = TestHelpers.CreateListCasesRequest(mosaicId: mosaicId);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithProvidedLastName()
+        {
+            const string expectedJsonQuery = "{ \"Residents.FirstName\" : /^testington$/i, \"SubmissionState\" : 1 }";
+            const string firstName = "testington";
+            var requestWithMosaicId = TestHelpers.CreateListCasesRequest(firstName: firstName);
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithMosaicId);
 

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -108,8 +108,9 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             if (request.FirstName != null)
             {
-                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                    r => r.FirstName.ToLower() == request.FirstName.ToLower());
+                var bsonQuery = "{'Residents.FirstName':" + "/^" + request.FirstName.ToLower() + "$/i}";
+                
+                filter &= MongoDB.Bson.Serialization.BsonSerializer.Deserialize<BsonDocument>(bsonQuery);
             }
 
             if (request.LastName != null)

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -109,14 +109,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             if (request.FirstName != null)
             {
                 var bsonQuery = "{'Residents.FirstName':" + "/^" + request.FirstName.ToLower() + "$/i}";
-                
+
                 filter &= MongoDB.Bson.Serialization.BsonSerializer.Deserialize<BsonDocument>(bsonQuery);
             }
 
             if (request.LastName != null)
             {
-                filter &= Builders<CaseSubmission>.Filter.ElemMatch(x => x.Residents,
-                    r => r.LastName.ToLower() == request.LastName.ToLower());
+                var bsonQuery = "{'Residents.LastName':" + "/^" + request.LastName.ToLower() + "$/i}";
+
+                filter &= MongoDB.Bson.Serialization.BsonSerializer.Deserialize<BsonDocument>(bsonQuery);
             }
 
             filter &= Builders<CaseSubmission>.Filter.Eq(x =>

--- a/database/manual-updates/2021-09-22_1-index-resident-case-submissions-firstname-lastname.md
+++ b/database/manual-updates/2021-09-22_1-index-resident-case-submissions-firstname-lastname.md
@@ -1,0 +1,41 @@
+# Index By Case Submission Resident Id (Mosaic Id)
+
+## The problem we're trying to solve
+
+Querying DocumentDB for case submissions by Resident Id (Mosaic Id) is slow.
+
+## Justification for doing a manual update
+
+Currently the only way to update our indexes.
+
+## The plan
+
+1. Simply connect to DocumentDB instance
+2. Run the query
+
+## Link to Jira ticket
+
+[Optimise and index query for Residents.Firstname](https://hackney.atlassian.net/browse/SCT-1266)
+[Optimise and index query for Residents.Lastname](https://hackney.atlassian.net/browse/SCT-1267)
+
+## MongoDB query
+
+```
+db['resident-case-submissions'].createIndex(
+    {
+        "Residents.FirstName": 1
+    },
+    {
+        name: "residents_firstname", background: true
+    }
+);
+
+db['resident-case-submissions'].createIndex(
+    {
+        "Residents.LastName": 1
+    },
+    {
+        name: "residents_lastname", background: true
+    }
+);
+```


### PR DESCRIPTION
## Link to JIRA ticket

[Optimise and index query for Residents.Firstname ](https://hackney.atlassian.net/browse/SCT-1266)
[Optimise and index query for Residents.Lastname](https://hackney.atlassian.net/browse/SCT-1267)

## Describe this PR

### *What is the problem we're trying to solve*

We're optimising the way data is loaded form MongoDB.
The current implementation uses the `ElemMatch` function, it is slow as it iterates over all the columns.

### *What changes have we introduced*

Updated our requests to DocumentDb to use `eq` instead of `elemmatch` (documentdb can not use elemmatch for indexed fields)

Index our case submissions using the resident's first name and last name.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
