### PR TITLE
Unlink resident from referral

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/MashResident/UpdateMashResidentTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/MashResident/UpdateMashResidentTests.cs
@@ -28,7 +28,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers.MashResident
         }
 
         [Test]
-        public void WhenSuccessfullyUpdateActionReturns204AndUpdatedMashResident()
+        public void WhenSuccessfullyUpdateActionReturns200AndUpdatedMashResident()
         {
             var matchingPersonId = _faker.Random.Long(3, 4);
             var request = TestHelpers.CreateMashResidentUpdateRequest(matchingPersonId);

--- a/SocialCareCaseViewerApi.Tests/V1/Controllers/MashResident/UpdateMashResidentTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Controllers/MashResident/UpdateMashResidentTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using SocialCareCaseViewerApi.Tests.V1.Helpers;
 using SocialCareCaseViewerApi.V1.Controllers;
+using SocialCareCaseViewerApi.V1.Exceptions;
 using SocialCareCaseViewerApi.V1.Factories;
 using SocialCareCaseViewerApi.V1.UseCase.Interfaces;
 
@@ -43,6 +44,38 @@ namespace SocialCareCaseViewerApi.Tests.V1.Controllers.MashResident
 
             response?.StatusCode.Should().Be(200);
             response?.Value.Should().BeEquivalentTo(updatedMashResident);
+        }
+
+        [Test]
+        public void WhenMashResidentUseCaseUpdateMashResidentThrowsPersonNotFoundExceptionReturnsBadRequest()
+        {
+            var matchingPersonId = _faker.Random.Long(3, 4);
+            var request = TestHelpers.CreateMashResidentUpdateRequest(matchingPersonId);
+            const string errorMessage = "test-error-message";
+            _mashResidentUseCase
+                .Setup(x => x.UpdateMashResident(request, _fakeMashResidentId))
+                .Throws(new PersonNotFoundException(errorMessage));
+
+            var response = _mashResidentController.UpdateMashResident(request, _fakeMashResidentId) as ObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(errorMessage);
+        }
+
+        [Test]
+        public void WhenMashResidentUseCaseUpdateMashResidentThrowsMashResidentNotFoundExceptionReturnsBadRequest()
+        {
+            var matchingPersonId = _faker.Random.Long(3, 4);
+            var request = TestHelpers.CreateMashResidentUpdateRequest(matchingPersonId);
+            const string errorMessage = "test-error-message";
+            _mashResidentUseCase
+                .Setup(x => x.UpdateMashResident(request, _fakeMashResidentId))
+                .Throws(new MashResidentNotFoundException(errorMessage));
+
+            var response = _mashResidentController.UpdateMashResident(request, _fakeMashResidentId) as ObjectResult;
+
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be(errorMessage);
         }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateMashResidentDetailsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/MashReferralGatewayTests/UpdateMashResidentDetailsTests.cs
@@ -35,7 +35,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             DatabaseContext.SaveChanges();
 
             var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
-            var mashResident = MashResidentHelper.SaveMashResidentToDatabase(DatabaseContext, mashReferral.Id);
+            var mashResident = MashResidentHelper.SaveMashResidentToDatabase(DatabaseContext, mashReferral.Id, null);
 
             mashResident.SocialCareId.Should().BeNull();
 
@@ -44,6 +44,25 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.MashReferralGatewayTests
             var response = _mashReferralGateway.UpdateMashResident(request, mashResident.Id);
             response.Should().BeEquivalentTo(mashResident.ToDomain());
             response.SocialCareId.Should().Be(personMatch.Id);
+        }
+
+        [Test]
+        public void WhenMashResidentWithLinkedPersonExistAndUpdateTypeIsUnLinkPersonUpdatesSocialCareIdValueOnMashResident()
+        {
+            var personMatch = TestHelpers.CreatePerson();
+            DatabaseContext.Persons.Add(personMatch);
+            DatabaseContext.SaveChanges();
+
+            var mashReferral = MashReferralHelper.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+            var mashResident = MashResidentHelper.SaveMashResidentToDatabase(DatabaseContext, mashReferral.Id, personMatch.Id);
+
+            mashResident.SocialCareId.Should().NotBeNull();
+
+            var request = TestHelpers.CreateMashResidentUpdateRequest(personMatch.Id, updateType: "UNLINK-PERSON");
+
+            var response = _mashReferralGateway.UpdateMashResident(request, mashResident.Id);
+            response.Should().BeEquivalentTo(mashResident.ToDomain());
+            response.SocialCareId.Should().BeNull();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/MashResidentHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/MashResidentHelper.cs
@@ -4,9 +4,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 {
     public static class MashResidentHelper
     {
-        public static MashResident SaveMashResidentToDatabase(DatabaseContext databaseContext, long? mashReferralId = null)
+        public static MashResident SaveMashResidentToDatabase(DatabaseContext databaseContext, long? mashReferralId = null, long? socialCareId = null)
         {
             var resident = TestHelpers.CreateMashResident(mashReferralId);
+            resident.SocialCareId = socialCareId;
             databaseContext.MashResidents.Add(resident);
             databaseContext.SaveChanges();
             return resident;

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -703,7 +703,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
 
         }
 
-        public static MashResident CreateMashResident(long? mashReferralId = null)
+        public static MashResident CreateMashResident(long? mashReferralId = null, long? socialCareId = null)
         {
             return new Faker<MashResident>()
                 .RuleFor(x => x.Id, f => f.UniqueIndex)
@@ -716,13 +716,15 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 .RuleFor(x => x.School, f => f.Address.City())
                 .RuleFor(x => x.Address, f => f.Address.FullAddress())
                 .RuleFor(x => x.Postcode, f => f.Address.ZipCode())
-                .RuleFor(x => x.MashReferralId, f => mashReferralId ?? f.UniqueIndex);
+                .RuleFor(x => x.MashReferralId, f => mashReferralId ?? f.UniqueIndex)
+                .RuleFor(x => x.SocialCareId, f => socialCareId ?? f.UniqueIndex);
         }
 
-        public static UpdateMashResidentRequest CreateMashResidentUpdateRequest(long? matchId = null)
+        public static UpdateMashResidentRequest CreateMashResidentUpdateRequest(long? matchId = null, string? updateType = null)
         {
             return new Faker<UpdateMashResidentRequest>()
-                .RuleFor(x => x.SocialCareId, f => matchId ?? f.Random.Long(1, 10));
+                .RuleFor(x => x.SocialCareId, f => matchId ?? f.Random.Long(1, 10))
+                .RuleFor(x => x.UpdateType, f => updateType ?? f.Random.String());
         }
 
         public static MashReferral CreateMashReferral(string? stage = null, long? mashReferralId = null)

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -167,7 +167,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             return mashreferral;
         }
 
-        public static MashResident CreateUnLinkedMashResident(DatabaseContext databaseContext, MashReferral referral, DbPerson personMatch = null)
+        public static MashResident CreateMashResident(DatabaseContext databaseContext, MashReferral referral, DbPerson personMatch = null)
         {
             var mashResident = new Faker<MashResident>()
                 .RuleFor(r => r.Id, f => f.UniqueIndex)
@@ -180,11 +180,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 .RuleFor(r => r.School, f => f.Random.String2(1, 5))
                 .RuleFor(r => r.Address, f => f.Address.State())
                 .RuleFor(r => r.Postcode, f => f.Address.ZipCode())
+                .RuleFor(r => r.SocialCareId, f => personMatch?.Id ?? f.UniqueIndex)
                 .Generate();
 
             mashResident.MashReferralId = referral.Id;
             mashResident.MashReferral = referral;
-            mashResident.SocialCareId = null;
+
 
             databaseContext.MashResidents.Add(mashResident);
             databaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/LinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/LinkClientInReferralToResidentInSystem.cs
@@ -26,13 +26,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
             _existingDbPerson = IntegrationTestHelpers.CreateExistingPerson(DatabaseContext);
             _mashReferral = IntegrationTestHelpers.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
 
-            _unlinkedResident = IntegrationTestHelpers.CreateUnLinkedMashResident(DatabaseContext, _mashReferral, _existingDbPerson);
+            _unlinkedResident = IntegrationTestHelpers.CreateMashResident(DatabaseContext, _mashReferral, _existingDbPerson);
         }
 
         [Test]
         public async Task SuccessfulLinkingMatchesMashResidentToSavedPersonInDb()
         {
-            _unlinkedResident.SocialCareId.Should().BeNull();
+            _unlinkedResident.SocialCareId = null;
+            DatabaseContext.SaveChanges();
 
             var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
             var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
@@ -51,54 +52,54 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
             patchMashResidentResponse.SocialCareId.Should().Be(_existingDbPerson.Id);
         }
 
-        [Test]
-        public async Task WhenTheRequestIsInvalidReturnsBadRequestStatusCode()
-        {
-            const string request = "invalid request";
-            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-        }
-
-        [Test]
-        public async Task WhenTheRequestContainsAnIncorrectPersonIdReturnsRelevantErrorMessage()
-        {
-            var incorrectPersonId = _existingDbPerson.Id + 20;
-            var request = new UpdateMashResidentRequest { SocialCareId = incorrectPersonId };
-            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var patchResponse = JsonConvert.DeserializeObject<string>(content);
-
-            patchResponse.Should().Be($"Person with id {incorrectPersonId} not found");
-        }
-
-
-        [Test]
-        public async Task WhenTheRequestContainsAnIncorrectMashResidentIdReturnsRelevantErrorMessage()
-        {
-            var incorrectMashResidentId = _unlinkedResident.Id + 20;
-            var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
-            var patchUri = new Uri($"/api/v1/mash-resident/{incorrectMashResidentId}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var patchResponse = JsonConvert.DeserializeObject<string>(content);
-
-            patchResponse.Should().Be($"MASH resident with id {incorrectMashResidentId} not found");
-        }
+        // [Test]
+        // public async Task WhenTheRequestIsInvalidReturnsBadRequestStatusCode()
+        // {
+        //     const string request = "invalid request";
+        //     var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+        //     var serializedRequest = JsonSerializer.Serialize(request);
+        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+        //
+        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+        //
+        //     response.StatusCode.Should().Be(400);
+        // }
+        //
+        // [Test]
+        // public async Task WhenTheRequestContainsAnIncorrectPersonIdReturnsRelevantErrorMessage()
+        // {
+        //     var incorrectPersonId = _existingDbPerson.Id + 20;
+        //     var request = new UpdateMashResidentRequest { SocialCareId = incorrectPersonId };
+        //     var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+        //     var serializedRequest = JsonSerializer.Serialize(request);
+        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+        //
+        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+        //
+        //     response.StatusCode.Should().Be(400);
+        //     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+        //     var patchResponse = JsonConvert.DeserializeObject<string>(content);
+        //
+        //     patchResponse.Should().Be($"Person with id {incorrectPersonId} not found");
+        // }
+        //
+        //
+        // [Test]
+        // public async Task WhenTheRequestContainsAnIncorrectMashResidentIdReturnsRelevantErrorMessage()
+        // {
+        //     var incorrectMashResidentId = _unlinkedResident.Id + 20;
+        //     var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
+        //     var patchUri = new Uri($"/api/v1/mash-resident/{incorrectMashResidentId}", UriKind.Relative);
+        //     var serializedRequest = JsonSerializer.Serialize(request);
+        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+        //
+        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+        //
+        //     response.StatusCode.Should().Be(400);
+        //     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+        //     var patchResponse = JsonConvert.DeserializeObject<string>(content);
+        //
+        //     patchResponse.Should().Be($"MASH resident with id {incorrectMashResidentId} not found");
+        // }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/LinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/LinkClientInReferralToResidentInSystem.cs
@@ -51,55 +51,5 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
 
             patchMashResidentResponse.SocialCareId.Should().Be(_existingDbPerson.Id);
         }
-
-        // [Test]
-        // public async Task WhenTheRequestIsInvalidReturnsBadRequestStatusCode()
-        // {
-        //     const string request = "invalid request";
-        //     var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-        //     var serializedRequest = JsonSerializer.Serialize(request);
-        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-        //
-        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-        //
-        //     response.StatusCode.Should().Be(400);
-        // }
-        //
-        // [Test]
-        // public async Task WhenTheRequestContainsAnIncorrectPersonIdReturnsRelevantErrorMessage()
-        // {
-        //     var incorrectPersonId = _existingDbPerson.Id + 20;
-        //     var request = new UpdateMashResidentRequest { SocialCareId = incorrectPersonId };
-        //     var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-        //     var serializedRequest = JsonSerializer.Serialize(request);
-        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-        //
-        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-        //
-        //     response.StatusCode.Should().Be(400);
-        //     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        //     var patchResponse = JsonConvert.DeserializeObject<string>(content);
-        //
-        //     patchResponse.Should().Be($"Person with id {incorrectPersonId} not found");
-        // }
-        //
-        //
-        // [Test]
-        // public async Task WhenTheRequestContainsAnIncorrectMashResidentIdReturnsRelevantErrorMessage()
-        // {
-        //     var incorrectMashResidentId = _unlinkedResident.Id + 20;
-        //     var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
-        //     var patchUri = new Uri($"/api/v1/mash-resident/{incorrectMashResidentId}", UriKind.Relative);
-        //     var serializedRequest = JsonSerializer.Serialize(request);
-        //     var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-        //
-        //     var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-        //
-        //     response.StatusCode.Should().Be(400);
-        //     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-        //     var patchResponse = JsonConvert.DeserializeObject<string>(content);
-        //
-        //     patchResponse.Should().Be($"MASH resident with id {incorrectMashResidentId} not found");
-        // }
     }
 }

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
@@ -34,8 +34,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
         public async Task SuccessfulUnLinkingRemovesLinkFromMashResidentToSavedPersonInDb()
         {
             _linkedResident.SocialCareId.Should().NotBeNull();
-
-            var request = new UpdateMashResidentRequest {UpdateType = "UNLINK-PERSON"};
+            var request = new UpdateMashResidentRequest { UpdateType = "UNLINK-PERSON" };
             var patchUri = new Uri($"/api/v1/mash-resident/{_linkedResident.Id}", UriKind.Relative);
             var serializedRequest = JsonSerializer.Serialize(request);
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.V1.Boundary.Requests;
+using SocialCareCaseViewerApi.V1.Boundary.Response;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+using MashReferral = SocialCareCaseViewerApi.V1.Infrastructure.MashReferral;
+
+namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
+{
+    [TestFixture]
+    public class LinkClientInReferralToResidentInSystem : IntegrationTestSetup<Startup>
+    {
+        private MashReferral _mashReferral;
+        private MashResident _unlinkedResident;
+        private Person _existingDbPerson;
+
+        [SetUp]
+        public void Setup()
+        {
+            _existingDbPerson = IntegrationTestHelpers.CreateExistingPerson(DatabaseContext);
+            _mashReferral = IntegrationTestHelpers.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
+
+            _unlinkedResident = IntegrationTestHelpers.CreateUnLinkedMashResident(DatabaseContext, _mashReferral, _existingDbPerson);
+        }
+
+        [Test]
+        public async Task SuccessfulLinkingMatchesMashResidentToSavedPersonInDb()
+        {
+            _unlinkedResident.SocialCareId.Should().BeNull();
+
+            var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
+            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+            var serializedRequest = JsonSerializer.Serialize(request);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var linkMashResidentResponse = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+
+            linkMashResidentResponse.StatusCode.Should().Be(200);
+
+            _unlinkedResident.SocialCareId.Should().Be(_existingDbPerson.Id);
+
+            var content = await linkMashResidentResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var patchMashResidentResponse = JsonConvert.DeserializeObject<MashResidentResponse>(content);
+
+            patchMashResidentResponse.SocialCareId.Should().Be(_existingDbPerson.Id);
+        }
+
+        [Test]
+        public async Task WhenTheRequestIsInvalidReturnsBadRequestStatusCode()
+        {
+            const string request = "invalid request";
+            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+            var serializedRequest = JsonSerializer.Serialize(request);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task WhenTheRequestContainsAnIncorrectPersonIdReturnsRelevantErrorMessage()
+        {
+            var incorrectPersonId = _existingDbPerson.Id + 20;
+            var request = new UpdateMashResidentRequest { SocialCareId = incorrectPersonId };
+            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+            var serializedRequest = JsonSerializer.Serialize(request);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(400);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var patchResponse = JsonConvert.DeserializeObject<string>(content);
+
+            patchResponse.Should().Be($"Person with id {incorrectPersonId} not found");
+        }
+
+
+        [Test]
+        public async Task WhenTheRequestContainsAnIncorrectMashResidentIdReturnsRelevantErrorMessage()
+        {
+            var incorrectMashResidentId = _unlinkedResident.Id + 20;
+            var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
+            var patchUri = new Uri($"/api/v1/mash-resident/{incorrectMashResidentId}", UriKind.Relative);
+            var serializedRequest = JsonSerializer.Serialize(request);
+            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
+
+            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(400);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var patchResponse = JsonConvert.DeserializeObject<string>(content);
+
+            patchResponse.Should().Be($"MASH resident with id {incorrectMashResidentId} not found");
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
@@ -35,7 +35,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
         {
             _linkedResident.SocialCareId.Should().NotBeNull();
 
-            var request = new UpdateMashResidentRequest { UpdateType = "UNLINK-PERSON"};
+            var request = new UpdateMashResidentRequest {UpdateType = "UNLINK-PERSON"};
             var patchUri = new Uri($"/api/v1/mash-resident/{_linkedResident.Id}", UriKind.Relative);
             var serializedRequest = JsonSerializer.Serialize(request);
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/MASH/UnLinkClientInReferralToResidentInSystem.cs
@@ -14,10 +14,10 @@ using MashReferral = SocialCareCaseViewerApi.V1.Infrastructure.MashReferral;
 namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
 {
     [TestFixture]
-    public class LinkClientInReferralToResidentInSystem : IntegrationTestSetup<Startup>
+    public class UnLinkClientInReferralToResidentInSystem : IntegrationTestSetup<Startup>
     {
         private MashReferral _mashReferral;
-        private MashResident _unlinkedResident;
+        private MashResident _linkedResident;
         private Person _existingDbPerson;
 
         [SetUp]
@@ -26,79 +26,25 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests.MASH
             _existingDbPerson = IntegrationTestHelpers.CreateExistingPerson(DatabaseContext);
             _mashReferral = IntegrationTestHelpers.SaveMashReferralToDatabase(DatabaseContext, "CONTACT");
 
-            _unlinkedResident = IntegrationTestHelpers.CreateUnLinkedMashResident(DatabaseContext, _mashReferral, _existingDbPerson);
+            _linkedResident =
+                IntegrationTestHelpers.CreateMashResident(DatabaseContext, _mashReferral, _existingDbPerson);
         }
 
         [Test]
-        public async Task SuccessfulLinkingMatchesMashResidentToSavedPersonInDb()
+        public async Task SuccessfulUnLinkingRemovesLinkFromMashResidentToSavedPersonInDb()
         {
-            _unlinkedResident.SocialCareId.Should().BeNull();
+            _linkedResident.SocialCareId.Should().NotBeNull();
 
-            var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
-            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
+            var request = new UpdateMashResidentRequest { UpdateType = "UNLINK-PERSON"};
+            var patchUri = new Uri($"/api/v1/mash-resident/{_linkedResident.Id}", UriKind.Relative);
             var serializedRequest = JsonSerializer.Serialize(request);
             var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
 
-            var linkMashResidentResponse = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
+            var unlinkMashResidentResponse = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
 
-            linkMashResidentResponse.StatusCode.Should().Be(200);
+            unlinkMashResidentResponse.StatusCode.Should().Be(200);
 
-            _unlinkedResident.SocialCareId.Should().Be(_existingDbPerson.Id);
-
-            var content = await linkMashResidentResponse.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var patchMashResidentResponse = JsonConvert.DeserializeObject<MashResidentResponse>(content);
-
-            patchMashResidentResponse.SocialCareId.Should().Be(_existingDbPerson.Id);
-        }
-
-        [Test]
-        public async Task WhenTheRequestIsInvalidReturnsBadRequestStatusCode()
-        {
-            const string request = "invalid request";
-            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-        }
-
-        [Test]
-        public async Task WhenTheRequestContainsAnIncorrectPersonIdReturnsRelevantErrorMessage()
-        {
-            var incorrectPersonId = _existingDbPerson.Id + 20;
-            var request = new UpdateMashResidentRequest { SocialCareId = incorrectPersonId };
-            var patchUri = new Uri($"/api/v1/mash-resident/{_unlinkedResident.Id}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var patchResponse = JsonConvert.DeserializeObject<string>(content);
-
-            patchResponse.Should().Be($"Person with id {incorrectPersonId} not found");
-        }
-
-
-        [Test]
-        public async Task WhenTheRequestContainsAnIncorrectMashResidentIdReturnsRelevantErrorMessage()
-        {
-            var incorrectMashResidentId = _unlinkedResident.Id + 20;
-            var request = new UpdateMashResidentRequest { SocialCareId = _existingDbPerson.Id };
-            var patchUri = new Uri($"/api/v1/mash-resident/{incorrectMashResidentId}", UriKind.Relative);
-            var serializedRequest = JsonSerializer.Serialize(request);
-            var requestContent = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-
-            var response = await Client.PatchAsync(patchUri, requestContent).ConfigureAwait(true);
-
-            response.StatusCode.Should().Be(400);
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-            var patchResponse = JsonConvert.DeserializeObject<string>(content);
-
-            patchResponse.Should().Be($"MASH resident with id {incorrectMashResidentId} not found");
+            _linkedResident.SocialCareId.Should().BeNull();
         }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashResidentRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateMashResidentRequest.cs
@@ -3,6 +3,7 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 {
     public class UpdateMashResidentRequest
     {
-        public long SocialCareId { get; set; }
+        public long? SocialCareId { get; set; }
+        public string? UpdateType { get; set; }
     }
 }

--- a/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/MashReferralGateway.cs
@@ -104,6 +104,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 throw new MashResidentNotFoundException($"MASH resident with id {mashResidentId} not found");
             }
 
+            if (request.UpdateType == "UNLINK-PERSON")
+            {
+                mashResident.SocialCareId = null;
+                _databaseContext.SaveChanges();
+
+                return mashResident.ToDomain();
+            }
+
             var person = _databaseContext.Persons.FirstOrDefault(x => x.Id == request.SocialCareId);
 
             if (person == null)


### PR DESCRIPTION
## Link to JIRA ticket

[JIRA ticket.](https://hackney.atlassian.net/browse/SCT-1633)
## Describe this PR

### *What is the problem we're trying to solve*

During the MASH workflow, a worker needs to be able to un-assign person from Mash resident. i.e unlink the referral from the saved person(s) in the service's DB.

### *What changes have we introduced*

- Moved error testing cases linking person to mash resident from Integration test to the controller.
- Added condition inside MashRefferalGateway update method to check for presence of "UNLINK-PERSON" update type + with tests and refactored helper classes to support that.
- Integration test to check the happy path.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
