### PR TITLE
feat(SCT-1753): promote exact prefix matches to the top of search results

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Search/GetPersonRecordsBySearchQueryTests.cs
@@ -265,6 +265,33 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Search
         }
 
         [Test]
+        public void WhenMultipleMatchesExistExactPrefixMatchesArePromotedToTheTop()
+        {
+            DatabaseContext.Persons.Add(
+                DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "Samantha", lastName: "Golding"));
+            DatabaseContext.Persons.Add(
+                DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "Sammy", lastName: "Goldice"));
+            DatabaseContext.Persons.Add(
+                DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "Sonia-Sam", lastName: "GildingGol"));
+            DatabaseContext.Persons.Add(
+                DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "SonnySam", lastName: "Gladding-Gol"));
+            DatabaseContext.Persons.Add(
+                DatabaseGatewayHelper.CreatePersonDatabaseEntity(firstName: "Sachsam", lastName: "Geldingol"));
+
+            DatabaseContext.SaveChanges();
+
+            var query = new PersonSearchRequest() { FirstName = "sam", LastName = "gol" };
+
+            var (listOfPersons, _, _) = _searchGateway.GetPersonRecordsBySearchQuery(query);
+            listOfPersons.Count.Should().Be(5);
+            listOfPersons[0].FirstName.Should().Be("Sammy");
+            listOfPersons[1].FirstName.Should().Be("Samantha");
+            listOfPersons[2].FirstName.Should().Be("Sachsam");
+            listOfPersons[3].FirstName.Should().Be("Sonia-Sam");
+            listOfPersons[4].FirstName.Should().Be("SonnySam");
+        }
+
+        [Test]
         public void GetAllResidentsWithPostCodeQueryParameterReturnsOnlyResidentsWithPostcodeInDisplayAddress()
         {
             var person1 = DatabaseGatewayHelper.CreatePersonDatabaseEntity();

--- a/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/SearchGateway.cs
@@ -75,7 +75,9 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 sb.Append(@", (");
                 if (!string.IsNullOrEmpty(firstName))
                 {
-                    sb.Append(@" word_similarity(Person.first_name, {0})");
+                    sb.Append(@" cast(word_similarity(Person.first_name, {0}) as real)");
+                    sb.Append(
+                        @" + cast(""like""(lower(Person.first_name), lower({0}) || '%')::int as real)");
                 }
                 if (!string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName))
                 {
@@ -83,13 +85,15 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 }
                 if (!string.IsNullOrEmpty(lastName))
                 {
-                    sb.Append(@" word_similarity(Person.last_name, {1})");
+                    sb.Append(@" cast(word_similarity(Person.last_name, {1}) as real)");
+                    sb.Append(
+                        @" + cast(""like""(lower(Person.last_name), lower({1}) || '%')::int as real)");
                 }
                 sb.Append(@") as Score");
             }
             else
             {
-                sb.Append(@", 1.0 as Score");
+                sb.Append(@", cast(1.0 as real) as Score");
             }
 
             sb.Append(@" FROM dbo.dm_persons Person


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1751

## Describe this PR

### *What is the problem we're trying to solve*

Currently postgres fuzzy search will produce the following ranking given the search term "ali"

Denali
Alisonne
Ali-longer-name

As users tend to type in the first few letters of a name, the following ordering would make more sense.

Alisonne
Ali-longer-name
Denali

### *What changes have we introduced*

When we calculate the scores for matches, if the statement `like(lower(Person.first_name), 'ali%')` is true we add `1.0` to the score for that result. The same is computed on the last name.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

None
