### PR TITLE
SCT-1453 Improve null value handling in case statuses

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -604,18 +604,53 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
                 Notes = infraStructureCaseStatus.Notes,
                 Person = infraStructureCaseStatus.Person,
                 Type = infraStructureCaseStatus.Type,
-                Answers = infraStructureCaseStatus.Answers.Select(
-                    a => new SocialCareCaseViewerApi.V1.Domain.CaseStatusAnswer
-                    {
-                        Option = a.Option,
-                        Value = a.Value,
-                        StartDate = a.StartDate,
-                        CreatedAt = a.CreatedAt.Value,
-                        GroupId = a.GroupId,
-                        EndDate = a.EndDate,
-                        DiscardedAt = a.DiscardedAt
-                    }
-                    ).ToList()
+                Answers = infraStructureCaseStatus.Answers.Select(a => a.ToDomain()).ToList()
+            });
+        }
+
+        [Test]
+        public void ConvertCaseStatusAnswerInfrastructureToDomain()
+        {
+            var infraStructureCaseStatusAnswer = TestHelpers.CreateCaseStatusAnswers(min: 1, max: 1).FirstOrDefault();
+
+            var domainCaseStatusAnswer = infraStructureCaseStatusAnswer.ToDomain();
+
+            domainCaseStatusAnswer.Should().BeEquivalentTo(new SocialCareCaseViewerApi.V1.Domain.CaseStatusAnswer()
+            {
+
+                Option = infraStructureCaseStatusAnswer.Option,
+                Value = infraStructureCaseStatusAnswer.Value,
+                StartDate = infraStructureCaseStatusAnswer.StartDate,
+                CreatedAt = infraStructureCaseStatusAnswer.CreatedAt.Value,
+                GroupId = infraStructureCaseStatusAnswer.GroupId,
+                EndDate = infraStructureCaseStatusAnswer.EndDate,
+                DiscardedAt = infraStructureCaseStatusAnswer.DiscardedAt
+            });
+        }
+
+        [Test]
+        public void CanConvertCaseStatusAnswerInfrastructureToDomainWhenNullableValuesInInfrastructureObjectAreNull()
+        {
+            var infraStructureCaseStatusAnswer = TestHelpers.CreateCaseStatusAnswers(min: 1, max: 1).FirstOrDefault();
+            infraStructureCaseStatusAnswer.Option = null;
+            infraStructureCaseStatusAnswer.Value = null;
+            infraStructureCaseStatusAnswer.DiscardedAt = null;
+            infraStructureCaseStatusAnswer.EndDate = null;
+            infraStructureCaseStatusAnswer.CreatedAt = null;
+            infraStructureCaseStatusAnswer.LastModifiedAt = null;
+
+            var domainCaseStatusAnswer = infraStructureCaseStatusAnswer.ToDomain();
+
+            domainCaseStatusAnswer.Should().BeEquivalentTo(new SocialCareCaseViewerApi.V1.Domain.CaseStatusAnswer()
+            {
+
+                Option = infraStructureCaseStatusAnswer.Option,
+                Value = infraStructureCaseStatusAnswer.Value,
+                StartDate = infraStructureCaseStatusAnswer.StartDate,
+                CreatedAt = infraStructureCaseStatusAnswer.CreatedAt,
+                GroupId = infraStructureCaseStatusAnswer.GroupId,
+                EndDate = infraStructureCaseStatusAnswer.EndDate,
+                DiscardedAt = infraStructureCaseStatusAnswer.DiscardedAt
             });
         }
     }

--- a/SocialCareCaseViewerApi/V1/Domain/CaseStatusAnswer.cs
+++ b/SocialCareCaseViewerApi/V1/Domain/CaseStatusAnswer.cs
@@ -5,9 +5,9 @@ namespace SocialCareCaseViewerApi.V1.Domain
 {
     public class CaseStatusAnswer
     {
-        public string Option { get; set; } = null!;
-        public string Value { get; set; } = null!;
-        public DateTime CreatedAt { get; set; }
+        public string? Option { get; set; }
+        public string? Value { get; set; }
+        public DateTime? CreatedAt { get; set; }
         public DateTime StartDate { get; set; }
         public DateTime? DiscardedAt { get; set; }
         public string GroupId { get; set; } = null!;

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -298,18 +298,20 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 EndDate = caseStatus.EndDate,
                 Notes = caseStatus.Notes,
                 Person = caseStatus.Person,
-                Answers = caseStatus.Answers.Select(
-                    a => new Domain.CaseStatusAnswer
-                    {
-                        Option = a.Option,
-                        Value = a.Value,
-                        StartDate = a.StartDate,
-                        CreatedAt = a.CreatedAt.Value,
-                        GroupId = a.GroupId,
-                        EndDate = a.EndDate,
-                        DiscardedAt = a.DiscardedAt
-                    }
-                    ).ToList()
+                Answers = caseStatus.Answers.Select(a => a.ToDomain()).ToList()
+            };
+        }
+        public static Domain.CaseStatusAnswer ToDomain(this Infrastructure.CaseStatusAnswer caseStatusAnswer)
+        {
+            return new Domain.CaseStatusAnswer()
+            {
+                Option = caseStatusAnswer.Option,
+                Value = caseStatusAnswer.Value,
+                StartDate = caseStatusAnswer.StartDate,
+                CreatedAt = caseStatusAnswer.CreatedAt,
+                GroupId = caseStatusAnswer.GroupId,
+                EndDate = caseStatusAnswer.EndDate,
+                DiscardedAt = caseStatusAnswer.DiscardedAt
             };
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1453

## Describe this PR

### *What is the problem we're trying to solve*

Imported case status data won't have values for certain properties, such as createdAt, that are currently handled as non-nullable values. This will cause issue loading the data after we have imported the data.

### *What changes have we introduced*

Make sure all values marked as non-nullable in infrastruture object can be handled by the factory when converting to domain objects.

Added a new extension method for case status answers to tidy things up.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
