### PR TITLE
wraped up deallcation for both team and worker

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateAllocationRequestTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Boundary/Request/UpdateAllocationRequestTests.cs
@@ -22,6 +22,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Boundary.Request
                 (TestHelpers.UpdateValidatorAllocationRequest(0, deallocationDate: today, ragRating: null), "Id must be greater than 1"),
                 (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationReason: null, deallocationDate: today, ragRating: null), "Deallocation reason required"),
                 (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationReason: "", deallocationDate: today, ragRating: null), "Deallocation reason required"),
+                (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationDate: today, deallocationScope: null, ragRating: null), "Deallocation Scope required"),
+                (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationDate: today, deallocationScope: "foo", ragRating: null), "Deallocation Scope must be either 'team' or 'worker'"),
                 (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationDate: null, ragRating: null), "Deallocation Date is required"),
                 (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationDate: tomorrow, ragRating: null), "DeallocationDate start date must not be in future"),
                 (TestHelpers.UpdateValidatorAllocationRequest(1, deallocationDate: today, ragRating: null, createdBy: null), "Email required"),

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/TestHelpers.cs
@@ -109,6 +109,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                 string? deallocationReason = "Reason",
                 string? createdBy = "example@test.com",
                 string? ragRating = "urgent",
+                string? deallocationScope = "team",
                 DateTime? deallocationDate = default
             )
         {
@@ -116,6 +117,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
             var updateAllocationRequest = new Faker<UpdateAllocationRequest>()
                 .RuleFor(u => u.Id, f => id)
                 .RuleFor(u => u.DeallocationReason, f => deallocationReason)
+                .RuleFor(u => u.DeallocationScope, f => deallocationScope)
                 .RuleFor(u => u.CreatedBy, createdBy)
                 .RuleFor(c => c.RagRating, f => ragRating)
                 .RuleFor(u => u.DeallocationDate, f => deallocationDate);

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/IntegrationTestHelpers.cs
@@ -123,13 +123,14 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
             return createAllocationRequest;
         }
 
-        public static UpdateAllocationRequest PatchAllocationRequest(int allocationId, Worker createdByWorker, string? ragRating, string? deallocationReason, DateTime? deallocationDate)
+        public static UpdateAllocationRequest PatchAllocationRequest(int allocationId, Worker createdByWorker, string? ragRating, string? deallocationReason, DateTime? deallocationDate, string? deallocationScope)
         {
             var updateAllocationRequest = new Faker<UpdateAllocationRequest>()
                 .RuleFor(c => c.Id, f => allocationId)
                 .RuleFor(c => c.CreatedBy, f => createdByWorker.Email)
                 .RuleFor(c => c.RagRating, f => ragRating)
                 .RuleFor(c => c.DeallocationReason, f => deallocationReason)
+                .RuleFor(c => c.DeallocationScope, f => deallocationScope)
                 .RuleFor(c => c.DeallocationDate, f => deallocationDate)
                 .RuleFor(c => c.RagRating, f => ragRating);
 

--- a/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateAllocationDetails.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/IntegrationTests/UpdateAllocationDetails.cs
@@ -68,7 +68,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 createdByWorker: _existingDbWorker,
                 ragRating: null,
                 deallocationReason: null,
-                deallocationDate: null);
+                deallocationDate: null, deallocationScope: "worker");
             var serializedPatchRequest = JsonSerializer.Serialize(newAllocationPatchRequest);
             var patchRequestContent = new StringContent(serializedPatchRequest, Encoding.UTF8, "application/json");
             var patchAllocationResponse = await Client.PatchAsync(patchUri, patchRequestContent).ConfigureAwait(true);
@@ -115,7 +115,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 createdByWorker: _existingDbWorker,
                 ragRating: "low",
                 deallocationReason: null,
-                deallocationDate: null);
+                deallocationDate: null,
+                deallocationScope: "worker");
             var serializedPatchRequest = JsonSerializer.Serialize(newAllocationPatchRequest);
             var patchRequestContent = new StringContent(serializedPatchRequest, Encoding.UTF8, "application/json");
             var patchAllocationResponse = await Client.PatchAsync(patchUri, patchRequestContent).ConfigureAwait(true);
@@ -164,6 +165,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.IntegrationTests
                 createdByWorker: _existingDbWorker,
                 ragRating: null,
                 deallocationReason: "reason",
+                deallocationScope: "worker",
                 deallocationDate: today);
             var serializedPatchRequest = JsonSerializer.Serialize(newAllocationPatchRequest);
             var patchRequestContent = new StringContent(serializedPatchRequest, Encoding.UTF8, "application/json");

--- a/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/UseCase/CaseRecordsUseCaseTests.cs
@@ -142,7 +142,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.UseCase
                 TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Warning Note Reviewed"),
                 TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Worker allocated"),
                 TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Rag Rating Updated"),
-                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Worker deallocated")
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Worker deallocated"),
+                TestHelpers.CreateCaseSubmission(SubmissionState.Submitted, residentId: int.Parse(request.MosaicId ?? ""), formId: "Team deallocated")
             };
 
             _mockDatabaseGateWay.Setup(x => x.GetNCReferenceByPersonId(request.MosaicId)).Returns(request.MosaicId ?? "");

--- a/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateAllocationRequest.cs
+++ b/SocialCareCaseViewerApi/V1/Boundary/Requests/UpdateAllocationRequest.cs
@@ -20,6 +20,9 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
 
         [JsonPropertyName("deallocationDate")]
         public DateTime? DeallocationDate { get; set; }
+
+        [JsonPropertyName("deallocationScope")]
+        public string? DeallocationScope { get; set; }
     }
 
     public class UpdateAllocationRequestValidator : AbstractValidator<UpdateAllocationRequest>
@@ -40,6 +43,10 @@ namespace SocialCareCaseViewerApi.V1.Boundary.Requests
             RuleFor(x => x.CreatedBy)
                 .NotNull().WithMessage("Email required")
                 .EmailAddress().WithMessage("Provide a valid email");
+            RuleFor(x => x.DeallocationScope)
+                .NotNull().WithMessage("Deallocation Scope required")
+                .When(x => x.RagRating == null && x.DeallocationReason != null)
+                .Matches("(?i:^team|worker)").WithMessage("Deallocation Scope must be either 'team' or 'worker'");
             RuleFor(x => x.RagRating)
                 .Matches("(?i:^none|low|high|medium|urgent)").WithMessage("RAG rating must be 'low', 'high', 'medium', 'urgent' or 'none'");
             When(x => x.RagRating != null

--- a/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
+++ b/SocialCareCaseViewerApi/V1/UseCase/CaseRecordsUseCase.cs
@@ -94,7 +94,8 @@ namespace SocialCareCaseViewerApi.V1.UseCase
                     "Warning Note Ended",
                     "Rag Rating Updated",
                     "Worker allocated",
-                    "Worker deallocated"
+                    "Worker deallocated",
+                    "Team deallocated"
                 };
                 allCareCaseData = allCareCaseData.Where(x => (!caseExclusionList.Contains(x.FormName))).ToList();
             }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We need to be able to deallocate both team and worker allocations via single call.

### *What changes have we introduced*

Adjusted request and code to implement the functionality + test

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

