### PR TITLE
SCT-1450 update start date handling when patching without end date

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -216,7 +216,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                             }
                         }
 
-                        if (existingAnswerGroups?.Count() == 1)
+                        if (existingAnswerGroups?.Count() == 1 || (existingAnswerGroups?.Count() == 2 && caseStatus.Answers.Any(x => x.StartDate > DateTime.Today && x.EndDate == null)))
                         {
                             caseStatus.StartDate = (DateTime) request.StartDate;
                         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1450

## Describe this PR

### *What is the problem we're trying to solve*

Currently, the backend is configured so that if we are editing LAC we update the start date of the `dbo.sccv_person_case_status` table only if there is one group of answers.

However, there could be the following scenario where we would still want to edit the start in the `dbo.sccv_person_case_status` table (and there would be two groups of answers):

1. Add a LAC status (starting 01/11/2021)
3. Update the LAC status so there is now a 'Scheduled status' (scheduled for 01/03/2022)
5. Edit the LAC status (with a new start date of 03/11/2021)

At this point we would still want to update the `dbo.sccv_person_case_status` start date as we are technically still editing the 'first group' of answers 

We would want to end up with the start date of `dbo.sccv_person_case_status` to be 03/11/2021 and the start date of the new answer group (copied/replaced original answers) should also now be 03/11/2021

### *What changes have we introduced*

Update the logic on the gateway so it can handle the scenario above correctly.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
