### PR TITLE
Feat: fetch worker allocations by worker email

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/ListAllocationsRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/ListAllocationsRequestTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NUnit.Framework;
-using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
@@ -19,24 +18,39 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
 
 
         [Test]
-        public void ValidationFailsWhenMosaicIdAndWorkerIdAreNotProvided()
+        public void ValidationFailsWhenNoAttributesAreProvided()
         {
-            var errors = ValidationHelper.ValidateModel(_request);
+            var validator = new ListAllocationsRequestValidator();
+            var validationResults = validator.Validate(_request);
 
-            Assert.AreEqual(errors.Count, 1);
-            Assert.IsTrue(errors.Any(x => x.ErrorMessage.Contains("Please provide either mosaic_id or worker_id")));
+            Assert.IsFalse(validationResults.IsValid);
+            Assert.IsTrue(validationResults.Errors.Any(x => x.ErrorMessage.Contains("Please provide either mosaic_id, worker_id or worker_email")));
         }
 
         [Test]
-        public void ValidationFailsWhenBothMosaicIdAndWorkerIdAreProvided()
+        public void ValidationFailsWhenTwoOrMoreAttributesAreProvided()
         {
             _request.MosaicId = 50;
             _request.WorkerId = 30;
+            _request.WorkerEmail = "test@example.com";
 
-            var errors = ValidationHelper.ValidateModel(_request);
+            var validator = new ListAllocationsRequestValidator();
+            var validationResults = validator.Validate(_request);
 
-            Assert.AreEqual(errors.Count, 1);
-            Assert.IsTrue(errors.Any(x => x.ErrorMessage.Contains("Please provide only mosaic_id or worker_id, but not both")));
+            Assert.IsFalse(validationResults.IsValid);
+            Assert.IsTrue(validationResults.Errors.Any(x => x.ErrorMessage.Contains("Please provide only one of mosaic_id, worker_id or worker_email")));
+        }
+
+        [Test]
+        public void ValidationFailsWhenTheWorkerEmailProvidedIsNotAnEmailAddress()
+        {
+            _request.WorkerEmail = "not-an-email";
+
+            var validator = new ListAllocationsRequestValidator();
+            var validationResults = validator.Validate(_request);
+
+            Assert.IsFalse(validationResults.IsValid);
+            Assert.IsTrue(validationResults.Errors.Any(x => x.ErrorMessage.Contains("Please provide a valid email address for worker_email")));
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/AllocationsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/AllocationsUseCaseTests.cs
@@ -75,7 +75,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void ListAllocationsByWorkerEmail()
         {
-            var request = new ListAllocationsRequest() {WorkerEmail = "test@example.com"};
+            var request = new ListAllocationsRequest() { WorkerEmail = "test@example.com" };
             var gatewayResponse = new List<Allocation> { new Allocation() { AllocatedWorker = "Test Worker" } };
 
             _mockDatabaseGateway.Setup(x => x.SelectAllocations(0, 0, "test@example.com"))

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/AllocationsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/AllocationsUseCaseTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
@@ -68,6 +70,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
             var response = _allocationsUseCase.ExecutePost(new CreateAllocationRequest());
 
             response.Should().BeEquivalentTo(responseObject);
+        }
+
+        [Test]
+        public void ListAllocationsByWorkerEmail()
+        {
+            var request = new ListAllocationsRequest() {WorkerEmail = "test@example.com"};
+            var gatewayResponse = new List<Allocation> { new Allocation() { AllocatedWorker = "Test Worker" } };
+
+            _mockDatabaseGateway.Setup(x => x.SelectAllocations(0, 0, "test@example.com"))
+                .Returns(gatewayResponse);
+
+            var response = _allocationsUseCase.Execute(request);
+
+            response.Allocations.Should().BeEquivalentTo(gatewayResponse);
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListAllocationsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListAllocationsRequest.cs
@@ -11,6 +11,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromQuery(Name = "worker_id")]
         public long WorkerId { get; set; }
+
+        [FromQuery(Name = "worker_email")]
+        public string WorkerEmail { get; set; }
     }
 
     public class ListAllocationsRequestValidator : ValidationAttribute

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListAllocationsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListAllocationsRequest.cs
@@ -1,11 +1,13 @@
-using System.ComponentModel.DataAnnotations;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class ListAllocationsRequest
     {
-        [ListAllocationsRequestValidator]
         [FromQuery(Name = "mosaic_id")]
         public long MosaicId { get; set; }
 
@@ -16,24 +18,39 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public string WorkerEmail { get; set; }
     }
 
-    public class ListAllocationsRequestValidator : ValidationAttribute
+    public class ListAllocationsRequestValidator : AbstractValidator<ListAllocationsRequest>
     {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        public ListAllocationsRequestValidator()
         {
-            var request = (ListAllocationsRequest) validationContext.ObjectInstance;
-            var mosaicId = request.MosaicId;
-            var workerId = request.WorkerId;
+            RuleFor(x => x)
+                .Must(OneIsSet)
+                .WithMessage("Please provide either mosaic_id, worker_id or worker_email");
 
-            if (mosaicId == 0 && workerId == 0) //missing parameter will result in value 0
-            {
-                return new ValidationResult($"Please provide either mosaic_id or worker_id");
-            }
-            else if (mosaicId != 0 && workerId != 0)
-            {
-                return new ValidationResult($"Please provide only mosaic_id or worker_id, but not both");
-            }
+            RuleFor(x => x)
+                .Must(OnlyOneIsSet)
+                .WithMessage("Please provide only one of mosaic_id, worker_id or worker_email");
 
-            return ValidationResult.Success;
+            When(x => !String.IsNullOrEmpty(x.WorkerEmail), () =>
+            {
+                RuleFor(x => x.WorkerEmail)
+                    .EmailAddress()
+                    .WithMessage("Please provide a valid email address for worker_email");
+            });
+        }
+
+        private bool OnlyOneIsSet(ListAllocationsRequest request)
+        {
+            return new List<int>
+            {
+                request.MosaicId == 0 ? 0 : 1,
+                request.WorkerId == 0 ? 0 : 1,
+                String.IsNullOrEmpty(request.WorkerEmail) ? 0 : 1,
+            }.Sum() <= 1;
+        }
+
+        private bool OneIsSet(ListAllocationsRequest request)
+        {
+            return !(request.MosaicId == 0 && request.WorkerId == 0 && String.IsNullOrEmpty(request.WorkerEmail));
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -36,7 +36,7 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         /// Find allocations by Mosaic ID or officer email
         /// </summary>
         /// <response code="200">Success. Returns allocations related to the specified ID or officer email</response>
-        /// <response code="404">No allocations found for the specified mosaic id or worker id</response>
+        /// <response code="400">One or more request parameters are invalid or missing</response>
         [ProducesResponseType(typeof(AllocationList), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("allocations")]

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -33,9 +33,9 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         }
 
         /// <summary>
-        /// Find allocations by Mosaic ID or officer email
+        /// Find allocations by Mosaic ID, Worker ID or Worker Email
         /// </summary>
-        /// <response code="200">Success. Returns allocations related to the specified ID or officer email</response>
+        /// <response code="200">Success. Returns allocations related to the specified Mosaic ID, Worker ID or Worker Email</response>
         /// <response code="400">One or more request parameters are invalid or missing</response>
         [ProducesResponseType(typeof(AllocationList), StatusCodes.Status200OK)]
         [HttpGet]

--- a/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
+++ b/SocialCareCaseViewerApi/V1/Controllers/SocialCareCaseViewerApiController.cs
@@ -42,6 +42,14 @@ namespace SocialCareCaseViewerApi.V1.Controllers
         [Route("allocations")]
         public IActionResult GetAllocations([FromQuery] ListAllocationsRequest request)
         {
+            var validator = new ListAllocationsRequestValidator();
+            var validationResults = validator.Validate(request);
+
+            if (!validationResults.IsValid)
+            {
+                return BadRequest(validationResults.ToString());
+            }
+
             return Ok(_allocationUseCase.Execute(request));
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -66,25 +66,25 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     .Include(x => x.Person)
                     .ThenInclude(y => y.Addresses)
                     .Select(x => new Allocation()
-                        {
-                            Id = x.Id,
-                            PersonId = x.PersonId,
-                            PersonDateOfBirth = x.Person.DateOfBirth,
-                            PersonName = ToTitleCaseFullPersonName(x.Person.FirstName, x.Person.LastName),
-                            AllocatedWorker = x.Worker == null ? null : $"{x.Worker.FirstName} {x.Worker.LastName}",
-                            AllocatedWorkerTeam = x.Team.Name,
-                            WorkerType = x.Worker.Role,
-                            AllocationStartDate = x.AllocationStartDate,
-                            AllocationEndDate = x.AllocationEndDate,
-                            CaseStatus = x.CaseStatus,
-                            PersonAddress =
-                                x.Person.Addresses.FirstOrDefault(x =>
-                                    !string.IsNullOrEmpty(x.IsDisplayAddress) &&
-                                    x.IsDisplayAddress.ToUpper() == "Y") == null
-                                    ? null
-                                    : x.Person.Addresses.FirstOrDefault(x => x.IsDisplayAddress.ToUpper() == "Y")
-                                        .AddressLines
-                        }
+                    {
+                        Id = x.Id,
+                        PersonId = x.PersonId,
+                        PersonDateOfBirth = x.Person.DateOfBirth,
+                        PersonName = ToTitleCaseFullPersonName(x.Person.FirstName, x.Person.LastName),
+                        AllocatedWorker = x.Worker == null ? null : $"{x.Worker.FirstName} {x.Worker.LastName}",
+                        AllocatedWorkerTeam = x.Team.Name,
+                        WorkerType = x.Worker.Role,
+                        AllocationStartDate = x.AllocationStartDate,
+                        AllocationEndDate = x.AllocationEndDate,
+                        CaseStatus = x.CaseStatus,
+                        PersonAddress =
+                            x.Person.Addresses.FirstOrDefault(x =>
+                                !string.IsNullOrEmpty(x.IsDisplayAddress) &&
+                                x.IsDisplayAddress.ToUpper() == "Y") == null
+                                ? null
+                                : x.Person.Addresses.FirstOrDefault(x => x.IsDisplayAddress.ToUpper() == "Y")
+                                    .AddressLines
+                    }
                     ).AsNoTracking().ToList();
             }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/Interfaces/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/Interfaces/IDatabaseGateway.cs
@@ -13,7 +13,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways.Interfaces
          string lastName = null, string dateOfBirth = null, string postcode = null, string address = null, string contextFlag = null);
 
         AddNewResidentResponse AddNewResident(AddNewResidentRequest request);
-        List<Allocation> SelectAllocations(long mosaicId, long workerId);
+        List<Allocation> SelectAllocations(long mosaicId, long workerId, string workerEmail);
         CreateAllocationResponse CreateAllocation(CreateAllocationRequest request);
         string GetPersonIdByNCReference(string nfReference);
         string GetNCReferenceByPersonId(string personId);

--- a/SocialCareCaseViewerApi/V1/UseCase/AllocationsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/AllocationsUseCase.cs
@@ -16,7 +16,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             return new AllocationList
             {
-                Allocations = _databaseGateway.SelectAllocations(request.MosaicId, request.WorkerId)
+                Allocations = _databaseGateway.SelectAllocations(request.MosaicId, request.WorkerId, "")
             };
         }
 

--- a/SocialCareCaseViewerApi/V1/UseCase/AllocationsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/AllocationsUseCase.cs
@@ -16,7 +16,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             return new AllocationList
             {
-                Allocations = _databaseGateway.SelectAllocations(request.MosaicId, request.WorkerId, "")
+                Allocations = _databaseGateway.SelectAllocations(request.MosaicId, request.WorkerId, request.WorkerEmail)
             };
         }
 


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

The allocations endpoint only allows searching by Mosaic ID or Worker ID, this means some actions require multiple HTTP requests to get allocations from a worker's email address. This PR addresses this.

### *What changes have we introduced*

* Add worker_email to List Allocations request object.
* Add logic for fetching allocations by email address to the DB Gateway.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Add worker_email as an option to the swagger documentation.