### PR TITLE
fix(SCT-1314): Refactor parameter name

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -642,7 +642,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             {
                 var value = new Faker<CaseStatusValue>()
                     .RuleFor(c => c.Name, f => f.Random.String2(1000))
-                    .RuleFor(c => c.Value, f => f.Random.String2(1000));
+                    .RuleFor(c => c.Selected, f => f.Random.String2(1000));
 
                 caseStatusValues.Add(value);
             }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseStatusRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateCaseStatusRequest.cs
@@ -29,8 +29,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [JsonPropertyName("name")]
         public string Name { get; set; } = null!;
 
-        [JsonPropertyName("value")]
-        public string Value { get; set; } = null!;
+        [JsonPropertyName("selected")]
+        public string Selected { get; set; } = null!;
     }
 
     public class UpdateCaseStatusValidator : AbstractValidator<UpdateCaseStatusRequest>
@@ -46,7 +46,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                 .ChildRules(value =>
                 {
                     value.RuleFor(x => x.Name).NotNull().WithMessage("Field must have a name");
-                    value.RuleFor(x => x.Value).NotNull().WithMessage("Field selected value must not be empty");
+                    value.RuleFor(x => x.Selected).NotNull().WithMessage("Field selected value must not be empty");
                 });
         }
     }


### PR DESCRIPTION
## Link to JIRA ticket

[LInk to ticket](https://hackney.atlassian.net/browse/SCT-1314)

## Describe this PR

### *What is the problem we're trying to solve*

Frontend and backend are not aligned, frontend sends a `selected` parameter and the backend expects a `value` parameter.

### *What changes have we introduced*

Refactored the parameter from "values" to "selected"
The change has been done in the backend so there's only one way the parameter is called (when adding a case status, the parameter sent was already `selected`

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly
