### PR TITLE
Fix auditing when updating rag

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1162,8 +1162,9 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             var query = DatabaseContext.Allocations.ToList();
             var updatedRecord = query.First(x => x.Id == teamAllocation.Id);
 
-            Assert.AreEqual(updatedRecord.RagRating, request.RagRating);
-            Assert.AreEqual(updatedRecord.LastModifiedBy, worker.Email);
+            updatedRecord.RagRating.Should().Be(request.RagRating);
+            updatedRecord.LastModifiedBy.Should().Be(worker.Email);
+            updatedRecord.LastModifiedAt.Should().NotBeNull();
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1124,6 +1124,49 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void UpdatingWorkerAllocationWithRagRatingShouldUpdateTheRecordInTheDatabaseWithNewRagRatingAndAuditingStamp()
+        {
+            var allocationStartDate = DateTime.Now.AddDays(-60);
+            var (request, worker, _, person, team) = TestHelpers.CreateUpdateAllocationRequest();
+            request.DeallocationDate = null;
+            request.DeallocationReason = null;
+            request.RagRating = "High";
+            request.CreatedBy = worker.Email;
+            var teamAllocation = new Allocation
+            {
+                Id = (int) (request.Id),
+                AllocationEndDate = null,
+                AllocationStartDate = allocationStartDate,
+                CreatedAt = allocationStartDate,
+                CaseStatus = "Open",
+                CaseClosureDate = null,
+                LastModifiedAt = null,
+                CreatedBy = worker.Email,
+                LastModifiedBy = null,
+                PersonId = person.Id,
+                TeamId = team.Id,
+                WorkerId = null
+            };
+
+            DatabaseContext.Allocations.Add(teamAllocation);
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.Teams.Add(team);
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.SaveChanges();
+
+            _mockProcessDataGateway.Setup(x => x.InsertCaseNoteDocument(It.IsAny<CaseNotesDocument>()))
+                .Returns(Task.FromResult(_faker.Random.Guid().ToString()));
+
+            _classUnderTest.UpdateRagRatingInAllocation(request);
+
+            var query = DatabaseContext.Allocations.ToList();
+            var updatedRecord = query.First(x => x.Id == teamAllocation.Id);
+
+            Assert.AreEqual(updatedRecord.RagRating, request.RagRating);
+            Assert.AreEqual(updatedRecord.LastModifiedBy, worker.Email);
+        }
+
+        [Test]
         public void UpdatingWorkerAllocationWithExistingTeamAllocationShouldUpdateTheRecordInTheDatabase()
         {
             var allocationStartDate = DateTime.Now.AddDays(-60);

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -929,6 +929,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
                 //copy existing values in case adding note fails
                 var tmpAllocation = (AllocationSet) allocation.Clone();
+                allocation.LastModifiedBy = request.CreatedBy;
 
                 allocation.RagRating = request.RagRating;
                 _databaseContext.SaveChanges();


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

No auditing fields are populated when 

### *What changes have we introduced*

Added fix and test

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

