### PR TITLE
feat(SCT-1756): allow separate first last name on search

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
@@ -142,6 +142,25 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
         }
 
         [Test]
+        public void WildcardSearchWithFirstNameInFirstNameQueryParameterReturnsMatchingResident()
+        {
+            var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "ciasom");
+            var person2 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "Ciasom");
+
+            DatabaseContext.Persons.Add(person1);
+            DatabaseContext.Persons.Add(person2);
+            DatabaseContext.SaveChanges();
+
+            var query = new PersonSearchRequest() { FirstName = "Cia" };
+
+            var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
+
+            listOfPersons.Count.Should().Be(2);
+            listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
+            listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person2.Id).ToResidentInformationResponse());
+        }
+
+        [Test]
         public void WildcardSearchWithFirstNameInNameQueryParameterReturnsMatchingResident()
         {
             var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "ciasom");
@@ -190,6 +209,24 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.SaveChanges();
 
             var query = new PersonSearchRequest() { Name = "sell" };
+
+            var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
+            listOfPersons.Count.Should().Be(2);
+            listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person1.Id).ToResidentInformationResponse());
+            listOfPersons.Should().ContainEquivalentOf(DatabaseContext.Persons.First(x => x.Id == person2.Id).ToResidentInformationResponse());
+        }
+
+        [Test]
+        public void WildcardSearchWithLastNameInLastNameQueryParameterReturnsMatchingResident()
+        {
+            var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(lastName: "tessellate");
+            var person2 = DatabaseGatewayHelper.CreatePersonDatabaseEntity(lastName: "Tessellate");
+
+            DatabaseContext.Persons.Add(person1);
+            DatabaseContext.Persons.Add(person2);
+            DatabaseContext.SaveChanges();
+
+            var query = new PersonSearchRequest() { LastName = "sell" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(2);

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
@@ -37,6 +37,26 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Search
         }
 
         [Test]
+        public void WhenOnlyFirstNameGivenCallsSearchGateway()
+        {
+            _mockSearchGateway.Setup(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>())).Returns((new List<ResidentInformation>(), 0, 0));
+
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo" });
+
+            _mockSearchGateway.Verify(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()), Times.Once);
+        }
+
+        [Test]
+        public void WhenOnlyLastNameGivenCallsSearchGateway()
+        {
+            _mockSearchGateway.Setup(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>())).Returns((new List<ResidentInformation>(), 0, 0));
+
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { LastName = "foo" });
+
+            _mockSearchGateway.Verify(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()), Times.Once);
+        }
+
+        [Test]
         public void ReturnsTheNextCursor()
         {
             var residents = _fixture.CreateMany<ResidentInformation>(21).ToList();

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PersonSearchRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PersonSearchRequest.cs
@@ -8,6 +8,12 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [FromQuery(Name = "person_id")]
         public string? PersonId { get; set; }
 
+        [FromQuery(Name = "first_name")]
+        public string? FirstName { get; set; }
+
+        [FromQuery(Name = "last_name")]
+        public string? LastName { get; set; }
+
         [FromQuery(Name = "name")]
         public string? Name { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -1,4 +1,3 @@
-using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -63,6 +62,19 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var dateOfBirthRangeEnd = request.DateOfBirth == null ? "" : $"{request.DateOfBirth}T23:59:59.000Z";
             var name = request.Name == null ? "" : $"{request.Name}";
             var cursor = request.Cursor ?? 0;
+
+            if (string.IsNullOrEmpty(request.Name))
+            {
+                if (!string.IsNullOrEmpty(request.FirstName))
+                {
+                    name += $"{request.FirstName}";
+                }
+
+                if (!string.IsNullOrEmpty(request.LastName))
+                {
+                    name += $" {request.LastName}";
+                }
+            }
 
             var sb = new StringBuilder();
 

--- a/SocialCareCaseViewerApi/V1/UseCase/SearchUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/SearchUseCase.cs
@@ -19,6 +19,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         {
             if (string.IsNullOrEmpty(query.DateOfBirth)
                 && string.IsNullOrEmpty(query.Name)
+                && string.IsNullOrEmpty(query.FirstName)
+                && string.IsNullOrEmpty(query.LastName)
                 && string.IsNullOrEmpty(query.PersonId)
                 && string.IsNullOrEmpty(query.Postcode))
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1756

## Describe this PR

### *What is the problem we're trying to solve*

Based on feedback we need to change the way we are running search. 

### *What changes have we introduced*

This particular PR allows either name or first and last name to be given when running a search query. Follow up PRs will build on this functionality.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Make changes to frontend to send first and last name separately.
