### PR TITLE
Logic update for considering active answers

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
@@ -115,13 +115,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.CaseStatus.LAC
 
             getCaseStatusesResponseAfterScheduledUpdate.StatusCode.Should().Be(200);
 
-            var updatedScheduledContent = await getCaseStatusesResponseAfterScheduledUpdate.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var updatedScheduledCaseStatusResponse = JsonConvert.DeserializeObject<List<CaseStatusResponse>>(updatedScheduledContent).ToList();
+            var updatedContentWithScheduledStatus = await getCaseStatusesResponseAfterScheduledUpdate.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var updatedCaseStatusWithScheduledStatusResponse = JsonConvert.DeserializeObject<List<CaseStatusResponse>>(updatedContentWithScheduledStatus).ToList();
 
-            updatedScheduledCaseStatusResponse.Count.Should().Be(1);
-            updatedScheduledCaseStatusResponse.Single().Answers.Count.Should().Be(4);
-            // updatedScheduledCaseStatusResponse.Single().Answers.First().EndDate.Should().Be(addScheduledAnswersRequest.StartDate); -thought this should work
-            updatedScheduledCaseStatusResponse.Single().Answers.Last().StartDate.Should().Be(addScheduledAnswersRequest.StartDate);
+            updatedCaseStatusWithScheduledStatusResponse.Count.Should().Be(1);
+            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Count.Should().Be(4);
+            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Last().StartDate.Should().Be(addScheduledAnswersRequest.StartDate);
 
             //patch case status to end it
             var endRequest = TestHelpers.CreateUpdateCaseStatusRequest(endDate: new DateTime(2000, 01, 11), email: _worker.Email, caseStatusId: caseStatusId, min: 1, max: 1);

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
@@ -110,6 +110,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.CaseStatus.LAC
             var createScheduledAnswersResponse = await Client.PostAsync(postScheduledAnswersUri, scheduledAnswersRequestContent).ConfigureAwait(true);
             createScheduledAnswersResponse.StatusCode.Should().Be(201);
 
+            //Get request to check that the scheduled answers were added
+            var getCaseStatusesResponseAfterScheduledUpdate = await Client.GetAsync(getUri).ConfigureAwait(true);
+
+            getCaseStatusesResponseAfterScheduledUpdate.StatusCode.Should().Be(200);
+
+            var updatedScheduledContent = await getCaseStatusesResponseAfterScheduledUpdate.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var updatedScheduledCaseStatusResponse = JsonConvert.DeserializeObject<List<CaseStatusResponse>>(updatedScheduledContent).ToList();
+
+            updatedScheduledCaseStatusResponse.Count.Should().Be(1);
+            updatedScheduledCaseStatusResponse.Single().Answers.Count.Should().Be(4);
+            // updatedScheduledCaseStatusResponse.Single().Answers.First().EndDate.Should().Be(addScheduledAnswersRequest.StartDate); -thought this should work
+            updatedScheduledCaseStatusResponse.Single().Answers.Last().StartDate.Should().Be(addScheduledAnswersRequest.StartDate);
+
             //patch case status to end it
             var endRequest = TestHelpers.CreateUpdateCaseStatusRequest(endDate: new DateTime(2000, 01, 11), email: _worker.Email, caseStatusId: caseStatusId, min: 1, max: 1);
             patchRequest.Notes = null;

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseStatus/CaseStatusExecuteUpdateUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseStatus/CaseStatusExecuteUpdateUseCaseTests.cs
@@ -185,15 +185,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.CaseStatus
         [Test]
         public void WhenTypeIsLACandTheProvidedEndDateIsValidAndThereAreScheduledAnswersItCallsTheGateway()
         {
-            var activeAnswers = TestHelpers.CreateCaseStatusAnswers(min: 2, max: 2, startDate: new DateTime(2000, 01, 11));
+            var activeAnswers = TestHelpers.CreateCaseStatusAnswers(min: 2, max: 2, startDate: new DateTime(2000, 01, 11), endDate: new DateTime(2040, 02, 01));
             var scheduledAnswers = TestHelpers.CreateCaseStatusAnswers(min: 2, max: 2, startDate: new DateTime(2040, 02, 01));
 
-            _caseStatus = TestHelpers.CreateCaseStatus(resident: _resident, startDate: new DateTime(200, 01, 11), type: "LAC");
+            _caseStatus = TestHelpers.CreateCaseStatus(resident: _resident, startDate: new DateTime(2000, 01, 11), type: "LAC");
             _caseStatus.Answers = new List<CaseStatusAnswer>();
             _caseStatus.Answers.AddRange(activeAnswers);
             _caseStatus.Answers.AddRange(scheduledAnswers);
 
-            _updateCaseStatusRequest = TestHelpers.CreateUpdateCaseStatusRequest(caseStatusId: _caseStatus.Id, email: _worker.Email, endDate: new DateTime(200, 01, 11), min: 1, max: 1);
+            _updateCaseStatusRequest = TestHelpers.CreateUpdateCaseStatusRequest(caseStatusId: _caseStatus.Id, email: _worker.Email, endDate: new DateTime(2000, 01, 11), min: 1, max: 1);
 
             _mockCaseStatusGateway.Setup(x => x.GetCasesStatusByCaseStatusId(_caseStatus.Id)).Returns(_caseStatus.ToDomain());
             _mockCaseStatusGateway.Setup(x => x.UpdateCaseStatus(It.IsAny<UpdateCaseStatusRequest>())).Returns(new DomainCaseStatus());

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseStatusesUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseStatusesUseCase.cs
@@ -136,7 +136,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                         }
                         break;
                     case "lac":
-                        var activeAnswers = caseStatus.Answers.Where(x => x.DiscardedAt == null && (x.EndDate == null || x.EndDate > DateTime.Today ));
+                        var activeAnswers = caseStatus.Answers.Where(x => x.DiscardedAt == null && (x.EndDate == null || x.EndDate > DateTime.Today));
 
                         if (activeAnswers.Count() == 2 && activeAnswers.FirstOrDefault().StartDate > request.EndDate)
                         {

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseStatusesUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseStatusesUseCase.cs
@@ -136,7 +136,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                         }
                         break;
                     case "lac":
-                        var activeAnswers = caseStatus.Answers.Where(x => x.DiscardedAt == null && x.EndDate == null);
+                        var activeAnswers = caseStatus.Answers.Where(x => x.DiscardedAt == null && (x.EndDate == null || x.EndDate > DateTime.Today ));
 
                         if (activeAnswers.Count() == 2 && activeAnswers.FirstOrDefault().StartDate > request.EndDate)
                         {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1430

## Describe this PR

### *What is the problem we're trying to solve*

When ending a LAC case status, if there is a scheduled status, we should be able to end the LAC on or after the start date of the current case status.
The existing logic took into consideration 'active answers' when determining if a case status could be ended on a certain date. This logic excluded answers with an end date. However, when answers are scheduled an end date is added to the current status answers. This means it was not possible to end the case status before the start of the scheduled answers.

### *What changes have we introduced*

The logic that determines what active answers now looks for answers which are not discarded, have no end date or have an end date that is in the future. This should now allow for status' with scheduled answers to be ended on or after the start date of the current answers.

Tests have been updated to reflect this logic.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Re-run frontend e2e tests to confirm they all pass
