### PR TITLE
Fix terraform vpc name in staging

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -26,7 +26,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "staging_vpc" {
   tags = {
-    Name = "vpc-staging-apis-staging"
+    Name = "apis-stg"
   }
 }
 data "aws_subnet_ids" "staging" {


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

The VPC name for staging APIs has changed, this causes the deployment to fail.

### *What changes have we introduced*

Add descriptions of what changes were made to address the problem and provide a solution.

Updated the staging APIs to allow for the updates. Confirmed the correct VPC by checking the social care staging RDS instance.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A
