### PR TITLE
fix(SCT-1756): use name to decide if we include it in the query

### DIFF
--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.EntityFrameworkCore;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;

--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using SocialCareCaseViewerApi.V1.Boundary.Requests;
 using SocialCareCaseViewerApi.V1.Boundary.Response;
@@ -90,7 +91,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
             sb.Append(@" FROM dbo.dm_persons Person LEFT JOIN dbo.dm_addresses Address ON Person.person_id = Address.person_id AND Address.is_display_address = 'Y' WHERE Person.marked_for_deletion = false");
 
-            if (!string.IsNullOrEmpty(request.Name))
+            if (!string.IsNullOrEmpty(name))
             {
                 sb.Append(@" AND ({0} <% Person.first_name OR {0} <% Person.last_name)");
             }

--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -80,7 +80,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             SELECT Person.person_id as PersonId,
                     COUNT('x') OVER(PARTITION BY 0) AS TotalRecords");
 
-            if (!string.IsNullOrEmpty(request.Name))
+            if (!string.IsNullOrEmpty(name))
             {
                 sb.Append(@" , word_similarity(Person.first_name || ' ' || Person.last_name, {0}) as Score");
             }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1756

## Describe this PR

### *What is the problem we're trying to solve*

Search is still not working when a first and last name only are given.


### *What changes have we introduced*

Originally I had this based off `request.Name` but this no longer makes sense, moving to just use `name` which is populated with first and last name if set.


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
