### PR TITLE
(SCT-1628) Specify db engine version

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -92,7 +92,7 @@ module "historical_postgres_db_staging" {
   db_port              = 5432
   subnet_ids           = data.aws_subnet_ids.staging.ids
   db_engine            = "postgres"
-  db_engine_version    = "11." //use 11. to ignore minor version upgrades
+  db_engine_version    = "11.12"
   db_instance_class    = "db.t2.small"
   db_allocated_storage = 20
   maintenance_window   = "sun:10:00-sun:10:30"


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1628](https://hackney.atlassian.net/browse/SCT-1628)

## Describe this PR

### *What is the problem we're trying to solve*
Terraform failed with `Error: Error creating DB Instance: InvalidParameterCombination: Cannot find version 11. for postgres` when [PR#561](https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/561) was merged.

Db engine version must be specified when the db is initially set up. It can be changed to `v.` later to ignore minor version upgrades

### *What changes have we introduced*
Specify the db engine version. The version matches the one used for other DBs for the solution on staging.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly