### PR TITLE
SCT-1473 Add episode end reason for LAC

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/CreateCaseStatusAnswerTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/CaseStatusGatewayTests/CreateCaseStatusAnswerTests.cs
@@ -127,9 +127,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.CaseStatusGatewayTests
 
             var caseStatusAnswers = DatabaseContext.CaseStatuses.FirstOrDefault().Answers;
 
-            caseStatusAnswers.Count.Should().Be(4);
+            caseStatusAnswers.Count.Should().Be(5);
 
-            var previousActiveAnswers = caseStatusAnswers.Where(x => x.GroupId == groupId);
+            var previousActiveAnswers = caseStatusAnswers.Where(x => x.GroupId == groupId && x.Option != LACAnswerOption.EpisodeReason);
 
             previousActiveAnswers.All(x => x.EndDate != null).Should().BeTrue();
             previousActiveAnswers.All(x => x.EndDate == request.StartDate);
@@ -189,6 +189,37 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.CaseStatusGatewayTests
             newScheduledAnswers.All(x => x.StartDate == request.StartDate).Should().BeTrue();
             newScheduledAnswers.Any(x => x.Option == requestAnswer1.Option && x.Value == requestAnswer1.Value).Should().BeTrue();
             newScheduledAnswers.Any(x => x.Option == requestAnswer2.Option && x.Value == requestAnswer2.Value).Should().BeTrue();
+        }
+
+        [Test]
+        public void AddsNewEpisodeReasonAnswerUsingTheStartAndEndDateOfTheCurrentAnswers()
+        {
+            var personId = 123;
+            var groupId = Guid.NewGuid().ToString();
+            var currentActiveAnswersStartDate = DateTime.Today.AddDays(-10);
+
+            var caseStatus = TestHelpers.CreateCaseStatus(type: "LAC", personId: personId);
+
+            var currentActiveAnswers = TestHelpers.CreateCaseStatusAnswers(caseStatusId: caseStatus.Id, startDate: currentActiveAnswersStartDate, min: 2, max: 2, groupId: groupId);
+            caseStatus.Answers = new List<CaseStatusAnswerInfrastructure>();
+            caseStatus.Answers.AddRange(currentActiveAnswers);
+            DatabaseContext.CaseStatuses.Add(caseStatus);
+            DatabaseContext.SaveChanges();
+
+            var requestAnswer = CaseStatusHelper.CreateCaseStatusRequestAnswers(min: 1, max: 1);
+
+            var request = CaseStatusHelper.CreateCaseStatusAnswerRequest(caseStatusId: caseStatus.Id, answers: requestAnswer, startDate: DateTime.Today.AddDays(-2));
+
+            _caseStatusGateway.ReplaceCaseStatusAnswers(request);
+
+            var updatedCaseStatus = DatabaseContext.CaseStatuses.FirstOrDefault();
+            updatedCaseStatus.Answers.Where(x => x.GroupId == groupId).Count().Should().Be(3);
+
+            var episodeEndReasonAnswer = updatedCaseStatus.Answers.Where(x => x.GroupId == groupId && x.Option == LACAnswerOption.EpisodeReason && x.Value == LACAnswerValue.X1).FirstOrDefault();
+            episodeEndReasonAnswer.Should().NotBeNull();
+            episodeEndReasonAnswer.StartDate.Should().Be(currentActiveAnswersStartDate);
+            episodeEndReasonAnswer.EndDate.Should().Be(request.StartDate);
+            episodeEndReasonAnswer.CreatedBy = request.CreatedBy;
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/CaseStatus/LAC/EndStatus.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Gateways;
 using SocialCareCaseViewerApi.V1.Infrastructure;
 using System;
 using System.Collections.Generic;
@@ -119,8 +120,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.CaseStatus.LAC
             var updatedCaseStatusWithScheduledStatusResponse = JsonConvert.DeserializeObject<List<CaseStatusResponse>>(updatedContentWithScheduledStatus).ToList();
 
             updatedCaseStatusWithScheduledStatusResponse.Count.Should().Be(1);
-            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Count.Should().Be(4);
-            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Last().StartDate.Should().Be(addScheduledAnswersRequest.StartDate);
+            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Count.Should().Be(5);
+            updatedCaseStatusWithScheduledStatusResponse.Single().Answers.Where(x => x.Option != LACAnswerOption.EpisodeReason).Last().StartDate.Should().Be(addScheduledAnswersRequest.StartDate);
 
             //patch case status to end it
             var endRequest = TestHelpers.CreateUpdateCaseStatusRequest(endDate: new DateTime(2000, 01, 11), email: _worker.Email, caseStatusId: caseStatusId, min: 1, max: 1);

--- a/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/CaseStatusGateway.cs
@@ -382,6 +382,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var activeAnswers = caseStatus
                                     .Answers
                                     .Where(x => x.DiscardedAt == null && x.EndDate == null);
+
             //discard future ones
             if (activeAnswers.Any(x => x.StartDate > DateTime.Today.Date))
             {
@@ -391,9 +392,19 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     answer.LastModifiedBy = request.CreatedBy;
                 }
             }
-            //end the current ones
+            //end the current ones and add new episode end reason (hard coded for data migration purposes)
             else
             {
+                caseStatus.Answers.Add(new CaseStatusAnswer()
+                {
+                    CreatedBy = request.CreatedBy,
+                    EndDate = request.StartDate,
+                    StartDate = activeAnswers.First().StartDate,
+                    Option = LACAnswerOption.EpisodeReason,
+                    Value = LACAnswerValue.X1,
+                    GroupId = activeAnswers.First().GroupId
+                });
+
                 foreach (var answer in activeAnswers)
                 {
                     answer.EndDate = request.StartDate;
@@ -424,5 +435,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             return caseStatus.ToDomain();
         }
+    }
+
+    public static class LACAnswerOption
+    {
+        public const string EpisodeReason = "episodeReason";
+    }
+    public static class LACAnswerValue
+    {
+        public const string X1 = "X1";
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1473

## Describe this PR

### *What is the problem we're trying to solve*

Currently we don't add end reasons for LAC episodes. Both imported data and Mosaic import template require these values for easy data handling.

### *What changes have we introduced*

Add hard coded `X1` `episodeReason` value for every episode that's ending.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly