### PR TITLE
feat(SCT-1354): Add "discarded_at" and "group_id" columns in the CaseStatusAnswers table

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/CreateCaseStatusTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/CreateCaseStatusTests.cs
@@ -95,6 +95,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.CaseStatusGatewayTests
             caseStatus.Answers.Any(a => a.Option == answersTwo.Option).Should().Be(true);
             caseStatus.Answers.Any(a => a.Value == answersOne.Value).Should().Be(true);
             caseStatus.Answers.Any(a => a.Value == answersTwo.Value).Should().Be(true);
+            caseStatus.Answers[0].GroupId.Should().NotBe(null);
+            caseStatus.Answers[1].GroupId.Should().NotBe(null);
+            caseStatus.Answers[1].GroupId.Should().Equals(caseStatus.Answers[0].GroupId);
             caseStatus.Notes.Should().Be(request.Notes);
             caseStatus.PersonId.Should().Be(person.Id);
             caseStatus.Type.Should().Be(request.Type);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/GetCaseStatusesByPersonIdTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/GetCaseStatusesByPersonIdTests.cs
@@ -62,6 +62,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.CaseStatusGatewayTests
                 }
                );
         }
+        [Test]
+        public void WhenMatchingIDReturnsOnlyActiveAnswersInCaseStatuses()
+        {
+            var (caseStatus, person, answers) = CaseStatusHelper.SavePersonCaseStatusWithDiscardedAnswerToDatabase(DatabaseContext);
+
+            var response = _caseStatusGateway.GetCaseStatusesByPersonId(person.Id);
+            response.Count.Should().Be(1);
+
+            var responseElement = response.First();
+            responseElement.Answers.Count.Should().Be(0);
+        }
 
         [Test]
         public void WhenMatchingIDAndPastCaseStatusReturnEmptyList()

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/CaseStatusHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/CaseStatusHelper.cs
@@ -14,15 +14,44 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         {
             var person = TestHelpers.CreatePerson();
             var caseStatus = TestHelpers.CreateCaseStatus(person.Id, resident: person);
+            databaseContext.Persons.Add(person);
+            databaseContext.CaseStatuses.Add(caseStatus);
+            databaseContext.SaveChanges();
+
+            var caseStatusAnswers = TestHelpers.CreateCaseStatusAnswers(caseStatusId: caseStatus.Id);
+            databaseContext.CaseStatusAnswers.AddRange(caseStatusAnswers);
+
+            databaseContext.SaveChanges();
+
+            return (caseStatus, person, caseStatusAnswers);
+        }
+        public static (CaseStatus, SocialCareCaseViewerApi.V1.Infrastructure.Person, List<CaseStatusAnswer>) SavePersonCaseStatusWithDiscardedAnswerToDatabase(
+          DatabaseContext databaseContext)
+        {
+            var person = TestHelpers.CreatePerson();
+
+            var caseStatus = TestHelpers.CreateCaseStatus(person.Id, resident: person);
 
             databaseContext.Persons.Add(person);
             databaseContext.CaseStatuses.Add(caseStatus);
 
             databaseContext.SaveChanges();
 
-            var caseStatusAnswers = TestHelpers.CreateCaseStatusAnswers(caseStatusId: caseStatus.Id);
-            databaseContext.CaseStatusAnswers.AddRange(caseStatusAnswers);
+            Guid identifier = Guid.NewGuid();
 
+            var legalStatusPast = new CaseStatusAnswer();
+            legalStatusPast.CaseStatusId = caseStatus.Id;
+            legalStatusPast.Option = "legalStatus";
+            legalStatusPast.Value = "C1";
+            legalStatusPast.GroupId = identifier.ToString();
+            legalStatusPast.StartDate = DateTime.Today.AddDays(-10);
+            legalStatusPast.CreatedAt = DateTime.Today.AddDays(-11);
+            legalStatusPast.DiscardedAt = DateTime.Today;
+
+            var caseStatusAnswers = new List<CaseStatusAnswer>();
+            caseStatusAnswers.Add(legalStatusPast);
+
+            databaseContext.CaseStatusAnswers.AddRange(caseStatusAnswers);
             databaseContext.SaveChanges();
 
             return (caseStatus, person, caseStatusAnswers);

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/CaseStatusHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/CaseStatusHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Bogus;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Infrastructure;
@@ -92,12 +91,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             databaseContext.SaveChanges();
 
             return (caseStatus, person);
-        }
-
-        public static DateTime? TrimMilliseconds(DateTime? dt)
-        {
-            if (dt == null) return null;
-            return new DateTime(dt.Value.Year, dt.Value.Month, dt.Value.Day, dt.Value.Hour, dt.Value.Minute, dt.Value.Second, 0, dt.Value.Kind);
         }
 
         public static DateTime? TrimMilliseconds(DateTime? dt)

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -537,7 +537,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? notes = null,
             DateTime? startDate = null,
             DateTime? endDate = null,
-            InfrastructurePerson? resident = null)
+            InfrastructurePerson? resident = null,
+            string? type = null)
         {
             resident ??= CreatePerson();
 
@@ -547,6 +548,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(cs => cs.StartDate, f => startDate ?? f.Date.Past())
                 .RuleFor(cs => cs.EndDate, f => endDate ?? f.Date.Future())
                 .RuleFor(cs => cs.Person, resident)
+                .RuleFor(cs => cs.Type, type ?? "CP")
                 .RuleFor(cs => cs.Answers, new List<CaseStatusAnswer>());
         }
 
@@ -598,7 +600,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         public static List<CaseStatusAnswer> CreateCaseStatusAnswers(
             DateTime? startDate = null,
             DateTime? createdAt = null,
-            long? caseStatusId = null)
+            long? caseStatusId = null,
+            string? groupId = null)
         {
             var caseStatusAnswers = new List<CaseStatusAnswer>();
 
@@ -608,6 +611,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                     .RuleFor(a => a.CaseStatusId, f => caseStatusId ?? f.Random.Long())
                     .RuleFor(a => a.Option, f => f.Random.String2(100))
                     .RuleFor(a => a.Value, f => f.Random.String2(100))
+                    .RuleFor(a => a.GroupId, f => groupId ?? f.Random.String2(36))
+                    .RuleFor(a => a.StartDate, f => startDate ?? f.Date.Past())
                     .RuleFor(a => a.StartDate, f => startDate ?? f.Date.Past())
                     .RuleFor(a => a.CreatedAt, f => createdAt ?? f.Date.Past());
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseStatus/CaseStatusExecutePostUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseStatus/CaseStatusExecutePostUseCaseTests.cs
@@ -8,8 +8,6 @@ using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.Gateways.Interfaces;
 using SocialCareCaseViewerApi.V1.UseCase;
 using System;
-using SocialCareCaseViewerApi.V1.Factories;
-using SocialCareCaseViewerApi.V1.Gateways.Interfaces;
 
 namespace SocialCareCaseViewerApi.Tests.V1.UseCase.CaseStatus
 {

--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -156,5 +156,38 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             return caseStatus.ToDomain();
         }
+
+        public CaseStatus CreateCaseStatusAnswer(CreateCaseStatusAnswerRequest request)
+        {
+            var caseStatus = _databaseContext.CaseStatuses.Include(x => x.Answers).FirstOrDefault(x => x.Id == request.CaseStatusId);
+
+            if (caseStatus == null)
+            {
+                throw new CaseStatusDoesNotExistException($"Case status id {request.CaseStatusId} does not exist.");
+            }
+
+            if (caseStatus.Answers == null) caseStatus.Answers = new List<CaseStatusAnswer>();
+
+            foreach (var answer in request.Answers)
+            {
+                Guid identifier = Guid.NewGuid();
+
+                var caseStatusAnswer = new Infrastructure.CaseStatusAnswer()
+                {
+                    CaseStatusId = caseStatus.Id,
+                    CreatedBy = request.CreatedBy,
+                    StartDate = request.StartDate,
+                    Option = answer.Option,
+                    Value = answer.Value,
+                    GroupId = identifier.ToString(),
+                    CreatedAt = _systemTime.Now //will get overwritten by audit feature 
+                };
+
+                caseStatus.Answers.Add(caseStatusAnswer);
+            }
+            _databaseContext.SaveChanges();
+
+            return caseStatus.ToDomain();
+        }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -43,10 +43,13 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .Include(cs => cs.Answers)
                 .Include(cs => cs.Person).ToList();
 
-            foreach (var caseStatus in caseStatuses){
+            foreach (var caseStatus in caseStatuses)
+            {
                 var caseAnswers = new List<CaseStatusAnswer>();
-                foreach (var answer in caseStatus.Answers){
-                    if (answer.DiscardedAt == null){
+                foreach (var answer in caseStatus.Answers)
+                {
+                    if (answer.DiscardedAt == null)
+                    {
                         caseAnswers.Add(answer);
                     }
                 }
@@ -64,8 +67,10 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .FirstOrDefault();
 
             var caseAnswers = new List<CaseStatusAnswer>();
-            foreach (var answer in caseStatus.Answers){
-                if (answer.DiscardedAt == null){
+            foreach (var answer in caseStatus.Answers)
+            {
+                if (answer.DiscardedAt == null)
+                {
                     caseAnswers.Add(answer);
                 }
             }
@@ -146,7 +151,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     caseStatus.Answers.Add(caseStatusAnswer);
                 }
             }
-            
+
             _databaseContext.SaveChanges();
 
             return caseStatus.ToDomain();

--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -40,8 +40,18 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .CaseStatuses
                 .Where(cs => cs.PersonId == personId)
                 .Where(cs => cs.EndDate == null || cs.EndDate > DateTime.Today)
-                .Include(cs => cs.Person)
-                .Include(cs => cs.Answers);
+                .Include(cs => cs.Answers)
+                .Include(cs => cs.Person).ToList();
+
+            foreach (var caseStatus in caseStatuses){
+                var caseAnswers = new List<CaseStatusAnswer>();
+                foreach (var answer in caseStatus.Answers){
+                    if (answer.DiscardedAt == null){
+                        caseAnswers.Add(answer);
+                    }
+                }
+                caseStatus.Answers = caseAnswers;
+            }
 
             return caseStatuses.Select(caseStatus => caseStatus.ToDomain()).ToList();
         }
@@ -51,8 +61,15 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .Where(cs => cs.StartDate <= date)
                 .Where(cs => cs.EndDate == null || cs.EndDate >= date)
                 .Include(cs => cs.Person)
-                .Include(cs => cs.Answers)
                 .FirstOrDefault();
+
+            var caseAnswers = new List<CaseStatusAnswer>();
+            foreach (var answer in caseStatus.Answers){
+                if (answer.DiscardedAt == null){
+                    caseAnswers.Add(answer);
+                }
+            }
+            caseStatus.Answers = caseAnswers;
 
             return caseStatus?.ToDomain();
         }
@@ -69,6 +86,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 Answers = new List<CaseStatusAnswer>()
             };
 
+            Guid identifier = Guid.NewGuid();
+
             foreach (var answer in request.Answers)
             {
                 var caseStatusAnswer = new CaseStatusAnswer
@@ -78,7 +97,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     Value = answer.Value,
                     StartDate = request.StartDate,
                     CreatedAt = _systemTime.Now,
-                    CreatedBy = request.CreatedBy
+                    CreatedBy = request.CreatedBy,
+                    GroupId = identifier.ToString()
                 };
                 caseStatus.Answers.Add(caseStatusAnswer);
             }
@@ -108,6 +128,25 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 caseStatus.EndDate = request.EndDate;
             }
 
+            if (request.Answers != null)
+            {
+                Guid identifier = Guid.NewGuid();
+
+                foreach (var answer in request.Answers)
+                {
+                    var caseStatusAnswer = new CaseStatusAnswer
+                    {
+                        CaseStatusId = caseStatus.Id,
+                        Option = answer.Option,
+                        Value = answer.Value,
+                        CreatedAt = _systemTime.Now,
+                        GroupId = identifier.ToString(),
+                        CreatedBy = request.EditedBy
+                    };
+                    caseStatus.Answers.Add(caseStatusAnswer);
+                }
+            }
+            
             _databaseContext.SaveChanges();
 
             return caseStatus.ToDomain();

--- a/SocialCareCaseViewerApi/V1/Infrastructure/CaseStatusAnswer.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/CaseStatusAnswer.cs
@@ -28,6 +28,11 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [ForeignKey("CaseStatusId")]
         public CaseStatus CaseStatus { get; set; }
 
+        [Column("discarded_at")]
+        public DateTime? DiscardedAt { get; set; }
+
+        [Column("group_id")]
+        public String GroupId { get; set; }
 
         //audit props
         [Column("sccv_created_at")]

--- a/database/manual-updates/2021-10-15_1_add_discarded_at_case_status_answers.md
+++ b/database/manual-updates/2021-10-15_1_add_discarded_at_case_status_answers.md
@@ -1,0 +1,30 @@
+# Update case statuses table structure
+
+## The problem we're trying to solve
+
+Added discarded_at column for case statuses answers
+
+## Justification for doing a manual update
+
+We don't have mautomated migrations yet
+
+## The plan
+
+1. Run the SQL script below
+
+## Link to Jira ticket
+
+https://hackney.atlassian.net/browse/SCT-1354
+
+## SQL statement(s)
+
+```sql
+--altering person_case_status_answers
+
+ALTER TABLE dbo.sccv_person_case_status_answers
+  ADD COLUMN discarded_at timestamp;
+
+ALTER TABLE dbo.sccv_person_case_status_answers
+  ADD COLUMN group_id varchar(36) not null;
+
+```

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -833,3 +833,9 @@ DROP TABLE IF EXISTS DBO.SCCV_CASE_STATUS_TYPE;
 
 ALTER TABLE dbo.sccv_person_case_status
   DROP COLUMN discarded_at;
+
+ALTER TABLE dbo.sccv_person_case_status_answers
+  ADD COLUMN discarded_at timestamp;
+
+ALTER TABLE dbo.sccv_person_case_status_answers
+  ADD COLUMN group_id varchar(36) not null;


### PR DESCRIPTION
## Link to JIRA ticket

[Link to ticket
](https://hackney.atlassian.net/browse/SCT-1354)

## Describe this PR

### *What is the problem we're trying to solve*

We need a `guid` and `discarded_at` column to keep track of the same answer blocks and if they are discarded or not

### *What changes have we introduced*

- Add "discarded_at" and "group_id" columns in the CaseStatusAnswers table
- Adjusted CaseStatusAnswer object
- Adjusted and added tests

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Run the SQL schema update on the server - make sure to not case unnecessary errors on Production servers
