### PR TITLE
SCT-1548 Add include deleted records count flag support

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -592,7 +592,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? workerEmail = null,
             long? personID = null,
             bool? pruneUnfinished = null,
-            bool? includeDeletedRecords = null)
+            bool? includeDeletedRecords = null,
+            bool? includeDeletedRecordsCount = null)
         {
             return new Faker<QueryCaseSubmissionsRequest>()
                 .RuleFor(q => q.FormId, formId)
@@ -607,7 +608,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(q => q.WorkerEmail, workerEmail)
                 .RuleFor(q => q.PersonID, personID)
                 .RuleFor(q => q.PruneUnfinished, f => pruneUnfinished ?? f.Random.Bool())
-                .RuleFor(q => q.IncludeDeletedRecords, f => includeDeletedRecords ?? f.Random.Bool());
+                .RuleFor(q => q.IncludeDeletedRecords, f => includeDeletedRecords ?? f.Random.Bool())
+                .RuleFor(q => q.IncludeDeletedRecordsCount, f => includeDeletedRecordsCount ?? f.Random.Bool());
         }
 
         private static List<CaseStatusValue> CreateCaseStatusValues(int? min, int? max)

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/QueryCaseSubmissionsRequest.cs
@@ -46,6 +46,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromQuery(Name = "includeDeletedRecords")]
         public bool IncludeDeletedRecords { get; set; } = false;
+
+        [FromQuery(Name = "includeDeletedRecordsCount")]
+        public bool IncludeDeletedRecordsCount { get; set; } = false;
     }
 
     public class QueryCaseSubmissionsValidator : AbstractValidator<QueryCaseSubmissionsRequest>

--- a/SocialCareCaseViewerApi/V1/Helpers/PaginatedExtended.cs
+++ b/SocialCareCaseViewerApi/V1/Helpers/PaginatedExtended.cs
@@ -2,6 +2,6 @@ namespace SocialCareCaseViewerApi.V1.Helpers
 {
     public class PaginatedExtended<T> : Paginated<T>
     {
-        public long DeletedItemsCount { get; set; }
+        public long? DeletedItemsCount { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/FormSubmissionsUseCase.cs
@@ -184,10 +184,15 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             var filter = GenerateFilter(request);
 
-            var deletedRecordsFilter = GenerateFilter(request, addDeletedRecordsFilter: false);
-            deletedRecordsFilter &= Builders<CaseSubmission>.Filter.Eq(s => s.Deleted, true);
+            long? deletedRecordsCount = null;
 
-            var deletedRecordsCount = _mongoGateway.GetRecordsCountByFilter(_collectionName, deletedRecordsFilter);
+            if (request.IncludeDeletedRecordsCount)
+            {
+                var deletedRecordsFilter = GenerateFilter(request, addDeletedRecordsFilter: false);
+                deletedRecordsFilter &= Builders<CaseSubmission>.Filter.Eq(s => s.Deleted, true);
+
+                deletedRecordsCount = _mongoGateway.GetRecordsCountByFilter(_collectionName, deletedRecordsFilter);
+            }
 
             var pagination = new Pagination { Page = request.Page, Size = request.Size };
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1548

## Describe this PR

### *What is the problem we're trying to solve*

Currently form submissions end point returns the deleted records count on every call. After reviewing the potential perormance hit we have agreed to change the integration with the front end so we only fetch this data if it's absolutely required by the UI. Only very limited number of users will ever need that data. 

### *What changes have we introduced*

Add new `includeDeletedRecordsCount` boolean property to `QueryCaseSubmissionsRequest`. Defaults to false.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly