### PR TITLE
Fix: raise the limit to 250 for allocations pages

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsPagingTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsPagingTests.cs
@@ -26,12 +26,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         [Test]
         public void GetAllocationsReturnsAmountOfResultsSetByTheLimit()
         {
-            var limit = 20; //hard coded in the gateway for now
+            var limit = 250; //hard coded in the gateway for now
 
             var person = TestHelpers.CreatePerson();
             DatabaseContext.Persons.Add(person);
 
-            for (int i = 0; i < 25; i++)
+            for (int i = 0; i < 260; i++)
             {
                 DatabaseContext.Add(TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "open"));
             }
@@ -44,12 +44,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
-        public void GivenMoreThanTwentyResultsWhenNextCursorUnspecifiedNextCursorIsTwenty()
+        public void GivenMoreThanTwoHundredAndFiftyResultsWhenNextCursorUnspecifiedNextCursorIsTwoHundredAndFifty()
         {
             var person = TestHelpers.CreatePerson();
             DatabaseContext.Persons.Add(person);
 
-            for (int i = 0; i < 25; i++)
+            for (int i = 0; i < 260; i++)
             {
                 DatabaseContext.Add(TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "open"));
             }
@@ -58,11 +58,11 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var (_, cursor) = _databaseGateway.SelectAllocations(mosaicId: person.Id, workerId: 0, workerEmail: "", 0);
 
-            cursor.Should().Be(20);
+            cursor.Should().Be(250);
         }
 
         [Test]
-        public void GivenLessThanTwentyResultsWhenNextCursorIsUnspecifiedNextCursorIsNull()
+        public void GivenLessThanTwoHundredAndFiftyResultsWhenNextCursorIsUnspecifiedNextCursorIsNull()
         {
             var person = TestHelpers.CreatePerson();
             DatabaseContext.Persons.Add(person);
@@ -80,7 +80,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
-        public void GivenTwentyResultsWhenNextCursorIsUnspecifiedNextCursorIsNull()
+        public void GivenTwoHundredAndFiftyResultsWhenNextCursorIsUnspecifiedNextCursorIsNull()
         {
             var person = TestHelpers.CreatePerson();
             DatabaseContext.Persons.Add(person);
@@ -98,7 +98,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
         }
 
         [Test]
-        public void GivenLessThanTwentyResultsWhenNextCursorIsTwentyNextCursorIsNull()
+        public void GivenLessThanTwoHundredAndFiftyResultsNextCursorIsNull()
         {
             var person = TestHelpers.CreatePerson();
             DatabaseContext.Persons.Add(person);
@@ -113,24 +113,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             var (_, cursor) = _databaseGateway.SelectAllocations(mosaicId: person.Id, workerId: 0, workerEmail: "", 0);
 
             cursor.Should().Be(null);
-        }
-
-        [Test]
-        public void GivenMoreThanFortyResultsWhenNextCursorIsTwentyNextCursorIsForty()
-        {
-            var person = TestHelpers.CreatePerson();
-            DatabaseContext.Persons.Add(person);
-
-            for (int i = 0; i < 50; i++)
-            {
-                DatabaseContext.Add(TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "open"));
-            }
-
-            DatabaseContext.SaveChanges();
-
-            var (_, cursor) = _databaseGateway.SelectAllocations(mosaicId: person.Id, workerId: 0, workerEmail: "", cursor: 20, teamId: 0);
-
-            cursor.Should().Be(40);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -47,7 +47,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
 
         public (List<Allocation>, int?) SelectAllocations(long mosaicId, long workerId, string workerEmail, long teamId, string sortBy = "rag_rating", int cursor = 0, string teamAllocationStatus = null, string status = "OPEN")
         {
-            var limit = 20;
+            var limit = 250;
 
             List<Allocation> allocations = new List<Allocation>();
             IQueryable<AllocationSet> query = _databaseContext.Allocations;


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

Currently the frontend does not implement pagination for allocations pages. We found out some users have more than 100 allocations.

### *What changes have we introduced*

Raise limit to 250

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
