### PR TITLE
SCT-1461 add end date to answer when closing cp status

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -147,25 +147,37 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 caseStatus.EndDate = request.EndDate;
 
-                if (caseStatus.Type.ToLower() == "lac")
+                switch (caseStatus.Type.ToLower())
                 {
-                    var activeAnswers = caseStatus
-                                                .Answers
-                                                .Where(x => x.DiscardedAt == null && (x.EndDate == null || x.EndDate > DateTime.Today));
+                    case "cp":
+                        var activeCPAnswers = caseStatus.Answers.Where(x => x.DiscardedAt == null);
 
-                    foreach (var a in activeAnswers.Where(x => x.StartDate > DateTime.Today))
-                    {
-                        a.DiscardedAt = _systemTime.Now;
-                        a.LastModifiedBy = request.EditedBy;
-                    }
+                        foreach (var a in activeCPAnswers)
+                        {
+                            a.EndDate = request.EndDate;
+                        }
 
-                    foreach (var a in activeAnswers.Where(x => x.StartDate <= DateTime.Today))
-                    {
-                        a.EndDate = request.EndDate;
-                        a.LastModifiedBy = request.EditedBy;
-                    }
+                        break;
 
-                    AddNewAnswers(request, caseStatus, startDate: request.EndDate, endDate: request.EndDate);
+                    case "lac":
+                        var activeLACAnswers = caseStatus
+                                                    .Answers
+                                                    .Where(x => x.DiscardedAt == null && (x.EndDate == null || x.EndDate > DateTime.Today));
+
+                        foreach (var a in activeLACAnswers.Where(x => x.StartDate > DateTime.Today))
+                        {
+                            a.DiscardedAt = _systemTime.Now;
+                            a.LastModifiedBy = request.EditedBy;
+                        }
+
+                        foreach (var a in activeLACAnswers.Where(x => x.StartDate <= DateTime.Today))
+                        {
+                            a.EndDate = request.EndDate;
+                            a.LastModifiedBy = request.EditedBy;
+                        }
+
+                        AddNewAnswers(request, caseStatus, startDate: request.EndDate, endDate: request.EndDate);
+                        break;
                 }
             }
             //end date not provided


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1461

## Describe this PR

### *What is the problem we're trying to solve*

When CP status is ended we don't currently set the end date for the active answer. End date should be set so the data is inline with imported data. This will also make the Mosaic import process easier.

### *What changes have we introduced*

Set the end date for active CP answer when status ends. 

Also includes unrelated update for flaky tests where it was possible for autogenerated dates to cause invalid status update request. Date in itself is irrelevant for what the tests are for, so this ensures the request is always valid.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
