### PR TITLE
Sct 1829 stop created by property getting updated during patch

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -2418,6 +2418,20 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void PatchPersonDoesNotUpdateCreatedByProperty()
+        {
+            var person = SavePersonToDatabase(DatabaseGatewayHelper.CreatePersonDatabaseEntity());
+            var request = GetValidPatchPersonRequest(person.Id);
+
+            var expectedCreatedBy = person.CreatedBy;
+            request.CreatedBy = "first.last@domain.com";
+
+            _classUnderTest.PatchPerson(request);
+
+            person.CreatedBy.Should().Be(expectedCreatedBy);
+        }
+
+        [Test]
         public void UpdatePersonSetsNewDisplayAddressWhenOneDoesntExist()
         {
             Person person = SavePersonToDatabase(DatabaseGatewayHelper.CreatePersonDatabaseEntity());

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -662,7 +662,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             person.MaritalStatus = request.MaritalStatus ?? person.MaritalStatus;
             person.GenderAssignedAtBirth = request.GenderAssignedAtBirth ?? person.GenderAssignedAtBirth;
             person.Pronoun = request.Pronoun ?? person.Pronoun;
-            person.CreatedBy = request.CreatedBy ?? person.CreatedBy;
             person.Nationality = request.Nationality ?? person.Nationality;
             person.HousingStaffInContact = request.HousingStaffInContact ?? person.HousingStaffInContact;
             person.CautionaryAlert = request.CautionaryAlert ?? person.CautionaryAlert;

--- a/SocialCareCaseViewerApi/V1/Infrastructure/Worker.cs
+++ b/SocialCareCaseViewerApi/V1/Infrastructure/Worker.cs
@@ -40,7 +40,9 @@ namespace SocialCareCaseViewerApi.V1.Infrastructure
         [MaxLength(1)]
         public string? ContextFlag { get; set; }
 
-        [Column("created_by")] [MaxLength(62)] public string? CreatedBy { get; set; }
+        [Column("created_by")]
+        [MaxLength(62)]
+        public string? CreatedBy { get; set; }
 
         [Column("date_start")] public DateTime? DateStart { get; set; }
 


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1829](https://hackney.atlassian.net/browse/SCT-1829)

## Describe this PR

### *What is the problem we're trying to solve*

Every time person record is patched the createdBy property is updated. This property should never be touched.

### *What changes have we introduced*

Update gateway to stop updating the property.

Also formats some unrelated code.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly