### PR TITLE
fix(SCT-1756): Correction as name is not set when first and last are

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -63,17 +63,14 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var name = request.Name == null ? "" : $"{request.Name}";
             var cursor = request.Cursor ?? 0;
 
-            if (string.IsNullOrEmpty(request.Name))
+            if (!string.IsNullOrEmpty(request.FirstName))
             {
-                if (!string.IsNullOrEmpty(request.FirstName))
-                {
-                    name += $"{request.FirstName}";
-                }
+                name += $"{request.FirstName}";
+            }
 
-                if (!string.IsNullOrEmpty(request.LastName))
-                {
-                    name += $" {request.LastName}";
-                }
+            if (!string.IsNullOrEmpty(request.LastName))
+            {
+                name += $" {request.LastName}";
             }
 
             var sb = new StringBuilder();


### PR DESCRIPTION
## Link to JIRA ticket

[Add a link to the JIRA ticket that the changes in this PR describe.](https://hackney.atlassian.net/browse/SCT-1756)

## Describe this PR

### *What is the problem we're trying to solve*

Made a small mistake where first and last name are only used if name is set, obviously this is wrong.

### *What changes have we introduced*

Allow first and last name to be concatenated when name is not set.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
