### PR TITLE
Fix inconsistent response for /residents?mosaic_id={id}

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
@@ -151,7 +151,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
         [TestCase("42NC")]
         [TestCase("A42SC")]
         [TestCase("TM42P")]
-        public void CallsGetPersonByMosaicIdWhenMosaicIdIsProvidedWithoutZeroPrefix(string mosaicId)
+        public void CallsGetPersonDetailsByIdWhenMosaicIdIsProvidedWithoutZeroPrefix(string mosaicId)
         {
             var request = new ResidentQueryParam() { MosaicId = mosaicId };
 
@@ -160,13 +160,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
 
             _residentUseCase.GetResidentsByQuery(request, cursor: 0, limit: 4);
 
-            _mockDatabaseGateway.Verify(x => x.GetPersonByMosaicId(Convert.ToInt64(request.MosaicId)));
+            _mockDatabaseGateway.Verify(x => x.GetPersonDetailsById(Convert.ToInt64(request.MosaicId)));
         }
 
         [Test]
         [TestCase("042")]
         [TestCase("0042")]
-        public void DoesNotCallGetPersonByMosaicIdWhenMosaicIdContainsLeadingZeros(string mosaicId)
+        public void DoesNotCallGetPersonDetailsByIdWhenMosaicIdContainsLeadingZeros(string mosaicId)
         {
             var request = new ResidentQueryParam() { MosaicId = mosaicId };
 
@@ -175,7 +175,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
 
             _residentUseCase.GetResidentsByQuery(request, cursor: 0, limit: 4);
 
-            _mockDatabaseGateway.Verify(x => x.GetPersonByMosaicId(It.IsAny<long>()), Times.Never);
+            _mockDatabaseGateway.Verify(x => x.GetPersonDetailsById(It.IsAny<long>()), Times.Never);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
@@ -60,7 +60,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 //check for individual. Ignore if provided id contains leading zeros as those won't be system Ids
                 if (!rqp.MosaicId.StartsWith("0"))
                 {
-                    var resident = _databaseGateway.GetPersonByMosaicId(mosaicId.Value);
+                    var resident = _databaseGateway.GetPersonDetailsById(mosaicId.Value);
 
                     if (resident != null)
                     {


### PR DESCRIPTION
## Link to ticket

https://trello.com/c/oDcrWVCK/305-fix-inability-to-get-resident-by-id

## Describe this PR

### *What is the problem we're trying to solve*

When calling the `GET /residents` API endpoint without any parameters, the API returns an array of residents with each including their addresses and phone numbers.

```json
{
  "residents": [
      {
          "mosaicId": "7",
          "firstName": "Birgit",
          "lastName": "Gaylard",
          "dateOfBirth": "1976-05-12T08:10:37.0000000",
          "ageContext": "A",
          "gender": "F",
          "nationality": "Somali",
          "addressList": [
              {
                  "endDate": "2043-08-14T11:32:05",
                  "displayAddressFlag": "N",
                  "addressLine1": "7 Jackson Junction",
                  "postCode": "E9 6SE"
              }
          ],
          "nhsNumber": "7589619035",
          "restricted": "Y"
      },
      {
          "mosaicId": "19",
          "firstName": "Cristobal",
          "lastName": "Cawdell",
          "dateOfBirth": "2009-03-25T15:45:18.0000000",
          "ageContext": "C",
          "gender": "M",
          "nationality": "Belizean",
          "phoneNumber": [
              {
                  "phoneNumber": "4457745916",
                  "phoneType": "House"
              },
              {
                  "phoneNumber": "1717514648",
                  "phoneType": "Work"
              }
          ],
          "nhsNumber": "9034481271",
          "restricted": "N"
      },
  ],
  "nextCursor": ""
}
```

 However, when you call it with a mosaic ID e.g. `GET /residents?mosaic_id={id}` it doesn't include their addresses and phone numbers.

```json
{
    "residents": [
        {
            "mosaicId": "7",
            "firstName": "Birgit",
            "lastName": "Gaylard",
            "dateOfBirth": "1976-05-12T08:10:37.0000000",
            "ageContext": "A",
            "gender": "F",
            "nationality": "Somali",
            "nhsNumber": "7589619035",
            "restricted": "Y"
        }
    ],
    "nextCursor": ""
}
```

### *What changes have we introduced*

This PR changes the `GetResidentsByQuery` in the `Residents` use case to call `databaseGateway.GetPersonDetailsById` instead of `databaseGateway.GetPersonByMosaicId` which is very similar but includes phone numbers and addresses. It means the response when calling `GET /residents?mosaic_id=7` is now:

```json
{
  "residents": [
      {
          "mosaicId": "7",
          "firstName": "Birgit",
          "lastName": "Gaylard",
          "dateOfBirth": "1976-05-12T08:10:37.0000000",
          "ageContext": "A",
          "gender": "F",
          "nationality": "Somali",
          "addressList": [
              {
                  "endDate": "2043-08-14T11:32:05",
                  "displayAddressFlag": "N",
                  "addressLine1": "7 Jackson Junction",
                  "postCode": "E9 6SE"
              }
          ],
          "nhsNumber": "7589619035",
          "restricted": "Y"
      }
  ],
  "nextCursor": ""
}

```

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
