### PR TITLE
Add sonarcloud coverage config

### DIFF
--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -27,4 +27,5 @@ COPY . .
 COPY ./SocialCareCaseViewerApi/rds-ca-2019-root.pem /ssl/rds-ca-2019-root.pem
 
 #build, test and SonarCloud scan
+RUN chmod 777 ./SocialCareCaseViewerApi.Tests/startup.sh
 CMD ./SocialCareCaseViewerApi.Tests/startup.sh

--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -11,9 +11,10 @@ WORKDIR /app
 #SonarCloud scan
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 RUN dotnet tool install --global dotnet-sonarscanner
+RUN dotnet tool install --global dotnet-coverage
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_social-care-case-viewer-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin /k:"LBHackney-IT_social-care-case-viewer-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
 
 # Copy csproj and restore as distinct layers
 COPY ./SocialCareCaseViewerApi.sln ./
@@ -23,11 +24,11 @@ COPY ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj ./Soci
 RUN dotnet restore ./SocialCareCaseViewerApi/SocialCareCaseViewerApi.csproj
 RUN dotnet restore ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
 
-# Copy everything else and build
+# Copy everything else, build and generate coverage file
 COPY . .
 COPY ./SocialCareCaseViewerApi/rds-ca-2019-root.pem /ssl/rds-ca-2019-root.pem
 RUN dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
-
+RUN dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
 RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
 
 CMD dotnet test

--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -28,5 +28,5 @@ RUN dotnet restore ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests
 COPY . .
 COPY ./SocialCareCaseViewerApi/rds-ca-2019-root.pem /ssl/rds-ca-2019-root.pem
 RUN dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
-RUN dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
+CMD dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
 RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -30,5 +30,3 @@ COPY ./SocialCareCaseViewerApi/rds-ca-2019-root.pem /ssl/rds-ca-2019-root.pem
 RUN dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
 RUN dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
 RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
-
-CMD dotnet test

--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -8,7 +8,6 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 RUN dotnet tool install --global dotnet-sonarscanner
 RUN dotnet tool install --global dotnet-coverage
@@ -18,9 +17,6 @@ ENV PATH="$PATH:/root/.dotnet/tools"
 COPY ./SocialCareCaseViewerApi.sln ./
 COPY ./SocialCareCaseViewerApi/SocialCareCaseViewerApi.csproj ./SocialCareCaseViewerApi/
 COPY ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj ./SocialCareCaseViewerApi.Tests/
-
-RUN dotnet restore ./SocialCareCaseViewerApi/SocialCareCaseViewerApi.csproj
-RUN dotnet restore ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
 
 # Copy everything else, build and generate coverage file
 COPY . .

--- a/SocialCareCaseViewerApi.Tests/Dockerfile
+++ b/SocialCareCaseViewerApi.Tests/Dockerfile
@@ -8,13 +8,11 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-#SonarCloud scan
+
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 RUN dotnet tool install --global dotnet-sonarscanner
 RUN dotnet tool install --global dotnet-coverage
 ENV PATH="$PATH:/root/.dotnet/tools"
-
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_social-care-case-viewer-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
 
 # Copy csproj and restore as distinct layers
 COPY ./SocialCareCaseViewerApi.sln ./
@@ -27,6 +25,6 @@ RUN dotnet restore ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests
 # Copy everything else, build and generate coverage file
 COPY . .
 COPY ./SocialCareCaseViewerApi/rds-ca-2019-root.pem /ssl/rds-ca-2019-root.pem
-RUN dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
-CMD dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+
+#build, test and SonarCloud scan
+CMD ./SocialCareCaseViewerApi.Tests/startup.sh

--- a/SocialCareCaseViewerApi.Tests/startup.sh
+++ b/SocialCareCaseViewerApi.Tests/startup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+dotnet sonarscanner begin /k:"LBHackney-IT_social-care-case-viewer-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj --no-incremental
+dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
+dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/SocialCareCaseViewerApi.Tests/startup.sh
+++ b/SocialCareCaseViewerApi.Tests/startup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+dotnet restore ./SocialCareCaseViewerApi/SocialCareCaseViewerApi.csproj
+dotnet restore ./SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj
+
 dotnet sonarscanner begin /k:"LBHackney-IT_social-care-case-viewer-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+
 dotnet build -c debug -o out SocialCareCaseViewerApi.Tests/SocialCareCaseViewerApi.Tests.csproj --no-incremental
 dotnet-coverage collect 'dotnet test' -f xml -o 'coverage.xml'
+
 dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,2 @@
 sonar.projectKey=LBHackney-IT_social-care-case-viewer-api
 sonar.organization=lbhackney-it
-sonar.exclusions=terraform/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=LBHackney-IT_social-care-case-viewer-api
 sonar.organization=lbhackney-it
+sonar.exclusions=terraform/**/*


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Default configuration for SonarCloud does not include code coverage setup

### *What changes have we introduced*

Add code coverage configuration. In order to run multiple dotnet commands in the correct order they have been moved to startup.sh file.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly