### PR TITLE
SCT-1346- Add deleted records filter to get resident cases end point

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -565,6 +565,60 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void CaseSubmissionToCareCaseDataReturnsDeletedSetToFalseByDefault()
+        {
+            var request = TestHelpers.CreateListCasesRequest();
+            var submission = TestHelpers.CreateCaseSubmission();
+
+            var response = submission.ToCareCaseData(request);
+
+            response.Deleted.Should().BeFalse();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CaseSubmissionToCareCaseDataReturnsDeletedSetIfNotNull(bool deleted)
+        {
+            var request = TestHelpers.CreateListCasesRequest();
+            var submission = TestHelpers.CreateCaseSubmission(deleted: deleted);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.Deleted.Should().Be(deleted);
+        }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataResturnsDeletetionDetailsIfDeletedIsTrueAndIncludeDeletedRecordsInRequestIsTrue()
+        {
+            var request = TestHelpers.CreateListCasesRequest(includeDeletedRecords: true);
+            var submission = TestHelpers.CreateCaseSubmission(deleted: true);
+
+            var response = submission.ToCareCaseData(request);
+
+            var expectedDeletionDetails = new DeletionDetails()
+            {
+                DeletedAt = submission.DeletionDetails.DeletedAt,
+                DeletedBy = submission.DeletionDetails.DeletedBy,
+                DeleteReason = submission.DeletionDetails.DeleteReason,
+                DeleteRequestedBy = submission.DeletionDetails.DeleteRequestedBy
+            };
+
+            response.DeletionDetails.Should().BeEquivalentTo(expectedDeletionDetails);
+        }
+
+        [Test]
+        public void CaseSubmissionToCareCaseDataReturnsNullForDeletionDetailsIfdIncludeDeletedRecordsInRequestIsFalse()
+        {
+            var request = TestHelpers.CreateListCasesRequest(includeDeletedRecords: false);
+            var submission = TestHelpers.CreateCaseSubmission(deleted: true);
+
+            var response = submission.ToCareCaseData(request);
+
+            response.DeletionDetails.Should().BeNull();
+        }
+
+        [Test]
         public void ConvertMashReferralFromInfrastructureToDomain()
         {
             var infrastructureReferral = TestHelpers.CreateMashReferral();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -521,13 +521,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             long? mosaicId = null,
             string? firstName = null,
             string? lastName = null,
-            string? workerEmail = null)
+            string? workerEmail = null,
+            bool? includeDeletedRecords = null)
         {
             return new Faker<ListCasesRequest>()
                 .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString())
                 .RuleFor(r => r.FirstName, firstName)
                 .RuleFor(r => r.LastName, lastName)
-                .RuleFor(r => r.WorkerEmail, workerEmail);
+                .RuleFor(r => r.WorkerEmail, workerEmail)
+                .RuleFor(r => r.IncludeDeletedRecords, includeDeletedRecords ?? false);
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -62,9 +62,74 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void GetResidentCasesCallMongoGatewayAndReturnsDeletedCasesCount()
+        {
+            var request = TestHelpers.CreateListCasesRequest(1L);
+
+            var expectedResponse = new List<CaseSubmission>
+            {
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), deleted: true)
+            };
+
+            _mockDatabaseGateWay.Setup(x => x.GetNCReferenceByPersonId(request.MosaicId)).Returns(request.MosaicId ?? "");
+            _mockDatabaseGateWay.Setup(x => x.GetPersonIdByNCReference(request.MosaicId)).Returns(request.MosaicId ?? "");
+            _mockProcessDataGateway.Setup(x => x.GetProcessData(request, request.MosaicId)).Returns(
+                () => new Tuple<IEnumerable<CareCaseData>, int>(new List<CareCaseData>(), 0));
+
+            _mockMongoGateway
+                .Setup(x => x.LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
+                    It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns((expectedResponse, 2));
+
+            _mockMongoGateway.Setup(x =>
+                x.GetRecordsCountByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
+                    It.IsAny<FilterDefinition<CaseSubmission>>()))
+                .Returns(1);
+
+            var response = _caseRecordsUseCase.GetResidentCases(request);
+
+            response.DeletedRecordsCount.Should().Be(1);
+        }
+
+        [Test]
+        public void GetResidentsCasesCallsMongoGatewayToGetDeletedRecordsCountForTheGivenFilter()
+        {
+            var request = TestHelpers.CreateListCasesRequest(mosaicId: 1L);
+
+            var expectedJsonFilter = "{ \"Residents._id\" : 1, \"SubmissionState\" : 1, \"Deleted\" : true }";
+
+            var expectedResponse = new List<CaseSubmission>
+            {
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? "")),
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""))
+            };
+
+            _mockDatabaseGateWay.Setup(x => x.GetNCReferenceByPersonId(request.MosaicId)).Returns(request.MosaicId ?? "");
+            _mockDatabaseGateWay.Setup(x => x.GetPersonIdByNCReference(request.MosaicId)).Returns(request.MosaicId ?? "");
+
+            _mockProcessDataGateway.Setup(x => x.GetProcessData(request, request.MosaicId)).Returns(() => new Tuple<IEnumerable<CareCaseData>, int>(new List<CareCaseData>(), 0));
+
+            _mockMongoGateway
+                .Setup(x => x.LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
+                    It.IsAny<FilterDefinition<CaseSubmission>>(), It.IsAny<Pagination>()))
+                .Returns((expectedResponse, 2));
+
+            _mockMongoGateway.Setup(x => x.GetRecordsCountByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], It.IsAny<FilterDefinition<CaseSubmission>>())).Returns(1);
+
+            _caseRecordsUseCase.GetResidentCases(request);
+
+            _mockMongoGateway.Verify(
+                x => x.GetRecordsCountByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions],
+                        It.Is<FilterDefinition<CaseSubmission>>(innerFilter => innerFilter.RenderToJson().Equals(expectedJsonFilter))), Times.Once);
+        }
+
+
+        [Test]
         public void GenerateFilterDefinitionForDefaultCase()
         {
-            const string expectedJsonQuery = "{ \"SubmissionState\" : 1 }";
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
             var emptyRequest = TestHelpers.CreateListCasesRequest();
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(emptyRequest);
@@ -75,7 +140,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GenerateFilterDefinitionWithProvidedMosaicId()
         {
-            const string expectedJsonQuery = "{ \"Residents._id\" : 1, \"SubmissionState\" : 1 }";
+            const string expectedJsonQuery = "{ \"Residents._id\" : 1, \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
             const long mosaicId = 1L;
             var requestWithMosaicId = TestHelpers.CreateListCasesRequest(mosaicId: mosaicId);
 
@@ -87,7 +152,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GenerateFilterDefinitionWithProvidedFirstName()
         {
-            const string expectedJsonQuery = "{ \"Residents.FirstName\" : /^testington$/i, \"SubmissionState\" : 1 }";
+            const string expectedJsonQuery = "{ \"Residents.FirstName\" : /^testington$/i, \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
             const string firstName = "testington";
             var requestWithFirstName = TestHelpers.CreateListCasesRequest(firstName: firstName);
 
@@ -99,7 +164,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GenerateFilterDefinitionWithProvidedLastName()
         {
-            const string expectedJsonQuery = "{ \"Residents.LastName\" : /^toastington$/i, \"SubmissionState\" : 1 }";
+            const string expectedJsonQuery = "{ \"Residents.LastName\" : /^toastington$/i, \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
             const string lastName = "toastington";
             var requestWithLastName = TestHelpers.CreateListCasesRequest(lastName: lastName);
 
@@ -111,11 +176,59 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
         [Test]
         public void GenerateFilterDefinitionWithProvidedWorkerEmail()
         {
-            const string expectedJsonQuery = "{ \"CreatedBy.Email\" : \"foo@hackney.gov.uk\", \"SubmissionState\" : 1 }";
+            const string expectedJsonQuery = "{ \"CreatedBy.Email\" : \"foo@hackney.gov.uk\", \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
             const string workerEmail = "foo@hackney.gov.uk";
             var requestWithLastName = TestHelpers.CreateListCasesRequest(workerEmail: workerEmail);
 
             var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithLastName);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithProvidedIncludeDeletedRecordsFlagSetToTrue()
+        {
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1 }";
+            const bool includeDeletedRecordsFlag = true;
+            var requestWithIncludeDeletedRecordsFlag = TestHelpers.CreateListCasesRequest(includeDeletedRecords: includeDeletedRecordsFlag);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithIncludeDeletedRecordsFlag);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithProvidedIncludeDeletedRecordsFlagSetToFalse()
+        {
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
+            const bool includeDeletedRecordsFlag = false;
+            var requestWithIncludeDeletedRecordsFlag = TestHelpers.CreateListCasesRequest(includeDeletedRecords: includeDeletedRecordsFlag);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithIncludeDeletedRecordsFlag);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithAddDeletedRecordsFilterTrueReturnsFilterWithDeletedRecordsExcludedWhenTheyAreNotRequested()
+        {
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1, \"Deleted\" : { \"$ne\" : true } }";
+            const bool includeDeletedRecordsFlag = false;
+            var requestWithIncludeDeletedRecordsFlag = TestHelpers.CreateListCasesRequest(includeDeletedRecords: includeDeletedRecordsFlag);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithIncludeDeletedRecordsFlag, addDeletedRecordsFilter: true);
+
+            response.RenderToJson().Should().Be(expectedJsonQuery);
+        }
+
+        [Test]
+        public void GenerateFilterDefinitionWithAddDeletedRecordsFilterFalseReturnsFilterWithDeletedRecordsIncludedWhetherTheyAreRequestedOrNot()
+        {
+            const string expectedJsonQuery = "{ \"SubmissionState\" : 1 }";
+            const bool includeDeletedRecordsFlag = false;
+            var requestWithIncludeDeletedRecordsFlag = TestHelpers.CreateListCasesRequest(includeDeletedRecords: includeDeletedRecordsFlag);
+
+            var response = CaseRecordsUseCase.GenerateFilterDefinition(requestWithIncludeDeletedRecordsFlag, addDeletedRecordsFilter: false);
 
             response.RenderToJson().Should().Be(expectedJsonQuery);
         }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -41,5 +41,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromQuery(Name = "order_by")]
         public string? OrderBy { get; set; } = null!;
+
+        [FromQuery(Name = "include_deleted_records")]
+        public bool IncludeDeletedRecords { get; set; } = false;
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseData.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseData.cs
@@ -1,5 +1,6 @@
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
+using SocialCareCaseViewerApi.V1.Infrastructure;
 
 #nullable enable
 namespace SocialCareCaseViewerApi.V1.Boundary.Response
@@ -34,5 +35,10 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         [JsonProperty("title")]
         public string? Title { get; set; }
 
+        [JsonProperty("deleted")]
+        public bool Deleted { get; set; } = false;
+
+        [JsonProperty("deletionDetails")]
+        public DeletionDetails? DeletionDetails { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseDataList.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseDataList.cs
@@ -6,5 +6,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
     {
         public List<CareCaseData> Cases { get; set; }
         public int? NextCursor { get; set; }
+        public long DeletedRecordsCount { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/EntityFactory.cs
@@ -202,7 +202,9 @@ namespace SocialCareCaseViewerApi.V1.Factories
                 DateOfEvent = caseSubmission.DateOfEvent?.ToString("O") ?? caseSubmission.CreatedAt.ToString("O"),
                 CaseFormUrl = caseSubmission.SubmissionId.ToString(),
                 FormType = "flexible-form",
-                Title = caseSubmission.Title
+                Title = caseSubmission.Title,
+                Deleted = (bool) (caseSubmission.Deleted == null ? false : caseSubmission.Deleted),
+                DeletionDetails = listCasesRequest.IncludeDeletedRecords ? caseSubmission.DeletionDetails : null
             };
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1543

## Describe this PR

### *What is the problem we're trying to solve*

We have implemented deleted submissions filter to form submissions end point, but that doesn't cover the cases end point that's used by the front end to populate person's timeline. 

### *What changes have we introduced*

1. Add `include_deleted_records` flag support to `GET` `/cases/` end point
2. Update the `CaseRecordsUseCase` to not return deleted records by default
3. Add `DeletedRecordsCount` property to the return object, so front end knows there are deleted records for the given filter (typically for particular mosaic_id when used for timeline)

We don't currently support any delete operation against records in `form_data` collection and that's out of scope of this PR. That support has to be developed later if required.

`DeletedRecordsCount` is populated on each call regardless whether deleted records are requested or not. This will cause additional mongo database call, so performance should be monitored closely after deployment. Call is simple with mosaic_id and deleted properties, so existing index  should help with the performance.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly