### PR TITLE
SCT-1548 add deleted records count filter to cases endpoint

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -523,14 +523,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? firstName = null,
             string? lastName = null,
             string? workerEmail = null,
-            bool? includeDeletedRecords = null)
+            bool? includeDeletedRecords = null,
+            bool? includeDeletedRecordsCount = null)
         {
             return new Faker<ListCasesRequest>()
                 .RuleFor(r => r.MosaicId, mosaicId == null ? null : mosaicId.ToString())
                 .RuleFor(r => r.FirstName, firstName)
                 .RuleFor(r => r.LastName, lastName)
                 .RuleFor(r => r.WorkerEmail, workerEmail)
-                .RuleFor(r => r.IncludeDeletedRecords, includeDeletedRecords ?? false);
+                .RuleFor(r => r.IncludeDeletedRecords, includeDeletedRecords ?? false)
+                .RuleFor(r => r.IncludeDeletedRecordsCount, includeDeletedRecordsCount ?? false);
         }
 
         public static UpdateCaseSubmissionRequest UpdateCaseSubmissionRequest(

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/ListCasesRequest.cs
@@ -44,5 +44,8 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [FromQuery(Name = "include_deleted_records")]
         public bool IncludeDeletedRecords { get; set; } = false;
+
+        [FromQuery(Name = "include_deleted_records_count")]
+        public bool IncludeDeletedRecordsCount { get; set; } = false;
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseDataList.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/CareCaseDataList.cs
@@ -6,6 +6,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
     {
         public List<CareCaseData> Cases { get; set; }
         public int? NextCursor { get; set; }
-        public long DeletedRecordsCount { get; set; }
+        public long? DeletedRecordsCount { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -54,17 +54,21 @@ namespace SocialCareCaseViewerApi.V1.UseCase
 
             var (response, totalCount) = _processDataGateway.GetProcessData(request, ncId);
             var allCareCaseData = response.ToList();
-            long deletedRecordsCount = 0;
+            long? deletedRecordsCount = null;
 
             if (request.MosaicId != null || request.WorkerEmail != null || request.FormName != null || request.FirstName != null || request.LastName != null)
             {
                 var filter = GenerateFilterDefinition(request);
 
-                var deletedRecordsFilter = GenerateFilterDefinition(request, addDeletedRecordsFilter: false);
+                if (request.IncludeDeletedRecordsCount)
+                {
+                    var deletedRecordsFilter = GenerateFilterDefinition(request, addDeletedRecordsFilter: false);
 
-                deletedRecordsFilter &= Builders<CaseSubmission>.Filter.Eq(x => x.Deleted, true);
+                    deletedRecordsFilter &= Builders<CaseSubmission>.Filter.Eq(x => x.Deleted, true);
 
-                deletedRecordsCount = _mongoGateway.GetRecordsCountByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], deletedRecordsFilter);
+                    deletedRecordsCount = _mongoGateway.GetRecordsCountByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], deletedRecordsFilter);
+
+                }
 
                 var caseSubmissions = _mongoGateway
                     .LoadRecordsByFilter(MongoConnectionStrings.Map[Collection.ResidentCaseSubmissions], filter, null)


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1548

## Describe this PR

### *What is the problem we're trying to solve*

Current deleted records count is always returned by the get cases end point. Thus causes unnecessary MongoDB calls and therefore affects performance.

### *What changes have we introduced*

Update cases end point not to return the deleted cases count unless specifically requested by setting the `include_deleted_records_count` flag to true.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly