### PR TITLE
Close allocations against missing persons

### DIFF
--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using SocialCareCaseViewerApi.Tests.V1.Helpers;
+using SocialCareCaseViewerApi.V1.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
+{
+    [TestFixture]
+    public class CloseAllocationsSetAgainstMissingPersonRecordsTests : DatabaseTests
+    {
+        //TODO: use real email
+        private static readonly FormattableString _queryUnderTest = $@"
+           update dbo.sccv_allocations_combined 
+            set 
+            case_status = 'Closed',
+            sccv_last_modified_by = 'first.last@hackney.gov.uk',
+            sccv_last_modified_at = NOW(),
+            closure_date_if_closed = NOW()
+            where id in
+            (select 
+	            a.id
+                from dbo.sccv_allocations_combined a
+                left join dbo.dm_persons p
+                on a.mosaic_id = p.person_id
+                where 
+	            p.person_id is null and a.case_status = 'Open');
+        ";
+
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
+
+        [Test]
+        public void ClosesAllAllocationsWhereAssociatedPersonDoesNotExistInTheDatabase()
+        {
+            var person = TestHelpers.CreatePerson();
+
+            var allocation1 = TestHelpers.CreateAllocation(personId: (int)person.Id, caseStatus: "Open");
+            var allocation2 = TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "Open");
+
+            var allocationAgainstMissingPerson = TestHelpers.CreateAllocation(personId: 555, caseStatus: "Open");
+            allocationAgainstMissingPerson.LastModifiedBy = null;
+            allocationAgainstMissingPerson.LastModifiedAt = null;
+            allocationAgainstMissingPerson.MarkedForDeletion = true;
+            allocationAgainstMissingPerson.CaseClosureDate = null;
+
+            DatabaseContext.Allocations.AddRange(new List<AllocationSet> { allocation1, allocation2, allocationAgainstMissingPerson });
+            DatabaseContext.Persons.Add(person);
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            var updatedAllocation = DatabaseContext.Allocations.FirstOrDefault(x => x.Id == allocationAgainstMissingPerson.Id);
+
+            updatedAllocation.CaseStatus.Should().Be("Closed");
+            updatedAllocation.LastModifiedBy.Should().Be("first.last@hackney.gov.uk");
+            updatedAllocation.LastModifiedAt.Should().BeCloseTo(DateTime.UtcNow, precision: 1000);
+            updatedAllocation.MarkedForDeletion.Should().BeTrue();
+            updatedAllocation.CaseClosureDate.Should().BeCloseTo(DateTime.UtcNow, precision: 1000);
+        }
+
+        [Test]
+        public void DoesNotCloseAnyAllocationsThatHavePersonAssociatedWithThem()
+        {
+            var person = TestHelpers.CreatePerson();
+
+            var allocation1 = TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "Open");
+            var allocation2 = TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "Open");
+
+            DatabaseContext.Database.ExecuteSqlInterpolated(_queryUnderTest);
+
+            var allocations = DatabaseContext.Allocations.ToList();
+
+            allocations.All(x => x.CaseStatus == "Open").Should().BeTrue();
+        }
+    }
+}

--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
@@ -19,7 +19,8 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
             case_status = 'Closed',
             sccv_last_modified_by = 'first.last@hackney.gov.uk',
             sccv_last_modified_at = NOW(),
-            closure_date_if_closed = NOW()
+            closure_date_if_closed = NOW(),
+            marked_for_deletion = true
             where id in
             (select 
 	            a.id
@@ -47,7 +48,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
             var allocationAgainstMissingPerson = TestHelpers.CreateAllocation(personId: 555, caseStatus: "Open");
             allocationAgainstMissingPerson.LastModifiedBy = null;
             allocationAgainstMissingPerson.LastModifiedAt = null;
-            allocationAgainstMissingPerson.MarkedForDeletion = true;
+            allocationAgainstMissingPerson.MarkedForDeletion = false;
             allocationAgainstMissingPerson.CaseClosureDate = null;
 
             DatabaseContext.Allocations.AddRange(new List<AllocationSet> { allocation1, allocation2, allocationAgainstMissingPerson });

--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
@@ -41,7 +41,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
         {
             var person = TestHelpers.CreatePerson();
 
-            var allocation1 = TestHelpers.CreateAllocation(personId: (int)person.Id, caseStatus: "Open");
+            var allocation1 = TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "Open");
             var allocation2 = TestHelpers.CreateAllocation(personId: (int) person.Id, caseStatus: "Open");
 
             var allocationAgainstMissingPerson = TestHelpers.CreateAllocation(personId: 555, caseStatus: "Open");

--- a/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
+++ b/SocialCareCaseViewerApi.Tests/V1/Data/PostgreSQL/CloseAllocationsSetAgainstMissingPersonRecordsTests.cs
@@ -66,7 +66,7 @@ namespace SocialCareCaseViewerApi.Tests.V1.Data.PostgreSQL
         }
 
         [Test]
-        public void DoesNotCloseAnyAllocationsThatHavePersonAssociatedWithThem()
+        public void DoesNotCloseAnyAllocationsThatHaveTheAssociatedPersonInTheDatabase()
         {
             var person = TestHelpers.CreatePerson();
 


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We have some allocation records that don't have the associated person in the database. This is due to issues with historical data imports.

### *What changes have we introduced*

Write a SQL script that closes those problematic allocation records. This will ensure the allocation numbers match correctly in the UI and also reports can identify these records since they have been marked as deleted

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly