### PR TITLE
Fix: index documentdb by worker email

### DIFF
--- a/database/manual-updates/2021-10-20_1-index-createdby-email.md
+++ b/database/manual-updates/2021-10-20_1-index-createdby-email.md
@@ -11,10 +11,10 @@ Currently the only way to update our indexes.
 ## The plan
 
 1. Connect to DocumentDB instance
-2. Run the query
+2. Run the mongodb scripts
 3. Observe that initial execution states showed a COLLSCAN being performed and that after indexing this became an IXSCAN
 
-## MongoDB query
+## MongoDB scripts
 
 ```
 use resident-case-submissions;


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We no longer use ElemMatch to get case submissions by worker email, we haven't indexed the CreatedBy.Email field yet though so we are still doing a COLLSCAN when finding the relevant CaseSubmissions. These changes to the DB will make a very slow query almost instant.

### *What changes have we introduced*

The documentation provides the required commands to created indexing on CreatedBy.Email field.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
