### PR TITLE
Add test for sorting by date added when filtered by worker id

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/Database/GetAllocationsSortingTests.cs
@@ -141,5 +141,35 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways.Database
             result[2].Id.Should().Be(allocation3.Id);
             result[3].Id.Should().Be(allocation4.Id);
         }
+
+        [Test]
+        public void GetAllocationsReturnsResultsInSortByDateAddedOrderWhenFilteredByWorkerIdAndWhenSortByIsSetToDateAdded()
+        {
+            var worker = TestHelpers.CreateWorker(hasAllocations: false, hasWorkerTeams: false, id: 123);
+
+            var person1 = TestHelpers.CreatePerson();
+            var allocation1 = TestHelpers.CreateAllocation(personId: (int) person1.Id, workerId: worker.Id, caseStatus: "open", dateAdded: DateTime.Today.AddDays(-50));
+
+            var person2 = TestHelpers.CreatePerson();
+            var allocation2 = TestHelpers.CreateAllocation(personId: (int) person2.Id, workerId: worker.Id, caseStatus: "open", dateAdded: DateTime.Today.AddDays(-10));
+
+            var person3 = TestHelpers.CreatePerson();
+            var allocation3 = TestHelpers.CreateAllocation(personId: (int) person3.Id, workerId: worker.Id, caseStatus: "open", dateAdded: DateTime.Today.AddDays(-60));
+
+            var person4 = TestHelpers.CreatePerson();
+            var allocation4 = TestHelpers.CreateAllocation(personId: (int) person4.Id, workerId: worker.Id, caseStatus: "open", dateAdded: DateTime.Today.AddDays(-30));
+
+            DatabaseContext.Persons.AddRange(new List<Person> { person1, person2, person3, person4 });
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.Allocations.AddRange(new List<AllocationSet>() { allocation1, allocation2, allocation3, allocation4 });
+            DatabaseContext.SaveChanges();
+
+            var (result, _) = _databaseGateway.SelectAllocations(mosaicId: 0, workerId: worker.Id, workerEmail: "", teamId: 0, sortBy: "date_added");
+
+            result[0].Id.Should().Be(allocation2.Id);
+            result[1].Id.Should().Be(allocation4.Id);
+            result[2].Id.Should().Be(allocation1.Id);
+            result[3].Id.Should().Be(allocation3.Id);
+        }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

SCT-1815

## Describe this PR

### *What is the problem we're trying to solve*

Issue was reported saying that when fetching allocations filtered by `worker_id` and setting the `sort_by` parameter to `date_added` the results weren't coming back in the correct order.

### *What changes have we introduced*

Added a test for the above scenario.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test is passing, so investigate further where the issue is since it looks like it's outside the API.
