### PR TITLE
SCT-1832 Get the most recent address first.

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -529,8 +529,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
             person.Addresses = new List<Address>
             {
                 secondAddress,
-                lastAddress,
-                firstAddress
+                firstAddress,
+                lastAddress
             };
 
             AddressDomain addressDomain = new AddressDomain()

--- a/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -513,6 +513,92 @@ namespace SocialCareCaseViewerApi.Tests.V1.Factories
         }
 
         [Test]
+        public void DisplaysTheMostRecentAddressMarkedAsYInGetPersonResponse()
+        {
+            var first = DateTime.Today;
+            var second = DateTime.Today.AddDays(-1);
+            var last = DateTime.Today.AddDays(-2);
+            var person = DatabaseGatewayHelper.CreatePersonDatabaseEntity();
+            person.Id = 123;
+
+            Address firstAddress = DatabaseGatewayHelper.CreateAddressDatabaseEntity(person.Id, startDate: first, isDisplayAddress: "Y");
+            Address secondAddress = DatabaseGatewayHelper.CreateAddressDatabaseEntity(person.Id, startDate: second, isDisplayAddress: "Y");
+            Address lastAddress = DatabaseGatewayHelper.CreateAddressDatabaseEntity(person.Id, startDate: last, isDisplayAddress: "Y");
+
+            // Addresses are in random order
+            person.Addresses = new List<Address>
+            {
+                secondAddress,
+                lastAddress,
+                firstAddress
+            };
+
+            AddressDomain addressDomain = new AddressDomain()
+            {
+                Address = firstAddress.AddressLines,
+                Postcode = firstAddress.PostCode,
+                Uprn = firstAddress.Uprn
+            };
+
+            var expectedResponse = new GetPersonResponse()
+            {
+                GenderAssignedAtBirth = person.GenderAssignedAtBirth,
+                PreferredLanguage = person.PreferredLanguage,
+                FluentInEnglish = person.FluentInEnglish,
+                InterpreterNeeded = person.InterpreterNeeded,
+                CommunicationDifficulties = person.CommunicationDifficulties,
+                DifficultyMakingDecisions = person.DifficultyMakingDecisions,
+                CommunicationDifficultiesDetails = person.CommunicationDifficultiesDetails,
+                Employment = person.Employment,
+                MaritalStatus = person.MaritalStatus,
+                ImmigrationStatus = person.ImmigrationStatus,
+                PrimarySupportReason = person.PrimarySupportReason,
+                TenureType = person.TenureType,
+                AccomodationType = person.AccomodationType,
+                AccessToHome = person.AccessToHome,
+                CareProvider = person.CareProvider,
+                LivingSituation = person.LivingSituation,
+                HousingOfficer = person.HousingOfficer,
+                HousingStaffInContact = person.HousingStaffInContact,
+                CautionaryAlert = person.CautionaryAlert,
+                PossessionEvictionOrder = person.PossessionEvictionOrder,
+                RentRecord = person.RentRecord,
+                HousingBenefit = person.HousingBenefit,
+                CouncilTenureType = person.CouncilTenureType,
+                TenancyHouseholdStructure = person.TenancyHouseholdStructure,
+                MentalHealthSectionStatus = person.MentalHealthSectionStatus,
+                DeafRegister = person.DeafRegister,
+                BlindRegister = person.BlindRegister,
+                Pronoun = person.Pronoun,
+                BlueBadge = person.BlueBadge,
+                OpenCase = person.OpenCase,
+                EmailAddress = person.EmailAddress,
+                DateOfBirth = person.DateOfBirth.Value,
+                DateOfDeath = person.DateOfDeath.Value,
+                Address = addressDomain,
+                SexualOrientation = person.SexualOrientation,
+                ContextFlag = person.AgeContext,
+                CreatedBy = person.CreatedBy,
+                Ethnicity = person.Ethnicity,
+                FirstLanguage = person.FirstLanguage,
+                FirstName = person.FirstName,
+                Gender = person.Gender,
+                LastName = person.LastName,
+                NhsNumber = person.NhsNumber.Value,
+                Id = person.Id,
+                PreferredMethodOfContact = person.PreferredMethodOfContact,
+                Religion = person.Religion,
+                Restricted = person.Restricted,
+                Title = person.Title,
+                AllocatedTeam = person.AllocatedTeam
+            };
+
+            var result = ResponseFactory.ToResponse(person);
+
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
         public void MapWarningNoteToResponseReturnsAnObjectWithFormattedDates()
         {
             var dbWarningNote = TestHelpers.CreateWarningNote();

--- a/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Helpers/DatabaseGatewayHelper.cs
@@ -85,6 +85,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
         public static Address CreateAddressDatabaseEntity(
             long? personId = null,
             string isDisplayAddress = "Y",
+            DateTime? startDate = null,
             DateTime? endDate = null,
             string postCode = null,
             string address = null
@@ -96,6 +97,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Helpers
                  .RuleFor(a => a.CreatedBy, f => f.Internet.Email())
                  .RuleFor(a => a.DataIsFromDmPersonsBackup, f => f.Random.String2(1))
                  .RuleFor(a => a.EndDate, endDate)
+                 .RuleFor(a => a.StartDate, startDate)
                  .RuleFor(a => a.IsDisplayAddress, f => string.IsNullOrEmpty(isDisplayAddress) ? f.Random.String2(1) : isDisplayAddress)
                  .RuleFor(a => a.LastModifiedAt, f => f.Date.Past())
                  .RuleFor(a => a.LastModifiedBy, f => f.Internet.Email())

--- a/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
+++ b/SocialCareCaseViewerApi/V1/Factories/ResponseFactory.cs
@@ -143,7 +143,7 @@ namespace SocialCareCaseViewerApi.V1.Factories
         public static GetPersonResponse ToResponse(Person person)
         {
             //get the current display address
-            var displayAddress = person.Addresses?.FirstOrDefault(x => x.IsDisplayAddress?.ToUpper() == "Y");
+            var displayAddress = person.Addresses?.OrderByDescending(x => x.StartDate).FirstOrDefault(x => x.IsDisplayAddress == "Y");
             var displayGpDetails = person.GpDetails?.FirstOrDefault();
 
             return new GetPersonResponse()

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -1485,7 +1485,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public Person GetPersonDetailsById(long id)
         {
             //load related entities to minimise SQL calls
-            var person = _databaseContext
+            return _databaseContext
                 .Persons
                 .Include(x => x.Addresses)
                 .Include(x => x.PhoneNumbers)
@@ -1498,9 +1498,6 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .Include(x => x.LastUpdated)
                 .FirstOrDefault(x => x.Id == id && x.MarkedForDeletion == false);
 
-            person.Addresses.OrderBy(x => x.StartDate).ToList();
-
-            return person;
         }
         public List<Person> GetPersonsByListOfIds(List<long> ids)
         {

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -542,7 +542,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             //check for changed address
             if (request.Address != null)
             {
-                Address displayAddress = person.Addresses.FirstOrDefault(x => x.IsDisplayAddress == "Y");
+                Address displayAddress = person.Addresses.OrderByDescending(x => x.StartDate).FirstOrDefault(x => x.IsDisplayAddress == "Y");
 
                 if (displayAddress == null)
                 {
@@ -567,7 +567,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             }
             else //address not provided, remove current display address if it exists
             {
-                Address displayAddress = person.Addresses.FirstOrDefault(x => x.IsDisplayAddress == "Y");
+                Address displayAddress = person.Addresses.OrderByDescending(x => x.StartDate).FirstOrDefault(x => x.IsDisplayAddress == "Y");
 
                 if (displayAddress != null)
                 {
@@ -755,7 +755,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
             //check for changed address
             if (request.Address != null)
             {
-                Address displayAddress = person.Addresses.FirstOrDefault(x => x.IsDisplayAddress == "Y");
+                Address displayAddress = person.Addresses.OrderByDescending(x => x.StartDate).FirstOrDefault(x => x.IsDisplayAddress == "Y");
 
                 if (displayAddress == null)
                 {
@@ -1485,7 +1485,7 @@ namespace SocialCareCaseViewerApi.V1.Gateways
         public Person GetPersonDetailsById(long id)
         {
             //load related entities to minimise SQL calls
-            return _databaseContext
+            var person = _databaseContext
                 .Persons
                 .Include(x => x.Addresses)
                 .Include(x => x.PhoneNumbers)
@@ -1497,6 +1497,10 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 .Include(x => x.Emails)
                 .Include(x => x.LastUpdated)
                 .FirstOrDefault(x => x.Id == id && x.MarkedForDeletion == false);
+
+            person.Addresses.OrderBy(x => x.StartDate).ToList();
+
+            return person;
         }
         public List<Person> GetPersonsByListOfIds(List<long> ids)
         {


### PR DESCRIPTION
## Link to JIRA ticket

[Ticket](https://hackney.atlassian.net/browse/SCT-1832)

## Describe this PR

### *What is the problem we're trying to solve*

We’ve come across a bug where people end up with two addresses with ‘is_display_address’ = 'Y'

This causes strange frontend behaviour when updating a resident's address.

### *What changes have we introduced*

Changed the order of addresses when we call get resident endpoint and same when we update the address.

Updating address will do following:

- Set previous most recent address to N
- Create new address entry related to the person id

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

