### PR TITLE
SCT-1354: add groupid to case status response

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/UpdateCaseStatusTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/UpdateCaseStatusTests.cs
@@ -60,6 +60,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.CaseStatusGatewayTests
 
             response.EndDate.Should().Be(request.EndDate);
             response.Answers.Should().ContainEquivalentOf(updateValue);
+            response.Answers[0].GroupId.Should().NotBeNull();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Domain/CaseStatusAnswer.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseStatusAnswer.cs
@@ -9,5 +9,6 @@ namespace SocialCareCaseViewerApi.V1.Domain
         public string Value { get; set; } = null!;
         public DateTime CreatedAt { get; set; }
         public DateTime StartDate { get; set; }
+        public string GroupId { get; set; } = null!;
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -304,7 +304,8 @@ namespace SocialCareCaseViewerApi.V1.Factories
                         Option = a.Option,
                         Value = a.Value,
                         StartDate = a.StartDate,
-                        CreatedAt = a.CreatedAt.Value
+                        CreatedAt = a.CreatedAt.Value,
+                        GroupId = a.GroupId
                     }
                     ).ToList()
             };


### PR DESCRIPTION
## Link to JIRA ticket

[Link to ticket](https://hackney.atlassian.net/browse/SCT-1339)

## Describe this PR

### *What is the problem we're trying to solve*

Answers in the response of a Case Status of type LAC don't contain the groupId information.
This is needed in the FE to do the matching between reponse.

### *What changes have we introduced*

This PR adds the groupId to the case status response

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly