### PR TITLE
Add total count of results to person search

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllResidentsTests.cs
@@ -34,7 +34,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void IfThereAreNoResidentsReturnsAnEmptyList()
         {
-            _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20).Should().BeEmpty();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
+
+            listOfPersons.Should().BeEmpty();
         }
 
         [Test]
@@ -47,7 +49,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person>() { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
 
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person2.Id).ToResidentInformationResponse());
@@ -61,7 +63,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person.Id);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person.Id);
 
             listOfPersons.First().AddressList.Should().BeNull();
         }
@@ -73,7 +75,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person.Id);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person.Id);
 
             listOfPersons.First().PhoneNumber.Should().BeNull();
         }
@@ -88,7 +90,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person2.Id);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, id: person2.Id);
 
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person2.Id.ToString());
@@ -105,7 +107,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
 
             listOfPersons
                 .Where(p => p.MosaicId.Equals(person.Id.ToString()))
@@ -126,7 +128,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.PhoneNumbers.Add(phoneNumber);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
 
             listOfPersons
                 .Where(p => p.MosaicId.Equals(phoneNumber.Person.Id.ToString()))
@@ -145,7 +147,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom");
 
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
@@ -162,7 +164,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "iaso");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "iaso");
 
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
@@ -179,7 +181,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, lastname: "tessellate");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, lastname: "tessellate");
 
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
@@ -196,7 +198,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, lastname: "sell");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, lastname: "sell");
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person2.Id).ToResidentInformationResponse());
@@ -210,7 +212,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", lastname: "Tessellate");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", lastname: "Tessellate");
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person.Id.ToString());
         }
@@ -223,7 +225,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", lastname: "ssellat");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", lastname: "ssellat");
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person.Id.ToString());
         }
@@ -244,7 +246,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS");
 
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person1.Id.ToString());
@@ -262,7 +264,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();
 
-            _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS").Should().BeEmpty();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E83 AS");
+
+            listOfPersons.Should().BeEmpty();
         }
 
         [Test]
@@ -280,7 +284,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
 
             listOfPersons.Count.Should().Be(1);
 
@@ -307,7 +311,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY").ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
             listOfPersons.Count.Should().Be(1);
             listOfPersons
                 .First(p => p.MosaicId.Equals(person1.Id.ToString()))
@@ -330,7 +334,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.PhoneNumbers.Add(phoneNumber);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY").ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
 
             var personUnderTest = listOfPersons
                 .First(p => p.MosaicId.Equals(person.Id.ToString()));
@@ -350,7 +354,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, dateOfBirth: person1.DateOfBirth.Value.ToString("yyyy-MM-dd")).ToList(); //Format passed by FE
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, dateOfBirth: person1.DateOfBirth.Value.ToString("yyyy-MM-dd")); //Format passed by FE
 
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
@@ -370,7 +374,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, contextflag: "A").ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, contextflag: "A");
 
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
@@ -400,7 +404,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address3);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", postcode: "E8 1DY").ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, firstname: "ciasom", postcode: "E8 1DY");
 
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person1.Id.ToString());
@@ -421,7 +425,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, postcode: "E8 1DY");
 
             listOfPersons.Count.Should().Be(1);
             listOfPersons.First().MosaicId.Should().Be(person.Id.ToString());
@@ -448,7 +452,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(address2);
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, address: addressQuery).ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20, address: addressQuery);
 
             listOfPersons.Count.Should().Be(1);
 
@@ -470,7 +474,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person>() { person1, person2, person3, person4, person5 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 3).ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 3);
 
             listOfPersons.Count.Should().Be(3);
 
@@ -492,7 +496,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person>() { person1, person2, person3, person4, person5 });
             DatabaseContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(cursor: 2, limit: 3).ToList();
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 2, limit: 3);
+
             listOfPersons.Count.Should().Be(3);
             listOfPersons
                 .Select(p => p.MosaicId)
@@ -513,7 +518,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.SaveChanges();
 
 
-            var listOfPersons = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
+            var (listOfPersons, _) = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
 
             listOfPersons
                 .First(p => p.MosaicId.Equals(person.Id.ToString()))
@@ -536,7 +541,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Addresses.Add(currentAddress);
             DatabaseContext.SaveChanges();
 
-            var response = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
+            var (response, _) = _classUnderTest.GetResidentsBySearchCriteria(0, 20);
             response.First().Uprn.Should().Be(currentAddress.Uprn.ToString());
         }
 
@@ -550,13 +555,28 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var response = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
+            var (response, _) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 20);
 
             response.Count.Should().Be(2);
 
             response.Any(x => x.MosaicId == person1.Id.ToString()).Should().BeTrue();
             response.Any(x => x.MosaicId == person2.Id.ToString()).Should().BeFalse();
             response.Any(x => x.MosaicId == person3.Id.ToString()).Should().BeTrue();
+        }
+
+        [Test]
+        public void ReturnsTotalPersonCountForGivenFilterIgnoringPagingAndCursor()
+        {
+            var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "foo");
+            var person2 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "foobar");
+            var person3 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "foobarbar");
+
+            DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
+            DatabaseContext.SaveChanges();
+
+            var (_, totalCount) = _classUnderTest.GetResidentsBySearchCriteria(cursor: 0, limit: 1, firstname: "foo");
+
+            totalCount.Should().Be(3);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
@@ -32,7 +32,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
             _residentUseCase = new ResidentUseCase(_mockDatabaseGateway.Object);
 
             _mockDatabaseGateway.Setup(x => x.GetResidentsBySearchCriteria(It.IsAny<int>(), It.IsAny<int>(), null, null, null, null, null, null, null))
-               .Returns(new List<ResidentInformation>());
+               .Returns((new List<ResidentInformation>(), 0));
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
 
             _mockDatabaseGateway.Setup(x =>
                     x.GetResidentsBySearchCriteria(0, 10, null, null, null, null, null, null, null))
-                .Returns(residents.ToList());
+                .Returns((residents.ToList(), 0));
 
             _residentUseCase.GetResidentsByQuery(new ResidentQueryParam(), cursor: 0, limit: 10).NextCursor.Should().Be(expectedNextCursor);
         }
@@ -100,7 +100,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
 
             _mockDatabaseGateway.Setup(x =>
                     x.GetResidentsBySearchCriteria(0, 10, null, null, null, null, null, null, null))
-                .Returns(residents.ToList());
+                .Returns((residents.ToList(), 0));
 
             _residentUseCase.GetResidentsByQuery(new ResidentQueryParam(), cursor: 0, limit: 10).NextCursor.Should().Be("");
         }
@@ -111,7 +111,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
             var request = new ResidentQueryParam();
 
             _mockDatabaseGateway.Setup(x => x.GetResidentsBySearchCriteria(0, 10, null, null, null, null, null, null, null))
-              .Returns(new List<ResidentInformation>()).Verifiable();
+              .Returns((new List<ResidentInformation>(), 0)).Verifiable();
 
             _residentUseCase.GetResidentsByQuery(request, cursor: 0, limit: 4);
 
@@ -124,7 +124,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
             var request = new ResidentQueryParam() { MosaicId = "43" };
 
             _mockDatabaseGateway.Setup(x => x.GetResidentsBySearchCriteria(0, 10, null, null, null, null, null, null, null))
-              .Returns(new List<ResidentInformation>());
+              .Returns((new List<ResidentInformation>(), 0));
 
             _mockDatabaseGateway.Setup(x => x.GetPersonIdsByEmergencyId(It.IsAny<string>())).Returns(new List<long>());
 
@@ -236,6 +236,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
             _residentUseCase.GetResidentsByQuery(request, cursor: 0, limit: 4);
 
             _mockDatabaseGateway.Verify(x => x.GetPersonsByListOfIds(listOfMatchingIds));
+        }
+
+        [Test]
+        public void ReturnsTotalCountOfResultsInReturnObject()
+        {
+            var request = new ResidentQueryParam() { FirstName = "foo" };
+            var totalCount = 3;
+
+            _mockDatabaseGateway.Setup(x => x.GetResidentsBySearchCriteria(0, 10, null, request.FirstName, null, null, null, null, null)).Returns((new List<ResidentInformation>(), totalCount));
+
+            var response = _residentUseCase.GetResidentsByQuery(request, 0, 1);
+
+            response.TotalCount.Should().Be(totalCount);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Residents/GetResidentsByQueryTests.cs
@@ -119,6 +119,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Residents
         }
 
         [Test]
+        public void SetsTotalCountWhenMosaicIdIsProvided()
+        {
+            var request = new ResidentQueryParam() { MosaicId = "123" };
+            var totalCount = 3;
+            var listOfIds = new List<long> { 1, 2, 3 };
+
+            _mockDatabaseGateway.Setup(x => x.GetResidentsBySearchCriteria(0, 10, null, null, null, null, null, null, null))
+              .Returns((new List<ResidentInformation>(), totalCount));
+
+            _mockDatabaseGateway.Setup(x => x.GetPersonIdsByEmergencyId(It.IsAny<string>())).Returns(listOfIds);
+            _mockDatabaseGateway.Setup(x => x.GetPersonsByListOfIds(listOfIds)).Returns(new List<Person>() { new Person(), new Person(), new Person() });
+
+            var result = _residentUseCase.GetResidentsByQuery(request, cursor: 0, limit: 10);
+
+            result.TotalCount.Should().Be(totalCount);
+        }
+
+        [Test]
         public void DoesNotCallGetResidentsBySearchCriteriaMethodWhenMosaicIdIsProvided()
         {
             var request = new ResidentQueryParam() { MosaicId = "43" };

--- a/SocialCareCaseViewerApi/V1/Boundary/Response/ResidentInformationList.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Response/ResidentInformationList.cs
@@ -7,5 +7,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Response
         public List<ResidentInformation> Residents { get; set; }
 
         public string NextCursor { get; set; }
+
+        public int TotalCount { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/Interfaces/IDatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/Interfaces/IDatabaseGateway.cs
@@ -9,7 +9,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways.Interfaces
 {
     public interface IDatabaseGateway
     {
-        List<ResidentInformation> GetResidentsBySearchCriteria(int cursor, int limit, long? id = null, string firstName = null,
+        (List<ResidentInformation>, int) GetResidentsBySearchCriteria(int cursor, int limit, long? id = null, string firstName = null,
          string lastName = null, string dateOfBirth = null, string postcode = null, string address = null, string contextFlag = null);
 
         AddNewResidentResponse AddNewResident(AddNewResidentRequest request);

--- a/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
@@ -39,6 +39,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         public ResidentInformationList GetResidentsByQuery(ResidentQueryParam rqp, int cursor, int limit)
         {
             long? mosaicId = null;
+            int totalCount = 0;
+            List<ResidentInformation> matchingResidents = new List<ResidentInformation>();
 
             if (!string.IsNullOrEmpty(rqp.MosaicId))
             {
@@ -86,7 +88,7 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                 limit = limit < 10 ? 10 : limit;
                 limit = limit > 100 ? 100 : limit;
 
-                residents.AddRange(_databaseGateway.GetResidentsBySearchCriteria(
+                (matchingResidents, totalCount) = _databaseGateway.GetResidentsBySearchCriteria(
                     cursor: cursor,
                     limit: limit,
                     id: mosaicId,
@@ -95,7 +97,10 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                     dateOfBirth: rqp.DateOfBirth,
                     postcode: rqp.Postcode,
                     address: rqp.Address,
-                    contextFlag: rqp.ContextFlag));
+                    contextFlag: rqp.ContextFlag);
+
+
+                residents.AddRange(matchingResidents);
             }
 
             var nextCursor = residents.Count == limit ? residents.Max(r => long.Parse(r.MosaicId)).ToString() : "";
@@ -103,7 +108,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
             return new ResidentInformationList
             {
                 Residents = residents,
-                NextCursor = nextCursor
+                NextCursor = nextCursor,
+                TotalCount = totalCount
             };
         }
     }

--- a/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/ResidentUseCase.cs
@@ -82,6 +82,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                         .Select(x => x.ToResidentInformationResponse())
                         .ToList());
                 }
+
+                totalCount = residents.Count;
             }
             else
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1483

## Describe this PR

### *What is the problem we're trying to solve*

ASC Finance have implemented the resident search end point for their person search. They have also implemented custom paging on their app. Currently they can't set up the paging correctly because the search end point doesn't return the total number of results for the given filter.

### *What changes have we introduced*

Added total count to response object so clients can see the amount of result for a given filter ignoring paging and cursor

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Make sure the extra property hasn't caused any issues for the existing front end.
