### PR TITLE
Update tests to use UTC in audit columns

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/AddMissingUPRNsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/AddMissingUPRNsTests.cs
@@ -102,7 +102,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
 
             var updatedAddress = DatabaseContext.Addresses.FirstOrDefault();
 
-            updatedAddress.LastModifiedAt.Should().BeCloseTo(DateTime.Now, precision: 10000);
+            updatedAddress.LastModifiedAt.Should().BeCloseTo(DateTime.UtcNow, precision: 10000);
             updatedAddress.LastModifiedBy.Should().Be(lastModifiedBy);
         }
 

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -403,10 +403,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 
             var updatedWorkerTeams = DatabaseContext.WorkerTeams.Where(x => x.WorkerId == worker.Id);
 
-            updatedWorkerTeams.FirstOrDefault(x => x.TeamId == newTeam.Id && x.WorkerId == worker.Id).CreatedAt.Should().BeCloseTo(DateTime.Now, 1000);
+            updatedWorkerTeams.FirstOrDefault(x => x.TeamId == newTeam.Id && x.WorkerId == worker.Id).CreatedAt.Should().BeCloseTo(DateTime.UtcNow, 1000);
             updatedWorkerTeams.FirstOrDefault(x => x.TeamId == newTeam.Id && x.WorkerId == worker.Id).CreatedBy.Should().Be(request.ModifiedBy);
 
-            updatedWorkerTeams.FirstOrDefault(x => x.TeamId == currentWorkerTeam.Team.Id && x.WorkerId == worker.Id).LastModifiedAt.Should().BeCloseTo(DateTime.Now, 1000);
+            updatedWorkerTeams.FirstOrDefault(x => x.TeamId == currentWorkerTeam.Team.Id && x.WorkerId == worker.Id).LastModifiedAt.Should().BeCloseTo(DateTime.UtcNow, 1000);
             updatedWorkerTeams.FirstOrDefault(x => x.TeamId == currentWorkerTeam.Team.Id && x.WorkerId == worker.Id).LastModifiedBy.Should().Be(request.ModifiedBy);
         }
 


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Some new tests are failing on Windows due to recent BST change. Failing datetime checks are an hour off.  

### *What changes have we introduced*

Update tests to use UTC datetime when checking against audit columns timestamps. Audit timestamps are always using UTC format, so tests should be setup accordingly. 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly