### PR TITLE
Fix not showing team allocations when worker allocation is closed

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1078,6 +1078,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             insertedRecord.CarePackage.Should().Be(request.CarePackage);
             insertedRecord.PersonId.Should().Be(request.MosaicId);
             insertedRecord.WorkerId.Should().Be(worker.Id);
+            insertedRecord.RagRating.Should().Be(allocation.RagRating);
             insertedRecord.CreatedBy.Should().Be(createdByWorker.Email);
         }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -842,8 +842,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             // Worker allocation
             if (request.AllocatedWorkerId != null && hasExistingTeamOnlyAllocation)
             {
-                var existingTeam = residentAllocations.FirstOrDefault(x => x.TeamId == request.AllocatedTeamId && x.WorkerId == null);
-                request.RagRating = existingTeam.RagRating;
+                var existingTeamAllocation = residentAllocations.FirstOrDefault(x => x.TeamId == request.AllocatedTeamId && x.WorkerId == null);
+                request.RagRating = existingTeamAllocation.RagRating;
                 response = CreateTeamAndWorkerAllocation(request, person, worker, allocatedBy, team);
             }
 

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -802,7 +802,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             var hasExistingTeamOnlyAllocation = residentAllocations.Any(x => x.TeamId == request.AllocatedTeamId && x.WorkerId == null);
             var hasExistingTeamAndWorkerAllocation = residentAllocations.Any(x => x.TeamId == request.AllocatedTeamId && x.WorkerId != null);
 
-
             // If person has allocation with the same team already and request is to allocate a team
             if (request.AllocatedWorkerId == null && hasExistingTeamOnlyAllocation)
             {
@@ -843,6 +842,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             // Worker allocation
             if (request.AllocatedWorkerId != null && hasExistingTeamOnlyAllocation)
             {
+                var existingTeam = residentAllocations.FirstOrDefault(x => x.TeamId == request.AllocatedTeamId && x.WorkerId == null);
+                request.RagRating = existingTeam.RagRating;
                 response = CreateTeamAndWorkerAllocation(request, person, worker, allocatedBy, team);
             }
 
@@ -996,6 +997,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                     {
                         PersonId = allocation.PersonId,
                         TeamId = allocation.TeamId,
+                        RagRating = allocation.RagRating,
                         AllocationStartDate = allocation.AllocationStartDate,
                         CreatedBy = allocation.CreatedBy,
                         CreatedAt = allocation.CreatedAt,

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -56,8 +56,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 query = query.Where(x => x.PersonId == mosaicId);
 
-                var teams = query.Where(x => x.TeamId != null && x.WorkerId == null).ToList();
-                var workerTeams = query.Where(x => x.TeamId != null && x.WorkerId != null).ToList();
+                var teams = query.Where(x => x.TeamId != null && x.WorkerId == null && x.CaseStatus.ToLower() != "closed").ToList();
+                var workerTeams = query.Where(x => x.TeamId != null && x.WorkerId != null && x.CaseStatus.ToLower() != "closed").ToList();
 
                 foreach (var allocation in teams)
                 {


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

if i try to deallocate just the worker, it removes the team allocation too.

### *What changes have we introduced*

Add descriptions of what changes were made to address the problem and provide a solution.

Code and test

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

