### PR TITLE
SCT-1628 increase db instance size to enable encryption

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -93,7 +93,7 @@ module "historical_postgres_db_staging" {
   subnet_ids           = data.aws_subnet_ids.staging.ids
   db_engine            = "postgres"
   db_engine_version    = "11." //use 11. to ignore minor version upgrades
-  db_instance_class    = "db.t2.micro"
+  db_instance_class    = "db.t2.small"
   db_allocated_storage = 20
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.social_care_historical_postgres_username.value


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1628](https://hackney.atlassian.net/browse/SCT-1628)

## Describe this PR

### *What is the problem we're trying to solve*

Terraform failed with ` Error: Error creating DB Instance: InvalidParameterCombination: DB Instance class db.t2.micro does not support encryption at rest` when [PR#560](https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/560) was merged

### *What changes have we introduced*

`db.t2.micro` does not support encryption at rest which is forced by the module. This increases the instance size to smallest size that supports encryption. Instances that do not support encryption are listed here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
