### PR TITLE
Set engine version to 11. to avoid specific version updates

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -92,7 +92,7 @@ module "historical_postgres_db_staging" {
   db_port              = 5432
   subnet_ids           = data.aws_subnet_ids.staging.ids
   db_engine            = "postgres"
-  db_engine_version    = "11.12"
+  db_engine_version    = "11."
   db_instance_class    = "db.t2.small"
   db_allocated_storage = 20
   maintenance_window   = "sun:10:00-sun:10:30"


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

The historic db has been updated to 11.13 however our state is a little wrong so it's trying to upgrade from .13 to .12.

### *What changes have we introduced*

Setting engine version to `11.` which should accept any patch update to the rds instance engine version.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
