### PR TITLE
Assign worker id on contact decision

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateMashReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateMashReferralTests.cs
@@ -29,6 +29,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
+        public void WhenUpdateTypeIsContactDecisionEitherEmailOrIdMustBeProvided()
+        {
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "CONTACT-DECISION");
+            request.WorkerId = null;
+            request.WorkerEmail = null;
+
+            var validationResult = _validator.Validate(request);
+
+            validationResult.ToString().Should().Be("Must provide a valid worker id or email");
+        }
+
+        [Test]
         public void WhenUpdateTypeIsInitialDecisionRequiresUrgentContactMustBeProvided()
         {
             var request = TestHelpers.CreateUpdateMashReferral(updateType: "INITIAL-DECISION");

--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateMashReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateMashReferralTests.cs
@@ -41,6 +41,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
         }
 
         [Test]
+        public void WhenUpdateTypeIsContactDecisionOnlyEmailOrIdMustBeProvided()
+        {
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "CONTACT-DECISION");
+
+            var validationResult = _validator.Validate(request);
+
+            validationResult.ToString().Should().Be("Do not provide both worker id and worker email address");
+        }
+
+        [Test]
         public void WhenUpdateTypeIsInitialDecisionRequiresUrgentContactMustBeProvided()
         {
             var request = TestHelpers.CreateUpdateMashReferral(updateType: "INITIAL-DECISION");

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -172,6 +172,18 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             response.Should().BeEquivalentTo(mashReferral.ToDomain());
         }
 
+        [Test]
+        public void SuccessfulUpdateOfMashReferralAssignsWorkerUsingEmailAndReturnsMashReferralDomain()
+        {
+            var worker = MashReferralHelper.SaveWorkerToDatabase(DatabaseContext);
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER", workerEmail: worker.Email);
+            request.WorkerId = null;
+
+            var response = _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
+
+            response.Should().BeEquivalentTo(mashReferral.ToDomain());
+        }
 
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -49,7 +49,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 
             act.Should().Throw<MashReferralStageMismatchException>()
-                .WithMessage($"Referral {mashReferral.Id} is in stage \"{mashReferral.Stage}\", this request requires the referral to be in stage \"screening\"");
+                .WithMessage($"Referral {mashReferral.Id} is in stage '{mashReferral.Stage}', this request requires the referral to be in stage 'SCREENING'");
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 
             act.Should().Throw<MashReferralStageMismatchException>()
-                .WithMessage($"Referral {mashReferral.Id} is in stage \"{mashReferral.Stage}\", this request requires the referral to be in stage \"contact\"");
+                .WithMessage($"Referral {mashReferral.Id} is in stage '{mashReferral.Stage}', this request requires the referral to be in stage 'CONTACT'");
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 
             act.Should().Throw<MashReferralStageMismatchException>()
-                .WithMessage($"Referral {mashReferral.Id} is in stage \"{mashReferral.Stage}\", this request requires the referral to be in stage \"initial\"");
+                .WithMessage($"Referral {mashReferral.Id} is in stage '{mashReferral.Stage}', this request requires the referral to be in stage 'INITIAL'");
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 
             act.Should().Throw<MashReferralStageMismatchException>()
-                .WithMessage($"Referral {mashReferral.Id} is in stage \"{mashReferral.Stage}\", this request requires the referral to be in stage \"final\"");
+                .WithMessage($"Referral {mashReferral.Id} is in stage '{mashReferral.Stage}', this request requires the referral to be in stage 'FINAL'");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -101,6 +101,21 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
                 .WithMessage($"Worker with id {workerId} not found");
         }
 
+
+        [Test]
+        public void UpdatingMashReferralThrowsWorkerNotFoundExceptionWhenWorkerIsNotFoundUsingEmail()
+        {
+            var workerEmail = _faker.Person.Email;
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER", workerEmail: workerEmail);
+            request.WorkerId = null;
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext);
+
+            Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
+
+            act.Should().Throw<WorkerNotFoundException>()
+                .WithMessage($"Worker with email {workerEmail} not found");
+        }
+
         [Test]
         public void SuccessfulUpdateOfMashReferralFromContactToInitialUpdatesAndReturnsMashReferralDomain()
         {

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -89,6 +89,19 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
         }
 
         [Test]
+        public void UpdatingMashReferralThrowsWorkerNotFoundExceptionWhenWorkerIsNotFoundUsingId()
+        {
+            var workerId = _faker.Random.Long(100);
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+
+            Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
+
+            act.Should().Throw<MashReferralNotFoundException>()
+                .WithMessage($"Worker with id {workerId} not found");
+        }
+
+        [Test]
         public void SuccessfulUpdateOfMashReferralFromContactToInitialUpdatesAndReturnsMashReferralDomain()
         {
             var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -91,13 +91,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
         [Test]
         public void UpdatingMashReferralThrowsWorkerNotFoundExceptionWhenWorkerIsNotFoundUsingId()
         {
-            var workerId = _faker.Random.Long(100);
-            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
-            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+            var workerId = _faker.Random.Int();
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER", workerId: workerId);
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext);
 
             Action act = () => _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 
-            act.Should().Throw<MashReferralNotFoundException>()
+            act.Should().Throw<WorkerNotFoundException>()
                 .WithMessage($"Worker with id {workerId} not found");
         }
 
@@ -145,16 +145,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             response.Should().BeEquivalentTo(mashReferral.ToDomain());
         }
 
+        [Test]
+        public void SuccessfulUpdateOfMashReferralAssignsWorkerAndReturnsMashReferralDomain()
+        {
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
 
-        // [Test]
-        // public void SuccessfulUpdateOfMashReferralAssignsWorkerAndReturnsMashReferralDomain()
-        // {
-        //     var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
-        //     var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
-        //
-        //     var response = _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
-        //
-        //     response.Should().BeEquivalentTo(mashReferral.ToDomain());
-        // }
+            var response = _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
+
+            response.Should().BeEquivalentTo(mashReferral.ToDomain());
+        }
+
+
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -163,8 +163,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
         [Test]
         public void SuccessfulUpdateOfMashReferralAssignsWorkerAndReturnsMashReferralDomain()
         {
+            var worker = MashReferralHelper.SaveWorkerToDatabase(DatabaseContext);
             var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
-            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
+            var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER", workerId: worker.Id);
 
             var response = _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateReferralTests.cs
@@ -131,5 +131,17 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
 
             response.Should().BeEquivalentTo(mashReferral.ToDomain());
         }
+
+
+        // [Test]
+        // public void SuccessfulUpdateOfMashReferralAssignsWorkerAndReturnsMashReferralDomain()
+        // {
+        //     var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+        //     var request = TestHelpers.CreateUpdateMashReferral(updateType: "ASSIGN-WORKER");
+        //
+        //     var response = _mashReferralGateway.UpdateReferral(request, mashReferral.Id);
+        //
+        //     response.Should().BeEquivalentTo(mashReferral.ToDomain());
+        // }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/MashReferralHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/MashReferralHelper.cs
@@ -12,5 +12,13 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             databaseContext.SaveChanges();
             return referral;
         }
+
+        public static Worker SaveWorkerToDatabase(DatabaseContext databaseContext)
+        {
+            var worker = TestHelpers.CreateWorker();
+            databaseContext.Workers.Add(worker);
+            databaseContext.SaveChanges();
+            return worker;
+        }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -687,13 +687,16 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? decision = null,
             bool? requiresUrgentContact = null,
             string? referralCategory = null,
+            string? stage = null,
             int? workerId = null)
         {
             var updateTypes = new List<string> { "SCREENING-DECISION", "INITIAL-DECISION", "ASSIGN-WORKER", "CONTACT-DECISION" };
+            var stageTypes = new List<string> { "SCREENING", "INITIAL", "FINAL", "CONTACT" };
 
             return new Faker<UpdateMashReferral>()
                 .RuleFor(x => x.WorkerEmail, f => workerEmail ?? f.Person.Email)
                 .RuleFor(x => x.UpdateType, f => updateType ?? f.PickRandom(updateTypes))
+                .RuleFor(x => x.Stage, f => stage ?? f.PickRandom(stageTypes))
                 .RuleFor(x => x.Decision, f => decision ?? f.Random.String2(100))
                 .RuleFor(x => x.RequiresUrgentContact, f => requiresUrgentContact ?? f.Random.Bool())
                 .RuleFor(x => x.ReferralCategory, f => referralCategory ?? f.Random.String2(100))

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -689,7 +689,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             string? referralCategory = null,
             int? workerId = null)
         {
-            var updateTypes = new List<string> { "SCREENING-DECISION", "INITIAL-DECISION", "ASSIGN-WORKER" };
+            var updateTypes = new List<string> { "SCREENING-DECISION", "INITIAL-DECISION", "ASSIGN-WORKER", "CONTACT-DECISION" };
 
             return new Faker<UpdateMashReferral>()
                 .RuleFor(x => x.WorkerEmail, f => workerEmail ?? f.Person.Email)

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -150,20 +150,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             return (caseStatuses, person);
         }
 
-        public static MashReferral SaveMashReferralToDatabase(DatabaseContext databaseContext)
+        public static MashReferral SaveMashReferralToDatabase(DatabaseContext databaseContext, string stage = null)
         {
-            var mashrefferal = new Faker<MashReferral>()
+            var mashreferral = new Faker<MashReferral>()
                 .RuleFor(w => w.Id, f => f.UniqueIndex)
                 .RuleFor(w => w.Referrer, f => f.Person.FullName)
                 .RuleFor(w => w.RequestedSupport, f => f.Random.String2(20))
                 .RuleFor(w => w.ReferralDocumentURI, f => f.Random.String2(20))
-                .RuleFor(w => w.Stage, f => f.Random.String2(20))
+                .RuleFor(w => w.Stage, f => stage ?? f.Random.String2(20))
                 .Generate(); ;
 
-            databaseContext.MashReferrals.Add(mashrefferal);
+            databaseContext.MashReferrals.Add(mashreferral);
             databaseContext.SaveChanges();
 
-            return mashrefferal;
+            return mashreferral;
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralOnContactDecisionTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralOnContactDecisionTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
+{
+    [TestFixture]
+    public class AssignWorkerToMashReferralOnContactDecisionTests : IntegrationTestSetup<Startup>
+    {
+        private SocialCareCaseViewerApi.V1.Infrastructure.Worker _existingDbWorker;
+        private SocialCareCaseViewerApi.V1.Infrastructure.MashReferral _existingDbReferral;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Clear test database of any rows in the database
+            DatabaseContext.Teams.RemoveRange(DatabaseContext.Teams);
+            DatabaseContext.Workers.RemoveRange(DatabaseContext.Workers);
+            DatabaseContext.MashReferrals.RemoveRange(DatabaseContext.MashReferrals);
+
+            // Create existing referral and unrelated worker
+            var (existingDbWorker, _) = IntegrationTestHelpers.SetupExistingWorker(DatabaseContext);
+            var existingDbReferral = IntegrationTestHelpers.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+            _existingDbWorker = existingDbWorker;
+            _existingDbReferral = existingDbReferral;
+        }
+
+        [Test]
+        public async Task SuccessfulPatchAssignsWorkerToReferralOnContactDecision()
+        {
+            var request = TestHelpers.CreateUpdateMashReferral();
+            request.WorkerId = _existingDbWorker.Id;
+            request.WorkerEmail = null;
+            request.UpdateType = "CONTACT-DECISION";
+            request.RequiresUrgentContact = false;
+            var postUri = new Uri($"/api/v1/mash-referral/{_existingDbReferral.Id}", UriKind.Relative);
+            var serializedRequest = JsonSerializer.Serialize(request);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var updatedMashReferralResponse = await Client.PatchAsync(postUri, requestContent).ConfigureAwait(true);
+
+            updatedMashReferralResponse.StatusCode.Should().Be(200);
+            _existingDbReferral.WorkerId.Should().Equals(_existingDbWorker.Id);
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralTests.cs
@@ -34,8 +34,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
         public async Task SuccessfulPatchAssignsWorkerToReferral()
         {
             var request = TestHelpers.CreateUpdateMashReferral();
-            request.WorkerId = _existingDbWorker.Id;
-            request.WorkerEmail = null;
+            request.WorkerId = null;
+            request.WorkerEmail = _existingDbWorker.Email;
             request.UpdateType = "ASSIGN-WORKER";
             var postUri = new Uri($"/api/v1/mash-referral/{_existingDbReferral.Id}", UriKind.Relative);
             var serializedRequest = JsonSerializer.Serialize(request);

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/AssignWorkerToMashReferralTests.cs
@@ -34,8 +34,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
         public async Task SuccessfulPatchAssignsWorkerToReferral()
         {
             var request = TestHelpers.CreateUpdateMashReferral();
-            request.WorkerId = null;
-            request.WorkerEmail = _existingDbWorker.Email;
+            request.WorkerId = _existingDbWorker.Id;
+            request.WorkerEmail = null;
             request.UpdateType = "ASSIGN-WORKER";
             var postUri = new Uri($"/api/v1/mash-referral/{_existingDbReferral.Id}", UriKind.Relative);
             var serializedRequest = JsonSerializer.Serialize(request);

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
@@ -1,4 +1,3 @@
-
 using FluentValidation;
 
 #nullable enable
@@ -20,43 +19,51 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         {
             RuleFor(x => x.Decision)
                 .NotNull()
-                .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "SCREENING-DECISION" || x.UpdateType == "FINAL-DECISION")
-                    .WithMessage("Must provide a decision");
+                .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "SCREENING-DECISION" ||
+                           x.UpdateType == "FINAL-DECISION")
+                .WithMessage("Must provide a decision");
             RuleFor(x => x.Decision)
                 .MinimumLength(1)
-                    .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "SCREENING-DECISION" || x.UpdateType == "FINAL-DECISION")
+                .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "SCREENING-DECISION" ||
+                           x.UpdateType == "FINAL-DECISION")
                 .WithMessage("Must provide a decision");
             RuleFor(x => x.ReferralCategory)
                 .NotNull()
-                    .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "FINAL-DECISION")
-                    .WithMessage("Must provide a referral category");
+                .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "FINAL-DECISION")
+                .WithMessage("Must provide a referral category");
             RuleFor(x => x.ReferralCategory)
                 .MinimumLength(1)
-                    .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "FINAL-DECISION")
-                    .WithMessage("Must provide a referral category");
+                .When(x => x.UpdateType == "INITIAL-DECISION" || x.UpdateType == "FINAL-DECISION")
+                .WithMessage("Must provide a referral category");
             RuleFor(x => x.RequiresUrgentContact)
                 .NotNull()
                 .When(x => x.UpdateType == "CONTACT-DECISION" || x.UpdateType == "INITIAL-DECISION" ||
                            x.UpdateType == "SCREENING-DECISION" || x.UpdateType == "FINAL-DECISION")
                 .WithMessage("Must provide if urgent contact is required");
-            RuleFor(x => x.WorkerId )
+            RuleFor(x => x.WorkerId)
                 .NotNull()
                 .GreaterThan(0)
-                .When(x => x.WorkerEmail == null && x.WorkerId != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
+                .When(x => x.WorkerEmail == null && x.WorkerId != null &&
+                           (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
                 .WithMessage("Must provide a valid worker id or email");
             RuleFor(x => x.WorkerEmail)
                 .NotNull()
                 .EmailAddress()
-                .When(x => x.WorkerId == null && x.WorkerEmail != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
+                .When(x => x.WorkerId == null && x.WorkerEmail != null &&
+                           (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
                 .WithMessage("Must provide a valid worker id or email");
-            When(x => x.WorkerEmail == null && x.WorkerId == null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"), () =>
-            {
-                RuleFor(x => x.WorkerId).NotNull().WithMessage("Must provide a valid worker id or email");
-            });
-            When(x => x.WorkerEmail != null && x.WorkerId != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"), () =>
-            {
-                RuleFor(x => x.WorkerId).Null().WithMessage("Do not provide both worker id and worker email address");
-            });
+            When(
+                x => x.WorkerEmail == null && x.WorkerId == null &&
+                     (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"),
+                () => { RuleFor(x => x.WorkerId).NotNull().WithMessage("Must provide a valid worker id or email"); });
+            When(
+                x => x.WorkerEmail != null && x.WorkerId != null &&
+                     (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"),
+                () =>
+                {
+                    RuleFor(x => x.WorkerId).Null()
+                        .WithMessage("Do not provide both worker id and worker email address");
+                });
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
@@ -39,21 +39,21 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
                 .When(x => x.UpdateType == "CONTACT-DECISION" || x.UpdateType == "INITIAL-DECISION" ||
                            x.UpdateType == "SCREENING-DECISION" || x.UpdateType == "FINAL-DECISION")
                 .WithMessage("Must provide if urgent contact is required");
-            RuleFor(x => x.WorkerId)
+            RuleFor(x => x.WorkerId )
                 .NotNull()
                 .GreaterThan(0)
-                .When(x => x.WorkerEmail == null && x.WorkerId != null && x.UpdateType == "ASSIGN-WORKER")
+                .When(x => x.WorkerEmail == null && x.WorkerId != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
                 .WithMessage("Must provide a valid worker id or email");
             RuleFor(x => x.WorkerEmail)
                 .NotNull()
                 .EmailAddress()
-                .When(x => x.WorkerId == null && x.WorkerEmail != null && x.UpdateType == "ASSIGN-WORKER")
+                .When(x => x.WorkerId == null && x.WorkerEmail != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"))
                 .WithMessage("Must provide a valid worker id or email");
-            When(x => x.WorkerEmail == null && x.WorkerId == null && x.UpdateType == "ASSIGN-WORKER", () =>
+            When(x => x.WorkerEmail == null && x.WorkerId == null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"), () =>
             {
                 RuleFor(x => x.WorkerId).NotNull().WithMessage("Must provide a valid worker id or email");
             });
-            When(x => x.WorkerEmail != null && x.WorkerId != null && x.UpdateType == "ASSIGN-WORKER", () =>
+            When(x => x.WorkerEmail != null && x.WorkerId != null && (x.UpdateType == "ASSIGN-WORKER" || x.UpdateType == "CONTACT-DECISION"), () =>
             {
                 RuleFor(x => x.WorkerId).Null().WithMessage("Do not provide both worker id and worker email address");
             });

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashReferral.cs
@@ -8,6 +8,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         public string? WorkerEmail { get; set; }
         public int? WorkerId { get; set; }
         public string UpdateType { get; set; } = null!;
+        public string? Stage { get; set; }
         public string? Decision { get; set; }
         public string? ReferralCategory { get; set; }
         public bool? RequiresUrgentContact { get; set; }

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
-using MongoDB.Bson.Serialization.IdGenerators;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -171,7 +171,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 }
                 else if (request.WorkerEmail != null)
                 {
-                    referral.WorkerId = _databaseContext.Workers.Where(w => w.Email == request.WorkerEmail).FirstOrDefault().Id;;
+                    referral.WorkerId = _databaseContext.Workers.Where(w => w.Email == request.WorkerEmail).FirstOrDefault().Id;
                 }
             }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -116,7 +116,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 referral.ContactDecisionCreatedAt = _systemTime.Now;
                 referral.ContactDecisionUrgentContactRequired = request.RequiresUrgentContact;
                 referral.Stage = "INITIAL";
-                referral.WorkerId = null;
+                referral.WorkerId = request.WorkerId;
             }
 
             if (request.UpdateType.Equals("INITIAL-DECISION"))

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -110,7 +110,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 if (!referral.Stage.Equals("CONTACT"))
                 {
-                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage \"{referral.Stage}\", this request requires the referral to be in stage \"contact\"");
+                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage '{referral.Stage}', this request requires the referral to be in stage 'CONTACT'");
                 }
 
                 referral.ContactDecisionCreatedAt = _systemTime.Now;
@@ -123,7 +123,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 if (!referral.Stage.Equals("INITIAL"))
                 {
-                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage \"{referral.Stage}\", this request requires the referral to be in stage \"initial\"");
+                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage '{referral.Stage}', this request requires the referral to be in stage 'INITIAL'");
                 }
 
                 referral.InitialDecisionCreatedAt = _systemTime.Now;
@@ -138,7 +138,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 if (!referral.Stage.Equals("SCREENING"))
                 {
-                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage \"{referral.Stage}\", this request requires the referral to be in stage \"screening\"");
+                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage '{referral.Stage}', this request requires the referral to be in stage 'SCREENING'");
                 }
 
                 referral.ScreeningCreatedAt = _systemTime.Now;
@@ -152,7 +152,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 if (!referral.Stage.Equals("FINAL"))
                 {
-                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage \"{referral.Stage}\", this request requires the referral to be in stage \"final\"");
+                    throw new MashReferralStageMismatchException($"Referral {referral.Id} is in stage '{referral.Stage}', this request requires the referral to be in stage 'FINAL'");
                 }
 
                 referral.FinalDecisionCreatedAt = _systemTime.Now;
@@ -165,7 +165,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (request.UpdateType.Equals("ASSIGN-WORKER"))
             {
-                referral.WorkerId = request.WorkerId;
+                if (request.WorkerId != null)
+                {
+                    referral.WorkerId = request.WorkerId;
+                }
+                else if (request.WorkerEmail != null)
+                {
+                    referral.WorkerId = _databaseContext.Workers.Where(w => w.Email == request.WorkerEmail).FirstOrDefault().Id;;
+                }
             }
 
             _databaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -165,6 +165,12 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             if (request.UpdateType.Equals("ASSIGN-WORKER"))
             {
+
+
+                if (_databaseContext.Workers.Find(request.WorkerId) == null)
+                {
+                    throw new WorkerNotFoundException($"Worker with id {request.WorkerId} not found");
+                }
                 if (request.WorkerId != null)
                 {
                     referral.WorkerId = request.WorkerId;


### PR DESCRIPTION
## Link to JIRA ticket

[JIRA ticket](https://hackney.atlassian.net/browse/SCT-1613).

## Describe this PR

### *What is the problem we're trying to solve*

Previously API for MASH referrals didn't include functionality to assign Worker to the Referral when request of type 'CONTACT-DECISION' was made. The proposed code changes allows that. 
+ expanded on functionality for update type of 'ASSIGN-WORKER'.

### *What changes have we introduced*

Rules in the boundary to enforce request to supply only for Worker email or Id must with tests.
Gateway code to support functionality with tests.
Integration test with additional helper to check the full journey.
Correctly formatted error messages and slightly better formatting in gateway tests to improve readability.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

n/a