### PR TITLE
feat(SCT-1756): Use first and last name independently of each other

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
@@ -242,7 +242,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "Tessellate"};
+            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "Tessellate" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(1);
@@ -257,7 +257,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "ssellat"};
+            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "ssellat" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(1);

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
@@ -48,7 +48,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person3);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = person1.FirstName };
+            var query = new PersonSearchRequest() { FirstName = person1.FirstName };
 
             var (result, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -75,7 +75,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(new List<Person>() { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -91,7 +91,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = person.FirstName };
+            var query = new PersonSearchRequest() { FirstName = person.FirstName };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -109,7 +109,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = person.FirstName };
+            var query = new PersonSearchRequest() { FirstName = person.FirstName };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -132,7 +132,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person3);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -170,7 +170,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "iaso" };
+            var query = new PersonSearchRequest() { FirstName = "iaso" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -189,7 +189,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "tessellate" };
+            var query = new PersonSearchRequest() { LastName = "tessellate" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -208,7 +208,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person2);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "sell" };
+            var query = new PersonSearchRequest() { LastName = "sell" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(2);
@@ -242,7 +242,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom Tessellate" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "Tessellate"};
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(1);
@@ -257,7 +257,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom ssellat" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom", LastName = "ssellat"};
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             listOfPersons.Count.Should().Be(1);
@@ -322,7 +322,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Addresses.Add(address2);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Postcode = "E8 1DY", Name = person.FirstName };
+            var query = new PersonSearchRequest() { Postcode = "E8 1DY", FirstName = person.FirstName };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -403,7 +403,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Addresses.Add(address3);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom", Postcode = "E8 1DY" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom", Postcode = "E8 1DY" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -447,7 +447,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(new List<Person>() { person1, person2, person3, person4, person5 });
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom", Cursor = 2 };
+            var query = new PersonSearchRequest() { FirstName = "ciasom", Cursor = 2 };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -470,7 +470,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Addresses.Add(address);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "ciasom" };
+            var query = new PersonSearchRequest() { FirstName = "ciasom" };
 
             var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -495,7 +495,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Addresses.Add(currentAddress);
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "foo" };
+            var query = new PersonSearchRequest() { FirstName = "foo" };
 
             var (response, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
             response.First().Uprn.Should().Be(currentAddress.Uprn.ToString());
@@ -511,7 +511,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "foo" };
+            var query = new PersonSearchRequest() { FirstName = "foo" };
 
             var (response, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -532,7 +532,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3 });
             DatabaseContext.SaveChanges();
 
-            var query = new PersonSearchRequest() { Name = "foo" };
+            var query = new PersonSearchRequest() { FirstName = "foo" };
 
             var (_, totalCount, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
 
@@ -552,7 +552,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo" };
+            var request = new PersonSearchRequest() { FirstName = "foo" };
 
             var (_, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -572,7 +572,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo" };
+            var request = new PersonSearchRequest() { FirstName = "foo" };
 
             var (_, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -592,7 +592,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo" };
+            var request = new PersonSearchRequest() { FirstName = "foo" };
 
             var (_, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -612,7 +612,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo", Cursor = 20 };
+            var request = new PersonSearchRequest() { FirstName = "foo", Cursor = 20 };
 
             var (_, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -632,7 +632,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo", Cursor = 20 };
+            var request = new PersonSearchRequest() { FirstName = "foo", Cursor = 20 };
 
             var (_, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -652,7 +652,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(personRecords);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "foo", Cursor = 40 };
+            var request = new PersonSearchRequest() { FirstName = "foo", Cursor = 40 };
 
             var (results, _, cursor) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 
@@ -672,7 +672,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
             DatabaseContext.Persons.AddRange(person1, person2, person3, person4);
             DatabaseContext.SaveChanges();
 
-            var request = new PersonSearchRequest() { Name = "zzzzz" };
+            var request = new PersonSearchRequest() { LastName = "zzzzz" };
 
             var (results, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(request);
 

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
@@ -31,7 +31,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Search
         {
             _mockSearchGateway.Setup(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>())).Returns((new List<ResidentInformation>(), 0, 0));
 
-            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo", LastName = "bar"});
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo", LastName = "bar" });
 
             _mockSearchGateway.Verify(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()), Times.Once);
         }

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/Search/GetPersonsBySearchQueryTests.cs
@@ -27,11 +27,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Search
         }
 
         [Test]
-        public void CallsSearchGateway()
+        public void WhenBothFirstAndLastNameGivenCallsSearchGateway()
         {
             _mockSearchGateway.Setup(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>())).Returns((new List<ResidentInformation>(), 0, 0));
 
-            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { Name = "foo" });
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo", LastName = "bar"});
 
             _mockSearchGateway.Verify(x => x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()), Times.Once);
         }
@@ -67,7 +67,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Search
                     x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()))
                 .Returns((residents.Take(20).ToList(), 0, 20));
 
-            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { Name = "foo" }).NextCursor.Should().Be(expectedNextCursor);
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo" }).NextCursor.Should().Be(expectedNextCursor);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase.Search
                     x.GetPersonRecordsBySearchQuery(It.IsAny<PersonSearchRequest>()))
                 .Returns((residents.ToList(), 0, null));
 
-            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { Name = "foo" }).NextCursor.Should().Be("");
+            _searchUseCase.GetResidentsByQuery(new PersonSearchRequest() { FirstName = "foo" }).NextCursor.Should().Be("");
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/PersonSearchRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/PersonSearchRequest.cs
@@ -14,9 +14,6 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
         [FromQuery(Name = "last_name")]
         public string? LastName { get; set; }
 
-        [FromQuery(Name = "name")]
-        public string? Name { get; set; }
-
         [FromQuery(Name = "date_of_birth")]
         public string? DateOfBirth { get; set; }
 

--- a/SocialCareCaseViewerApi/V1/UseCase/SearchUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/SearchUseCase.cs
@@ -18,7 +18,6 @@ namespace SocialCareCaseViewerApi.V1.UseCase
         public ResidentInformationList GetResidentsByQuery(PersonSearchRequest query)
         {
             if (string.IsNullOrEmpty(query.DateOfBirth)
-                && string.IsNullOrEmpty(query.Name)
                 && string.IsNullOrEmpty(query.FirstName)
                 && string.IsNullOrEmpty(query.LastName)
                 && string.IsNullOrEmpty(query.PersonId)


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1756

## Describe this PR

### *What is the problem we're trying to solve*

Get better search results by using first and last name independently of each other.

### *What changes have we introduced*

Some increase in complexity, will be simplified in a later ticket https://hackney.atlassian.net/browse/SCT-1753.

This change removes the ability to search using just a name and requires use of first and last name.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A
