### PR TITLE
Null rag rating fix

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
@@ -77,11 +77,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var (result, _) = _databaseGateway.SelectAllocations(mosaicId: personId, 0, workerEmail: "", 0, sortBy: sortBy, 0);
 
-            result[0].Id.Should().Be(allocationWithoutRagRating.Id);
-            result[1].Id.Should().Be(UrgentAllocation.Id);
-            result[2].Id.Should().Be(HighAllocation.Id);
-            result[3].Id.Should().Be(MediumAllocation.Id);
-            result[4].Id.Should().Be(LowAllocation.Id);
+            result[0].Id.Should().Be(UrgentAllocation.Id);
+            result[1].Id.Should().Be(HighAllocation.Id);
+            result[2].Id.Should().Be(MediumAllocation.Id);
+            result[3].Id.Should().Be(LowAllocation.Id);
+            result[4].Id.Should().Be(allocationWithoutRagRating.Id);
+
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
@@ -47,11 +47,12 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var (result, _) = _databaseGateway.SelectAllocations(mosaicId: personId, 0, "", 0, sortBy: "rag_rating", 0);
 
-            result[0].Id.Should().Be(allocationWithoutRagRating.Id);
-            result[1].Id.Should().Be(UrgentAllocation.Id);
-            result[2].Id.Should().Be(HighAllocation.Id);
-            result[3].Id.Should().Be(MediumAllocation.Id);
-            result[4].Id.Should().Be(LowAllocation.Id);
+            result[0].Id.Should().Be(UrgentAllocation.Id);
+            result[1].Id.Should().Be(HighAllocation.Id);
+            result[2].Id.Should().Be(MediumAllocation.Id);
+            result[3].Id.Should().Be(LowAllocation.Id);
+            result[4].Id.Should().Be(allocationWithoutRagRating.Id);
+
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -157,8 +157,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             {
                 "rag_rating" =>
                     allocations
-                        .OrderByDescending(x => x.RagRating == null)
-                        .ThenByDescending(x => x.RagRating != null ? Enum.Parse(typeof(RagRatingToNumber), x.RagRating, true) : null).ToList(),
+                        .OrderByDescending(x => x.RagRating != null ? Enum.Parse(typeof(RagRatingToNumber), x.RagRating, true) : null)
+                        .ThenByDescending(x => x.RagRating == null).ToList(),
                 "date_added" =>
                     allocations
                         .OrderByDescending(x => x.AllocationStartDate).ToList(),
@@ -167,8 +167,8 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                         .OrderBy(x => x.PersonReviewDate).ToList(),
                 _ =>
                     allocations
-                        .OrderByDescending(x => x.RagRating == null)
-                        .ThenByDescending(x => x.RagRating != null ? Enum.Parse(typeof(RagRatingToNumber), x.RagRating, true) : null).ToList()
+                        .OrderByDescending(x => x.RagRating != null ? Enum.Parse(typeof(RagRatingToNumber), x.RagRating, true) : null)
+                        .ThenByDescending(x => x.RagRating == null).ToList()
             };
 
             return (allocations


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1814

## Describe this PR

### *What is the problem we're trying to solve*

Legacy allocations where the rag_rating field is null need to be displayed at the bottom of the list when the SortBy value is rag_rating.

### *What changes have we introduced*

Switched current sorting, changed test

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

