### PR TITLE
Allocations: inverting the list sorting when requested by date added

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
@@ -104,10 +104,10 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
 
             var (result, _) = _databaseGateway.SelectAllocations(mosaicId: personId, workerId: 0, workerEmail: "", 0, "date_added", 0);
 
-            result[0].Id.Should().Be(allocation3.Id);
-            result[1].Id.Should().Be(allocation1.Id);
-            result[2].Id.Should().Be(allocation4.Id);
-            result[3].Id.Should().Be(allocation2.Id);
+            result[0].Id.Should().Be(allocation2.Id);
+            result[1].Id.Should().Be(allocation4.Id);
+            result[2].Id.Should().Be(allocation1.Id);
+            result[3].Id.Should().Be(allocation3.Id);
         }
 
         [Test]

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -161,7 +161,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                         .ThenByDescending(x => x.RagRating == null).ToList(),
                 "date_added" =>
                     allocations
-                        .OrderByDescending(x => x.AllocationStartDate).ToList(),
+                        .OrderBy(x => x.AllocationStartDate).ToList(),
                 "review_date" =>
                     allocations
                         .OrderBy(x => x.PersonReviewDate).ToList(),


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-1818

## Describe this PR

### *What is the problem we're trying to solve*

We need to sort our allocations with the oldest at the top when users click on "date added to team"

### *What changes have we introduced*

Adapted test to reflect change
Used OrderBy instead of OrderByDescending in code for this specific filter 


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

