### PR TITLE
SCT-1846 fix team deallocation activity note bug

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -29,6 +29,7 @@ using Team = SocialCareCaseViewerApi.V1.Infrastructure.Team;
 using TechUse = SocialCareCaseViewerApi.V1.Domain.TechUse;
 using WarningNote = SocialCareCaseViewerApi.V1.Infrastructure.WarningNote;
 using Worker = SocialCareCaseViewerApi.V1.Infrastructure.Worker;
+using MongoDB.Driver.Linq;
 
 namespace SocialCareCaseViewerApi.Tests.V1.Gateways
 {
@@ -1643,6 +1644,54 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             Assert.AreEqual(request.DeallocationDate, updatedRecord.AllocationEndDate);
             Assert.AreEqual(updatedRecord.CreatedBy, deAllocatedByWorker.Email);
             Assert.AreEqual(updatedRecord.CreatedAt, workerAllocation.CreatedAt);
+        }
+
+        [Test]
+        public void DeallocatingTeamWhenWorkerIsNotAllocatedShouldCreateOnlyTeamDeallocatedCaseNote()
+        {
+            var allocationStartDate = DateTime.Now.AddDays(-10);
+            var (request, worker, deAllocatedByWorker, person, team) = TestHelpers.CreateUpdateAllocationRequest();
+
+            var teamAllocation = new Allocation
+            {
+                Id = (int) request.Id,
+                AllocationEndDate = null,
+                AllocationStartDate = allocationStartDate,
+                CreatedAt = allocationStartDate,
+                CaseStatus = "Open",
+                CaseClosureDate = null,
+                LastModifiedAt = null,
+                CreatedBy = worker.Email,
+                LastModifiedBy = null,
+                PersonId = person.Id,
+                TeamId = team.Id,
+                WorkerId = null
+            };
+           
+            DatabaseContext.Workers.Add(worker);
+            DatabaseContext.Workers.Add(deAllocatedByWorker);
+            DatabaseContext.Teams.Add(team);
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.SaveChanges();
+
+            //remove other allocations created by the helper for simplicity
+            DatabaseContext.Allocations.RemoveRange(DatabaseContext.Allocations);
+            DatabaseContext.Allocations.Add(teamAllocation);
+            DatabaseContext.SaveChanges();
+
+            request.DeallocationScope = "team";
+
+            var response = _classUnderTestWithProcessDataGateway.UpdateAllocation(request);
+
+            var filter = Builders<BsonDocument>.Filter.Eq("mosaic_id", person.Id.ToString());
+
+            var query = MongoDbTestContext.getCollection().AsQueryable().Where(db => filter.Inject());
+
+            var result = query.ToList();
+
+            result.Count.Should().Be(1);
+            result.FirstOrDefault()["form_name"].Should().Be("Team deallocated");
+            result.FirstOrDefault()["_id"].Should().Be(ObjectId.Parse(response.CaseNoteId));
         }
 
         [Test]

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1674,7 +1674,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
             DatabaseContext.Persons.Add(person);
             DatabaseContext.SaveChanges();
 
-            //remove other allocations created by the helper for simplicity
+            //remove other allocations (created by the helpers) for simplicity
             DatabaseContext.Allocations.RemoveRange(DatabaseContext.Allocations);
             DatabaseContext.Allocations.Add(teamAllocation);
             DatabaseContext.SaveChanges();

--- a/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Gateways/DatabaseGateway.Tests.cs
@@ -1667,7 +1667,6 @@ namespace SocialCareCaseViewerApi.Tests.V1.Gateways
                 TeamId = team.Id,
                 WorkerId = null
             };
-           
             DatabaseContext.Workers.Add(worker);
             DatabaseContext.Workers.Add(deAllocatedByWorker);
             DatabaseContext.Teams.Add(team);

--- a/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
+++ b/SocialCareCaseViewerApi/V1/Gateways/DatabaseGateway.cs
@@ -1306,35 +1306,38 @@ namespace SocialCareCaseViewerApi.V1.Gateways
                 SetDeallocationValues(allocation, (DateTime) request.DeallocationDate, request.CreatedBy);
                 _databaseContext.SaveChanges();
 
-                try
+                if (allocation.WorkerId != null)
                 {
-                    var note = new DeallocationCaseNote
+                    try
                     {
-                        FirstName = person.FirstName,
-                        LastName = person.LastName,
-                        MosaicId = person.Id.ToString(),
-                        Timestamp = DateTime.Now.ToString("dd/MM/yyyy H:mm:ss"),
-                        WorkerEmail = createdBy.Email, //required for my cases search
-                        DeallocationReason = request.DeallocationReason,
-                        FormNameOverall = "API_Deallocation", //prefix API notes so they are easy to identify
-                        FormName = "Worker deallocated",
-                        AllocationId = request.Id.ToString(),
-                        CreatedBy = request.CreatedBy
-                    };
+                        var note = new DeallocationCaseNote
+                        {
+                            FirstName = person.FirstName,
+                            LastName = person.LastName,
+                            MosaicId = person.Id.ToString(),
+                            Timestamp = DateTime.Now.ToString("dd/MM/yyyy H:mm:ss"),
+                            WorkerEmail = createdBy.Email, //required for my cases search
+                            DeallocationReason = request.DeallocationReason,
+                            FormNameOverall = "API_Deallocation", //prefix API notes so they are easy to identify
+                            FormName = "Worker deallocated",
+                            AllocationId = request.Id.ToString(),
+                            CreatedBy = request.CreatedBy
+                        };
 
-                    var caseNotesDocument = new CaseNotesDocument() { CaseFormData = JsonConvert.SerializeObject(note) };
+                        var caseNotesDocument = new CaseNotesDocument() { CaseFormData = JsonConvert.SerializeObject(note) };
 
-                    response.CaseNoteId = _processDataGateway.InsertCaseNoteDocument(caseNotesDocument).Result;
-                }
-                catch (Exception ex)
-                {
-                    var allocationToRestore = _databaseContext.Allocations.FirstOrDefault(x => x.Id == request.Id);
-                    RestoreAllocationValues(tmpAllocation, allocationToRestore);
+                        response.CaseNoteId = _processDataGateway.InsertCaseNoteDocument(caseNotesDocument).Result;
+                    }
+                    catch (Exception ex)
+                    {
+                        var allocationToRestore = _databaseContext.Allocations.FirstOrDefault(x => x.Id == request.Id);
+                        RestoreAllocationValues(tmpAllocation, allocationToRestore);
 
-                    _databaseContext.SaveChanges();
+                        _databaseContext.SaveChanges();
 
-                    throw new UpdateAllocationException(
-                        $"Unable to create a case note. Allocation not updated: {ex.Message}");
+                        throw new UpdateAllocationException(
+                            $"Unable to create a case note. Allocation not updated: {ex.Message}");
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1846](https://hackney.atlassian.net/browse/SCT-1846)

## Describe this PR

### *What is the problem we're trying to solve*

When team is deallocated without worker the activity list shows both worker deallocated and team deallocated messages. 

### *What changes have we introduced*

Update the gateway so that the worker deallocated case note is not created when only team is deallocated. 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly