### PR TITLE
SCT-1451 update timestamp column data types in dbo.sccv_person_case_status table

### DIFF
--- a/database/manual-updates/2021-11-08_1-update-timestamp-columns-for-case-statuses.md
+++ b/database/manual-updates/2021-11-08_1-update-timestamp-columns-for-case-statuses.md
@@ -1,0 +1,27 @@
+# Update start_date and end_date columns data type
+
+## The problem we're trying to solve
+
+Currently the start_date and end_date columns are defined as timestamp wihout time zone. For consistency these should be defined as timestamp like other timestamp columns in the schema.
+
+## Justification for doing a manual update
+
+We don't have automated db migrations
+
+## The plan
+
+1. Run the script
+
+## Link to Jira ticket
+
+https://hackney.atlassian.net/browse/SCT-1451
+
+## SQL statement(s)
+
+```sql
+ALTER TABLE IF EXISTS dbo.sccv_person_case_status
+	ALTER start_date type timestamp;
+
+ALTER TABLE IF EXISTS dbo.sccv_person_case_status
+	ALTER end_date type timestamp;
+```

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -889,3 +889,9 @@ CREATE TABLE IF NOT EXISTS dbo.REF_MASH_RESIDENTS
 	FOREIGN KEY (fk_ref_mash_referrals_id)
 	  REFERENCES dbo.ref_mash_referrals (id)
 );
+
+ALTER TABLE IF EXISTS dbo.sccv_person_case_status
+	ALTER start_date type timestamp;
+
+ALTER TABLE IF EXISTS dbo.sccv_person_case_status
+	ALTER end_date type timestamp;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1451

## Describe this PR

### *What is the problem we're trying to solve*

Currently the `start_date` and `end_date` columns are defined as timestamp without time zone in `dbo.sccv_person_case_status`. For consistency these should be defined as timestamp like other timestamp columns in the schema.

### *What changes have we introduced*

Add sql script to alter the columns so they are in line with other timestamp columns.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Run the script on staging and production. We don't have any production data yet, so it's safe to run the update as is.
